### PR TITLE
Merge release/0.2.x (v0.2.5) back to main

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,34 @@
+name: Release Branch CI
+
+on:
+  push:
+    branches:
+      - 'release/*'
+  pull_request:
+    branches:
+      - 'release/*'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfuse3-dev
+
+      - name: Run make verify
+        run: make verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,96 @@
+# Changelog
+
+All notable changes to XEarthLayer will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.5] - 2025-12-15
+
+### Changed
+
+- Simplified CI workflow to single `make verify` job
+- Redesigned release workflow with atomic publish process:
+  - Creates draft release first
+  - Uploads all artifacts (Linux binary, .deb, .rpm, AUR files)
+  - Publishes release only after all assets uploaded successfully
+- Uses GitHub CLI for release operations instead of third-party actions
+
+### Fixed
+
+- Release workflow race condition where release was published before assets uploaded
+- CI/CD pipeline reliability issues with parallel async steps
+
+## [0.2.0] - 2025-12-15
+
+### Added
+
+- **Async Pipeline Architecture**: Complete rewrite of the tile generation pipeline using async/await for dramatically improved performance and resource efficiency
+  - Async FUSE filesystem implementation using fuse3 with multi-threaded I/O
+  - Request coalescing to deduplicate concurrent requests for the same tile
+  - HTTP concurrency limiter to prevent network stack exhaustion
+  - Cooperative cancellation support for FUSE timeout handling
+  - Two-tier caching with memory and disk layers
+
+- **TUI Dashboard**: Real-time monitoring interface showing:
+  - Pipeline metrics (requests, cache hits, downloads, errors)
+  - Active job tracking with status indicators
+  - Log output panel for debugging
+
+- **Linux Distribution Packages**:
+  - Debian/Ubuntu packages via cargo-deb
+  - RPM packages for Fedora/RHEL/openSUSE
+  - AUR package (PKGBUILD) for Arch Linux
+  - Static musl binary for universal Linux compatibility
+
+- **CI/CD Pipeline**:
+  - GitHub Actions workflow for automated testing on PRs
+  - Release workflow for building and publishing packages
+  - Branch protection for main branch
+
+### Changed
+
+- Minimum supported Rust version is now 1.70
+- Improved error handling throughout the pipeline
+- Reduced log verbosity for routine operations (moved to DEBUG level)
+- Refactored facade into smaller, testable units following Single Responsibility Principle
+
+### Fixed
+
+- Pipeline freeze when FUSE operations timeout ([#5](https://github.com/samsoir/xearthlayer/issues/5))
+- TUI corruption from log output during DDS errors
+- TUI dashboard display issues with metrics and job counters
+- Memory cache sharing between pipeline stages
+- DDS validation for malformed texture files
+
+### Performance
+
+- 10x+ improvement in tile generation throughput
+- Eliminated thread pool exhaustion under heavy load
+- Reduced memory usage through request coalescing
+- Faster cache lookups with async I/O
+
+## [0.1.0] - 2025-01-01
+
+### Added
+
+- Initial release of XEarthLayer
+- Regional scenery package system for on-demand satellite imagery
+- Package manager with download, install, and library management
+- FUSE-based virtual filesystem for X-Plane integration
+- Support for Bing Maps and Google Maps imagery providers
+- DDS texture generation with BC1/BC3 compression and mipmaps
+- Two-tier caching (memory + disk) for performance
+- CLI interface with package and config management
+- Ortho4XP scenery package compatibility
+
+### Notes
+
+- Linux support only (Windows and macOS planned for future releases)
+- Requires FUSE3 for filesystem mounting
+
+[Unreleased]: https://github.com/samsoir/xearthlayer/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/samsoir/xearthlayer/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/samsoir/xearthlayer/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.5"
 edition = "2021"
 authors = ["XEarthLayer Contributors"]
 license = "MIT"
-repository = "https://github.com/yourusername/xearthlayer"
+repository = "https://github.com/samsoir/xearthlayer"
 
 [workspace.dependencies]
 # Shared dependencies will be added here as needed

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,159 @@ uninstall: ## Uninstall binary from system
 	$(CARGO) uninstall xearthlayer
 	@echo "$(GREEN)Uninstall complete!$(NC)"
 
+##@ Packaging
+
+# Package configuration
+PKG_NAME := xearthlayer
+PKG_VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+AUR_DIR := pkg/aur
+AUR_REPO := ssh://aur@aur.archlinux.org/$(PKG_NAME).git
+
+.PHONY: pkg-deb
+pkg-deb: release ## Build Debian package (.deb)
+	@echo "$(BLUE)Building Debian package...$(NC)"
+	@command -v cargo-deb >/dev/null 2>&1 || { echo "$(YELLOW)Installing cargo-deb...$(NC)"; cargo install cargo-deb; }
+	cd xearthlayer-cli && $(CARGO) deb --no-build
+	@echo "$(GREEN)Debian package built: target/debian/$(PKG_NAME)_$(PKG_VERSION)-1_amd64.deb$(NC)"
+
+.PHONY: pkg-rpm
+pkg-rpm: release ## Build RPM package (.rpm) - requires rpmbuild
+	@echo "$(BLUE)Building RPM package...$(NC)"
+	@command -v rpmbuild >/dev/null 2>&1 || { echo "$(RED)Error: rpmbuild not found. Install rpm-build package.$(NC)"; exit 1; }
+	@mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+	@mkdir -p $(PKG_NAME)-$(PKG_VERSION)
+	@cp -r * $(PKG_NAME)-$(PKG_VERSION)/ 2>/dev/null || true
+	@tar czvf ~/rpmbuild/SOURCES/$(PKG_NAME)-$(PKG_VERSION).tar.gz $(PKG_NAME)-$(PKG_VERSION)
+	@rm -rf $(PKG_NAME)-$(PKG_VERSION)
+	@cp pkg/rpm/$(PKG_NAME).spec ~/rpmbuild/SPECS/
+	rpmbuild -bb ~/rpmbuild/SPECS/$(PKG_NAME).spec
+	@echo "$(GREEN)RPM package built in ~/rpmbuild/RPMS/$(NC)"
+
+.PHONY: pkg-tarball
+pkg-tarball: release ## Build release tarball
+	@echo "$(BLUE)Building release tarball...$(NC)"
+	@mkdir -p dist
+	@cp target/release/xearthlayer dist/
+	@cp README.md LICENSE dist/
+	@cd dist && tar czvf $(PKG_NAME)-$(PKG_VERSION)-x86_64-linux.tar.gz xearthlayer README.md LICENSE
+	@rm dist/xearthlayer dist/README.md dist/LICENSE
+	@echo "$(GREEN)Tarball built: dist/$(PKG_NAME)-$(PKG_VERSION)-x86_64-linux.tar.gz$(NC)"
+
+.PHONY: aur-prepare
+aur-prepare: ## Prepare AUR package for a tagged release (TAG=v0.2.0)
+	@if [ -z "$(TAG)" ]; then echo "$(RED)Error: TAG is required. Usage: make aur-prepare TAG=v0.2.0$(NC)"; exit 1; fi
+	@echo "$(BLUE)Preparing AUR package for $(TAG)...$(NC)"
+	@# Extract version from tag (remove 'v' prefix)
+	$(eval VERSION := $(shell echo $(TAG) | sed 's/^v//'))
+	@# Create AUR working directory
+	@rm -rf $(AUR_DIR)
+	@mkdir -p $(AUR_DIR)
+	@# Download source tarball from GitHub
+	@echo "$(BLUE)Downloading source tarball...$(NC)"
+	@curl -sL "https://github.com/samsoir/xearthlayer/archive/$(TAG).tar.gz" -o "$(AUR_DIR)/$(PKG_NAME)-$(VERSION).tar.gz"
+	@# Calculate SHA256
+	$(eval SHA256 := $(shell sha256sum "$(AUR_DIR)/$(PKG_NAME)-$(VERSION).tar.gz" | cut -d' ' -f1))
+	@echo "$(BLUE)SHA256: $(SHA256)$(NC)"
+	@# Generate PKGBUILD with correct version and checksum
+	@sed -e 's/^pkgver=.*/pkgver=$(VERSION)/' \
+	     -e "s/^sha256sums=.*/sha256sums=('$(SHA256)')/" \
+	     pkg/arch/PKGBUILD > $(AUR_DIR)/PKGBUILD
+	@# Generate .SRCINFO
+	@cd $(AUR_DIR) && makepkg --printsrcinfo > .SRCINFO
+	@# Clean up downloaded tarball (not needed for AUR)
+	@rm "$(AUR_DIR)/$(PKG_NAME)-$(VERSION).tar.gz"
+	@echo ""
+	@echo "$(GREEN)AUR package prepared in $(AUR_DIR)/$(NC)"
+	@echo "$(BLUE)Contents:$(NC)"
+	@ls -la $(AUR_DIR)/
+	@echo ""
+	@echo "$(YELLOW)Next steps:$(NC)"
+	@echo "  1. Review the PKGBUILD: cat $(AUR_DIR)/PKGBUILD"
+	@echo "  2. Test locally: cd $(AUR_DIR) && makepkg -si"
+	@echo "  3. Submit to AUR: make aur-publish TAG=$(TAG)"
+
+.PHONY: aur-publish
+aur-publish: ## Publish prepared AUR package (TAG=v0.2.0)
+	@if [ -z "$(TAG)" ]; then echo "$(RED)Error: TAG is required. Usage: make aur-publish TAG=v0.2.0$(NC)"; exit 1; fi
+	@if [ ! -f "$(AUR_DIR)/PKGBUILD" ]; then echo "$(RED)Error: Run 'make aur-prepare TAG=$(TAG)' first$(NC)"; exit 1; fi
+	@echo "$(BLUE)Publishing AUR package for $(TAG)...$(NC)"
+	$(eval VERSION := $(shell echo $(TAG) | sed 's/^v//'))
+	@# Clone or update AUR repo
+	@if [ -d "$(AUR_DIR)/aur-repo" ]; then \
+		echo "$(BLUE)Updating existing AUR repo...$(NC)"; \
+		cd $(AUR_DIR)/aur-repo && git pull; \
+	else \
+		echo "$(BLUE)Cloning AUR repo...$(NC)"; \
+		git clone $(AUR_REPO) $(AUR_DIR)/aur-repo || { \
+			echo "$(YELLOW)AUR repo doesn't exist yet. Creating new package...$(NC)"; \
+			mkdir -p $(AUR_DIR)/aur-repo && cd $(AUR_DIR)/aur-repo && git init; \
+		}; \
+	fi
+	@# Copy PKGBUILD and .SRCINFO to AUR repo
+	@cp $(AUR_DIR)/PKGBUILD $(AUR_DIR)/.SRCINFO $(AUR_DIR)/aur-repo/
+	@# Commit and push
+	@cd $(AUR_DIR)/aur-repo && \
+		git add PKGBUILD .SRCINFO && \
+		git commit -m "Update to $(VERSION)" && \
+		echo "$(BLUE)Pushing to AUR...$(NC)" && \
+		git push origin master
+	@echo ""
+	@echo "$(GREEN)Successfully published $(PKG_NAME) $(VERSION) to AUR!$(NC)"
+	@echo "$(BLUE)View at: https://aur.archlinux.org/packages/$(PKG_NAME)$(NC)"
+
+.PHONY: aur-test
+aur-test: ## Test AUR package build locally (TAG=v0.2.0)
+	@if [ -z "$(TAG)" ]; then echo "$(RED)Error: TAG is required. Usage: make aur-test TAG=v0.2.0$(NC)"; exit 1; fi
+	@if [ ! -f "$(AUR_DIR)/PKGBUILD" ]; then \
+		echo "$(YELLOW)AUR package not prepared. Running aur-prepare first...$(NC)"; \
+		$(MAKE) aur-prepare TAG=$(TAG); \
+	fi
+	@echo "$(BLUE)Testing AUR package build...$(NC)"
+	@cd $(AUR_DIR) && makepkg -sf
+	@echo "$(GREEN)AUR package built successfully!$(NC)"
+	@echo "$(BLUE)Package:$(NC)"
+	@ls -la $(AUR_DIR)/*.pkg.tar.zst 2>/dev/null || ls -la $(AUR_DIR)/*.pkg.tar.xz 2>/dev/null
+
+.PHONY: pkg-all
+pkg-all: pkg-deb pkg-tarball ## Build all packages (deb + tarball)
+	@echo "$(GREEN)All packages built!$(NC)"
+
+##@ Release Management
+
+.PHONY: version
+version: ## Show current version
+	@echo "$(BLUE)Current version:$(NC) $(PKG_VERSION)"
+
+.PHONY: bump-version
+bump-version: ## Bump version across all files (VERSION=x.y.z)
+	@if [ -z "$(VERSION)" ]; then echo "$(RED)Error: VERSION is required. Usage: make bump-version VERSION=0.3.0$(NC)"; exit 1; fi
+	@echo "$(BLUE)Bumping version to $(VERSION)...$(NC)"
+	@# Update workspace Cargo.toml
+	@sed -i 's/^version = ".*"/version = "$(VERSION)"/' Cargo.toml
+	@# Update RPM spec file
+	@sed -i 's/^Version:.*/Version:        $(VERSION)/' pkg/rpm/xearthlayer.spec
+	@echo "$(GREEN)Version bumped to $(VERSION)$(NC)"
+	@echo ""
+	@echo "$(YELLOW)Next steps:$(NC)"
+	@echo "  1. Update CHANGELOG.md with release notes"
+	@echo "  2. Commit: git add -A && git commit -m 'Bump version to $(VERSION)'"
+	@echo "  3. Tag: git tag v$(VERSION)"
+	@echo "  4. Push: git push origin HEAD && git push origin v$(VERSION)"
+
+.PHONY: release-checklist
+release-checklist: ## Show release checklist
+	@echo "$(BLUE)Release Checklist$(NC)"
+	@echo ""
+	@echo "  1. [ ] Ensure all tests pass: make verify"
+	@echo "  2. [ ] Update version: make bump-version VERSION=x.y.z"
+	@echo "  3. [ ] Update CHANGELOG.md with release notes"
+	@echo "  4. [ ] Commit version bump"
+	@echo "  5. [ ] Push to release branch and verify CI passes"
+	@echo "  6. [ ] Create and push tag: git tag vx.y.z && git push origin vx.y.z"
+	@echo "  7. [ ] Review and publish draft release on GitHub"
+	@echo "  8. [ ] (Optional) Publish to AUR: make aur-publish TAG=vx.y.z"
+	@echo ""
+
 ##@ Maintenance
 
 .PHONY: clean-all
@@ -224,6 +377,8 @@ clean-all: clean ## Deep clean (including cargo cache)
 	$(CARGO) clean
 	@rm -rf target/
 	@rm -rf Cargo.lock
+	@rm -rf dist/
+	@rm -rf $(AUR_DIR)/
 	@echo "$(GREEN)Deep clean complete!$(NC)"
 
 .PHONY: reset

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [How It Works](docs/how-it-works.md) for detailed architecture.
 
 ```bash
 # Build from source
-git clone https://github.com/youruser/xearthlayer.git
+git clone https://github.com/samsoir/xearthlayer.git
 cd xearthlayer
 make release
 
@@ -132,7 +132,7 @@ XEarthLayer is not tested with X-Plane 11, but should work in principle. The sce
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # Clone and build
-git clone https://github.com/youruser/xearthlayer.git
+git clone https://github.com/samsoir/xearthlayer.git
 cd xearthlayer
 make init
 make verify
@@ -146,7 +146,7 @@ Architecturally influenced by [AutoOrtho](https://github.com/kubilus1/autoortho)
 
 Developed with assistance from [Claude](https://claude.ai) by Anthropic.
 
-Made with :heart: in Californa.
+Made with :heart: in California.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -26,28 +26,6 @@ Tracking issues discovered during development and testing.
   - Easier to test validation in isolation
 - **Added**: 2025-12-05
 
-### TD1: Migrate to Async FUSE Model
-- **Status**: Open
-- **Priority**: Medium
-- **Description**: Current implementation uses blocking thread pool for parallel tile generation.
-  The FUSE library (`fuser`) supports an async model that could provide better scalability.
-- **Current Implementation**: `ParallelTileGenerator` wraps tile generation with:
-  - Blocking thread pool (std::thread)
-  - mpsc channels for work distribution
-  - Request coalescing via HashMap
-- **Future Implementation**:
-  - Use `fuser`'s async filesystem trait
-  - Integrate with tokio runtime
-  - Replace blocking channels with async equivalents
-- **Benefits**:
-  - Better thread utilization under high load
-  - More efficient I/O waiting
-  - Native async/await integration
-- **Risks**:
-  - Significant refactoring required
-  - Need to verify compatibility with current architecture
-- **Added**: 2025-11-25
-
 ## Future Enhancements
 
 ### E5: Diagnostic Magenta Chunks
@@ -75,6 +53,21 @@ Tracking issues discovered during development and testing.
 - Pre-warm cache for known flight areas
 
 ## Completed
+
+### TD1: Migrate to Async FUSE Model ✓
+- **Completed**: 2025-12-15
+- **Description**: Migrated from blocking thread pool to fully async pipeline architecture.
+- **Implementation**:
+  - New `fuse3` module using `fuse3` crate with async filesystem trait
+  - Multi-stage async pipeline: Download → Assembly → Encode → Cache
+  - Request coalescing via lock-free `DashMap`
+  - HTTP concurrency limiter to prevent network stack exhaustion
+  - Cancellation token support for FUSE timeout handling
+- **Benefits Achieved**:
+  - Eliminated thread pool exhaustion under heavy load
+  - Native async/await integration with tokio runtime
+  - Cooperative cancellation prevents resource leaks on timeout
+  - Better scalability for concurrent tile requests
 
 ### P1: Slow Initial Load ✓
 - **Completed**: 2025-11-25

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -60,7 +60,7 @@ xearthlayer-cli
 
 ```bash
 # Clone and build
-git clone https://github.com/youruser/xearthlayer.git
+git clone https://github.com/samsoir/xearthlayer.git
 cd xearthlayer
 make init
 make verify

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Sam de Freyssinet <sam@def.reyssi.net>
+pkgname=xearthlayer
+pkgver=0.2.0
+pkgrel=1
+pkgdesc="High-quality satellite imagery for X-Plane, streamed on demand"
+arch=('x86_64')
+url="https://github.com/samsoir/xearthlayer"
+license=('MIT')
+depends=('fuse3')
+makedepends=('rust' 'cargo')
+optdepends=(
+    'xplane12: X-Plane 12 flight simulator'
+)
+backup=()
+options=(!lto)
+source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+prepare() {
+    cd "$pkgname-$pkgver"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+    cd "$pkgname-$pkgver"
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --frozen --release
+}
+
+check() {
+    cd "$pkgname-$pkgver"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo test --frozen
+}
+
+package() {
+    cd "$pkgname-$pkgver"
+
+    # Install binary
+    install -Dm755 "target/release/xearthlayer" "$pkgdir/usr/bin/xearthlayer"
+
+    # Install license
+    install -Dm644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+    # Install documentation
+    install -Dm644 "README.md" "$pkgdir/usr/share/doc/$pkgname/README.md"
+
+    # Install shell completions (if generated)
+    # install -Dm644 "completions/xearthlayer.bash" "$pkgdir/usr/share/bash-completion/completions/xearthlayer"
+    # install -Dm644 "completions/xearthlayer.zsh" "$pkgdir/usr/share/zsh/site-functions/_xearthlayer"
+    # install -Dm644 "completions/xearthlayer.fish" "$pkgdir/usr/share/fish/vendor_completions.d/xearthlayer.fish"
+}

--- a/pkg/arch/PKGBUILD-git
+++ b/pkg/arch/PKGBUILD-git
@@ -1,0 +1,55 @@
+# Maintainer: Sam de Freyssinet <sam@def.reyssi.net>
+pkgname=xearthlayer-git
+pkgver=r0.0.0
+pkgrel=1
+pkgdesc="High-quality satellite imagery for X-Plane, streamed on demand (git version)"
+arch=('x86_64')
+url="https://github.com/samsoir/xearthlayer"
+license=('MIT')
+depends=('fuse3')
+makedepends=('rust' 'cargo' 'git')
+optdepends=(
+    'xplane12: X-Plane 12 flight simulator'
+)
+provides=("xearthlayer=${pkgver#r}")
+conflicts=('xearthlayer')
+options=(!lto)
+source=("$pkgname::git+$url.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "$pkgname"
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+    cd "$pkgname"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+    cd "$pkgname"
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --frozen --release
+}
+
+check() {
+    cd "$pkgname"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo test --frozen
+}
+
+package() {
+    cd "$pkgname"
+
+    # Install binary
+    install -Dm755 "target/release/xearthlayer" "$pkgdir/usr/bin/xearthlayer"
+
+    # Install license
+    install -Dm644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+    # Install documentation
+    install -Dm644 "README.md" "$pkgdir/usr/share/doc/$pkgname/README.md"
+}

--- a/pkg/rpm/xearthlayer.spec
+++ b/pkg/rpm/xearthlayer.spec
@@ -1,0 +1,55 @@
+Name:           xearthlayer
+Version:        0.2.5
+Release:        1%{?dist}
+Summary:        High-quality satellite imagery for X-Plane, streamed on demand
+
+License:        MIT
+URL:            https://github.com/samsoir/xearthlayer
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  rust >= 1.70
+BuildRequires:  cargo
+BuildRequires:  fuse3-devel
+
+Requires:       fuse3
+
+# Disable debug packages (release builds have no debug symbols)
+%global debug_package %{nil}
+
+%description
+XEarthLayer delivers satellite/aerial imagery to X-Plane without massive
+downloads. Instead of pre-downloading thousands of gigabytes of textures,
+XEarthLayer installs small regional packages and streams textures on-demand
+as you fly.
+
+Features:
+- Small regional packages (megabytes, not gigabytes)
+- On-demand texture streaming from Bing Maps or Google Maps
+- Two-tier caching for instant repeat visits
+- High-quality BC1/BC3 DDS textures with mipmaps
+- Works with Ortho4XP-generated scenery
+- Linux support (Windows and macOS planned)
+
+%prep
+%autosetup
+
+%build
+cargo build --release --locked
+
+%install
+install -Dm755 target/release/xearthlayer %{buildroot}%{_bindir}/xearthlayer
+install -Dm644 LICENSE %{buildroot}%{_licensedir}/%{name}/LICENSE
+install -Dm644 README.md %{buildroot}%{_docdir}/%{name}/README.md
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/xearthlayer
+
+%changelog
+* Mon Dec 15 2025 Sam de Freyssinet <sam@def.reyssi.net> - 0.2.0-1
+- Initial RPM release
+- Async pipeline architecture for improved performance
+- HTTP concurrency limiting to prevent network exhaustion
+- Cooperative cancellation for FUSE timeout handling
+- TUI dashboard for real-time monitoring

--- a/xearthlayer-cli/Cargo.toml
+++ b/xearthlayer-cli/Cargo.toml
@@ -5,10 +5,33 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "High-quality satellite imagery for X-Plane, streamed on demand"
+readme = "../README.md"
+keywords = ["xplane", "flight-simulator", "satellite-imagery", "fuse"]
+categories = ["command-line-utilities", "filesystem"]
 
 [[bin]]
 name = "xearthlayer"
 path = "src/main.rs"
+
+# cargo-deb configuration for Debian/Ubuntu packages
+[package.metadata.deb]
+name = "xearthlayer"
+maintainer = "Sam de Freyssinet <sam@def.reyssi.net>"
+copyright = "2025, XEarthLayer Contributors"
+license-file = ["../LICENSE", "0"]
+extended-description = """\
+XEarthLayer delivers satellite/aerial imagery to X-Plane without massive downloads. \
+Instead of pre-downloading thousands of gigabytes of textures, XEarthlayer installs \
+small regional packages and streams textures on-demand as you fly."""
+depends = "$auto, libfuse3-3"
+section = "games"
+priority = "optional"
+assets = [
+    ["target/release/xearthlayer", "usr/bin/", "755"],
+    ["../README.md", "usr/share/doc/xearthlayer/README.md", "644"],
+    ["../LICENSE", "usr/share/doc/xearthlayer/LICENSE", "644"],
+]
 
 [dependencies]
 xearthlayer = { path = "../xearthlayer" }

--- a/xearthlayer/Cargo.toml
+++ b/xearthlayer/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "fs", "macros"] }
-reqwest = { version = "0.12", features = ["blocking"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 image = "0.25"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "local-time"] }


### PR DESCRIPTION
## Summary
Merges the v0.2.5 release back to main, bringing:

- Linux packaging infrastructure (RPM, Debian, AUR)
- CHANGELOG.md
- Makefile targets for version management and packaging
- rustls switch for static builds
- Documentation updates
- Version bump to 0.2.5

## Release
- Release v0.2.5 published successfully: https://github.com/samsoir/xearthlayer/releases/tag/v0.2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)