### PR TITLE
Fix pipeline freeze by adding cancellation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,6 +3642,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/xearthlayer/Cargo.toml
+++ b/xearthlayer/Cargo.toml
@@ -33,6 +33,7 @@ sha2 = "0.10"
 futures = "0.3"
 bytes = "1.11.0"
 dashmap = "6.1"
+tokio-util = "0.7"
 
 [dev-dependencies]
 proptest = "1.4"

--- a/xearthlayer/src/pipeline/mod.rs
+++ b/xearthlayer/src/pipeline/mod.rs
@@ -62,8 +62,9 @@ pub use error::{ChunkFailure, ChunkResults, ChunkSuccess, JobError, StageError};
 pub use executor::{BlockingExecutor, ConcurrentRunner, ExecutorError, Timer, TokioExecutor};
 pub use http_limiter::HttpConcurrencyLimiter;
 pub use job::{Job, JobId, JobResult, Priority};
-pub use processor::{process_job, process_tile};
+pub use processor::{process_job, process_tile, process_tile_cancellable};
 pub use runner::{create_dds_handler, create_dds_handler_with_metrics};
 pub use stages::{
-    assembly_stage, cache_stage, download_stage, download_stage_with_limiter, encode_stage,
+    assembly_stage, cache_stage, download_stage, download_stage_cancellable,
+    download_stage_with_limiter, encode_stage,
 };

--- a/xearthlayer/src/pipeline/stages/mod.rs
+++ b/xearthlayer/src/pipeline/stages/mod.rs
@@ -14,5 +14,5 @@ mod encode;
 
 pub use assembly::assembly_stage;
 pub use cache::{cache_stage, check_memory_cache};
-pub use download::{download_stage, download_stage_with_limiter};
+pub use download::{download_stage, download_stage_cancellable, download_stage_with_limiter};
 pub use encode::encode_stage;

--- a/xearthlayer/src/telemetry/metrics.rs
+++ b/xearthlayer/src/telemetry/metrics.rs
@@ -199,6 +199,14 @@ impl PipelineMetrics {
         self.chunks_retried.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Record a download being cancelled (balances download_started).
+    ///
+    /// This is called when a download is aborted due to cancellation (e.g., FUSE timeout).
+    /// It decrements the active counter without counting as success or failure.
+    pub fn download_cancelled(&self) {
+        self.downloads_active.fetch_sub(1, Ordering::Relaxed);
+    }
+
     // === Cache tracking ===
 
     /// Record a memory cache hit.


### PR DESCRIPTION
## Summary

Fixes #5 - XEarthLayer freezes after extended use due to orphaned pipeline tasks accumulating resources.

### Root Cause

When FUSE requests timed out (after 10-30 seconds), the spawned pipeline tasks continued running indefinitely. These orphaned tasks held onto:
- HTTP connections
- Semaphore permits (HTTP concurrency limiter)
- Memory for in-progress downloads

Under sustained timeouts, resources accumulated until the system became unresponsive.

### Solution

Implemented cooperative cancellation using `tokio_util::CancellationToken`:

- **FUSE layer**: Creates a cancellation token per request, cancels it on timeout
- **Pipeline runner**: Checks cancellation before processing, uses `tokio::select!` to race between work and cancellation
- **Download stage**: Checks cancellation at key points:
  - Before starting each chunk download
  - While waiting for HTTP permits
  - During the actual HTTP request
  - During retry backoff delays
- **Coalescer**: Added `cancel()` method to clean up entries and notify waiting requests
- **Metrics**: Added `download_cancelled()` to properly balance the active download counter

### Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Added `tokio-util = "0.7"` dependency |
| `fuse/async_passthrough/types.rs` | Added `cancellation_token` to `DdsRequest` |
| `fuse/fuse3/filesystem.rs` | Create and cancel token on FUSE timeout |
| `fuse/async_passthrough/filesystem.rs` | Same for fuser-based implementation |
| `pipeline/processor.rs` | Added `process_tile_cancellable()` |
| `pipeline/stages/download.rs` | Added `download_stage_cancellable()` |
| `pipeline/runner.rs` | Updated to use cancellable processing |
| `pipeline/coalesce.rs` | Added `cancel()` method |
| `telemetry/metrics.rs` | Added `download_cancelled()` |

### Testing

- Ran extended test session with X-Plane 12
- Verified timeouts now properly release resources
- Confirmed active download counter returns to 0 after cancellation
- No freeze observed during testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)