### PR TITLE
Release 0.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 authors = ["XEarthLayer Contributors"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version to 0.2.7
- Update CHANGELOG.md with release notes

## Release Highlights

### Fixed
- **Deadlock with Cached Chunks**: Fixed system freeze when loading scenery with partially cached tiles
  - Root cause: Unlimited assembly tasks monopolized blocking thread pool, starving disk I/O and encode stages
  - Solution: Added concurrency limiter to assembly stage and merged with encode into shared CPU limiter

### Added
- **Storage-Aware Disk I/O Profiles**: Automatic detection and tuning of disk I/O concurrency based on storage type
  - Auto-detection via `/sys/block/<device>/queue/rotational` on Linux
  - HDD profile: Conservative concurrency (1-4 ops)
  - SSD profile: Moderate concurrency (32-64 ops) - default fallback
  - NVMe profile: Aggressive concurrency (128-256 ops)
  - Configurable via `cache.disk_io_profile` setting

- **Shared CPU Limiter with Over-Subscription**: Improved CPU utilization during tile generation
  - Formula: `max(num_cpus * 1.25, num_cpus + 2)` keeps cores busy during brief I/O waits

🤖 Generated with [Claude Code](https://claude.com/claude-code)