### PR TITLE
Centralize hardcoded values as configurable parameters

### DIFF
--- a/xearthlayer-cli/src/commands/run.rs
+++ b/xearthlayer-cli/src/commands/run.rs
@@ -126,6 +126,7 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
         .cache_disk_size(config.cache.disk_size)
         .generation_threads(config.generation.threads)
         .generation_timeout(config.generation.timeout)
+        .pipeline(config.pipeline.clone())
         .quiet_mode(use_tui) // Disable stats logging when TUI is active
         .build();
 

--- a/xearthlayer-cli/src/commands/start.rs
+++ b/xearthlayer-cli/src/commands/start.rs
@@ -90,6 +90,7 @@ pub fn run(args: StartArgs) -> Result<(), CliError> {
         .cache_disk_size(config.cache.disk_size)
         .generation_threads(config.generation.threads)
         .generation_timeout(config.generation.timeout)
+        .pipeline(config.pipeline.clone())
         .build();
 
     // Print banner

--- a/xearthlayer/src/config/download.rs
+++ b/xearthlayer/src/config/download.rs
@@ -1,5 +1,7 @@
 //! Download/orchestrator configuration.
 
+use super::file::{DEFAULT_DOWNLOAD_TIMEOUT_SECS, DEFAULT_MAX_RETRIES, DEFAULT_PARALLEL_DOWNLOADS};
+
 /// Configuration for tile downloading and orchestration.
 ///
 /// Groups all parameters needed to configure the download orchestrator,
@@ -85,9 +87,9 @@ impl DownloadConfig {
 impl Default for DownloadConfig {
     fn default() -> Self {
         Self {
-            timeout_secs: 30,
-            max_retries: 3,
-            parallel_downloads: 32,
+            timeout_secs: DEFAULT_DOWNLOAD_TIMEOUT_SECS,
+            max_retries: DEFAULT_MAX_RETRIES,
+            parallel_downloads: DEFAULT_PARALLEL_DOWNLOADS,
         }
     }
 }
@@ -99,9 +101,9 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = DownloadConfig::default();
-        assert_eq!(config.timeout_secs(), 30);
-        assert_eq!(config.max_retries(), 3);
-        assert_eq!(config.parallel_downloads(), 32);
+        assert_eq!(config.timeout_secs(), DEFAULT_DOWNLOAD_TIMEOUT_SECS);
+        assert_eq!(config.max_retries(), DEFAULT_MAX_RETRIES);
+        assert_eq!(config.parallel_downloads(), DEFAULT_PARALLEL_DOWNLOADS);
     }
 
     #[test]
@@ -115,23 +117,23 @@ mod tests {
     fn test_with_timeout_secs() {
         let config = DownloadConfig::new().with_timeout_secs(60);
         assert_eq!(config.timeout_secs(), 60);
-        assert_eq!(config.max_retries(), 3); // Unchanged
-        assert_eq!(config.parallel_downloads(), 32); // Unchanged
+        assert_eq!(config.max_retries(), DEFAULT_MAX_RETRIES); // Unchanged
+        assert_eq!(config.parallel_downloads(), DEFAULT_PARALLEL_DOWNLOADS); // Unchanged
     }
 
     #[test]
     fn test_with_max_retries() {
         let config = DownloadConfig::new().with_max_retries(5);
-        assert_eq!(config.timeout_secs(), 30); // Unchanged
+        assert_eq!(config.timeout_secs(), DEFAULT_DOWNLOAD_TIMEOUT_SECS); // Unchanged
         assert_eq!(config.max_retries(), 5);
-        assert_eq!(config.parallel_downloads(), 32); // Unchanged
+        assert_eq!(config.parallel_downloads(), DEFAULT_PARALLEL_DOWNLOADS); // Unchanged
     }
 
     #[test]
     fn test_with_parallel_downloads() {
         let config = DownloadConfig::new().with_parallel_downloads(16);
-        assert_eq!(config.timeout_secs(), 30); // Unchanged
-        assert_eq!(config.max_retries(), 3); // Unchanged
+        assert_eq!(config.timeout_secs(), DEFAULT_DOWNLOAD_TIMEOUT_SECS); // Unchanged
+        assert_eq!(config.max_retries(), DEFAULT_MAX_RETRIES); // Unchanged
         assert_eq!(config.parallel_downloads(), 16);
     }
 
@@ -170,6 +172,6 @@ mod tests {
         let debug_str = format!("{:?}", config);
         assert!(debug_str.contains("DownloadConfig"));
         assert!(debug_str.contains("timeout_secs"));
-        assert!(debug_str.contains("30"));
+        assert!(debug_str.contains(&DEFAULT_DOWNLOAD_TIMEOUT_SECS.to_string()));
     }
 }

--- a/xearthlayer/src/config/keys.rs
+++ b/xearthlayer/src/config/keys.rs
@@ -49,6 +49,15 @@ pub enum ConfigKey {
     GenerationThreads,
     GenerationTimeout,
 
+    // Pipeline settings
+    PipelineMaxHttpConcurrent,
+    PipelineMaxCpuConcurrent,
+    PipelineMaxPrefetchInFlight,
+    PipelineRequestTimeoutSecs,
+    PipelineMaxRetries,
+    PipelineRetryBaseDelayMs,
+    PipelineCoalesceChannelCapacity,
+
     // X-Plane settings
     XplaneSceneryDir,
 
@@ -93,6 +102,14 @@ impl FromStr for ConfigKey {
             "generation.threads" => Ok(ConfigKey::GenerationThreads),
             "generation.timeout" => Ok(ConfigKey::GenerationTimeout),
 
+            "pipeline.max_http_concurrent" => Ok(ConfigKey::PipelineMaxHttpConcurrent),
+            "pipeline.max_cpu_concurrent" => Ok(ConfigKey::PipelineMaxCpuConcurrent),
+            "pipeline.max_prefetch_in_flight" => Ok(ConfigKey::PipelineMaxPrefetchInFlight),
+            "pipeline.request_timeout_secs" => Ok(ConfigKey::PipelineRequestTimeoutSecs),
+            "pipeline.max_retries" => Ok(ConfigKey::PipelineMaxRetries),
+            "pipeline.retry_base_delay_ms" => Ok(ConfigKey::PipelineRetryBaseDelayMs),
+            "pipeline.coalesce_channel_capacity" => Ok(ConfigKey::PipelineCoalesceChannelCapacity),
+
             "xplane.scenery_dir" => Ok(ConfigKey::XplaneSceneryDir),
 
             "packages.library_url" => Ok(ConfigKey::PackagesLibraryUrl),
@@ -131,6 +148,13 @@ impl ConfigKey {
             ConfigKey::DownloadTimeout => "download.timeout",
             ConfigKey::GenerationThreads => "generation.threads",
             ConfigKey::GenerationTimeout => "generation.timeout",
+            ConfigKey::PipelineMaxHttpConcurrent => "pipeline.max_http_concurrent",
+            ConfigKey::PipelineMaxCpuConcurrent => "pipeline.max_cpu_concurrent",
+            ConfigKey::PipelineMaxPrefetchInFlight => "pipeline.max_prefetch_in_flight",
+            ConfigKey::PipelineRequestTimeoutSecs => "pipeline.request_timeout_secs",
+            ConfigKey::PipelineMaxRetries => "pipeline.max_retries",
+            ConfigKey::PipelineRetryBaseDelayMs => "pipeline.retry_base_delay_ms",
+            ConfigKey::PipelineCoalesceChannelCapacity => "pipeline.coalesce_channel_capacity",
             ConfigKey::XplaneSceneryDir => "xplane.scenery_dir",
             ConfigKey::PackagesLibraryUrl => "packages.library_url",
             ConfigKey::PackagesInstallLocation => "packages.install_location",
@@ -174,6 +198,19 @@ impl ConfigKey {
             ConfigKey::DownloadTimeout => config.download.timeout.to_string(),
             ConfigKey::GenerationThreads => config.generation.threads.to_string(),
             ConfigKey::GenerationTimeout => config.generation.timeout.to_string(),
+            ConfigKey::PipelineMaxHttpConcurrent => config.pipeline.max_http_concurrent.to_string(),
+            ConfigKey::PipelineMaxCpuConcurrent => config.pipeline.max_cpu_concurrent.to_string(),
+            ConfigKey::PipelineMaxPrefetchInFlight => {
+                config.pipeline.max_prefetch_in_flight.to_string()
+            }
+            ConfigKey::PipelineRequestTimeoutSecs => {
+                config.pipeline.request_timeout_secs.to_string()
+            }
+            ConfigKey::PipelineMaxRetries => config.pipeline.max_retries.to_string(),
+            ConfigKey::PipelineRetryBaseDelayMs => config.pipeline.retry_base_delay_ms.to_string(),
+            ConfigKey::PipelineCoalesceChannelCapacity => {
+                config.pipeline.coalesce_channel_capacity.to_string()
+            }
             ConfigKey::XplaneSceneryDir => config
                 .xplane
                 .scenery_dir
@@ -263,6 +300,27 @@ impl ConfigKey {
             ConfigKey::GenerationTimeout => {
                 config.generation.timeout = value.parse().unwrap();
             }
+            ConfigKey::PipelineMaxHttpConcurrent => {
+                config.pipeline.max_http_concurrent = value.parse().unwrap();
+            }
+            ConfigKey::PipelineMaxCpuConcurrent => {
+                config.pipeline.max_cpu_concurrent = value.parse().unwrap();
+            }
+            ConfigKey::PipelineMaxPrefetchInFlight => {
+                config.pipeline.max_prefetch_in_flight = value.parse().unwrap();
+            }
+            ConfigKey::PipelineRequestTimeoutSecs => {
+                config.pipeline.request_timeout_secs = value.parse().unwrap();
+            }
+            ConfigKey::PipelineMaxRetries => {
+                config.pipeline.max_retries = value.parse().unwrap();
+            }
+            ConfigKey::PipelineRetryBaseDelayMs => {
+                config.pipeline.retry_base_delay_ms = value.parse().unwrap();
+            }
+            ConfigKey::PipelineCoalesceChannelCapacity => {
+                config.pipeline.coalesce_channel_capacity = value.parse().unwrap();
+            }
             ConfigKey::XplaneSceneryDir => {
                 config.xplane.scenery_dir = optional_path(value);
             }
@@ -341,6 +399,13 @@ impl ConfigKey {
             ConfigKey::DownloadTimeout => Box::new(PositiveIntegerSpec),
             ConfigKey::GenerationThreads => Box::new(PositiveIntegerSpec),
             ConfigKey::GenerationTimeout => Box::new(PositiveIntegerSpec),
+            ConfigKey::PipelineMaxHttpConcurrent => Box::new(PositiveIntegerSpec),
+            ConfigKey::PipelineMaxCpuConcurrent => Box::new(PositiveIntegerSpec),
+            ConfigKey::PipelineMaxPrefetchInFlight => Box::new(PositiveIntegerSpec),
+            ConfigKey::PipelineRequestTimeoutSecs => Box::new(PositiveIntegerSpec),
+            ConfigKey::PipelineMaxRetries => Box::new(PositiveIntegerSpec),
+            ConfigKey::PipelineRetryBaseDelayMs => Box::new(PositiveIntegerSpec),
+            ConfigKey::PipelineCoalesceChannelCapacity => Box::new(PositiveIntegerSpec),
             ConfigKey::XplaneSceneryDir => Box::new(OptionalPathSpec),
             ConfigKey::PackagesLibraryUrl => Box::new(OptionalUrlSpec),
             ConfigKey::PackagesInstallLocation => Box::new(OptionalPathSpec),
@@ -372,6 +437,13 @@ impl ConfigKey {
             ConfigKey::DownloadTimeout,
             ConfigKey::GenerationThreads,
             ConfigKey::GenerationTimeout,
+            ConfigKey::PipelineMaxHttpConcurrent,
+            ConfigKey::PipelineMaxCpuConcurrent,
+            ConfigKey::PipelineMaxPrefetchInFlight,
+            ConfigKey::PipelineRequestTimeoutSecs,
+            ConfigKey::PipelineMaxRetries,
+            ConfigKey::PipelineRetryBaseDelayMs,
+            ConfigKey::PipelineCoalesceChannelCapacity,
             ConfigKey::XplaneSceneryDir,
             ConfigKey::PackagesLibraryUrl,
             ConfigKey::PackagesInstallLocation,

--- a/xearthlayer/src/config/mod.rs
+++ b/xearthlayer/src/config/mod.rs
@@ -39,9 +39,49 @@ mod xplane;
 
 pub use download::DownloadConfig;
 pub use file::{
-    config_directory, config_file_path, CacheSettings, ConfigFile, ConfigFileError,
-    DownloadSettings, GenerationSettings, LoggingSettings, PackagesSettings, ProviderSettings,
-    TextureSettings, XPlaneSettings,
+    config_directory,
+    config_file_path,
+    default_cpu_concurrent,
+    default_http_concurrent,
+    default_prefetch_in_flight,
+    num_cpus,
+    CacheSettings,
+    ConfigFile,
+    ConfigFileError,
+    DownloadSettings,
+    GenerationSettings,
+    LoggingSettings,
+    PackagesSettings,
+    PipelineSettings,
+    PrefetchSettings,
+    ProviderSettings,
+    TextureSettings,
+    XPlaneSettings,
+    // Pipeline defaults
+    DEFAULT_COALESCE_CHANNEL_CAPACITY,
+    // Cache defaults
+    DEFAULT_DISK_CACHE_SIZE,
+    // Download defaults
+    DEFAULT_DOWNLOAD_TIMEOUT_SECS,
+    // Generation defaults
+    DEFAULT_GENERATION_TIMEOUT_SECS,
+    DEFAULT_MAX_CONCURRENT_DOWNLOADS,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_MEMORY_CACHE_SIZE,
+    // Texture defaults
+    DEFAULT_MIPMAP_COUNT,
+    // DownloadConfig defaults
+    DEFAULT_PARALLEL_DOWNLOADS,
+    // Prefetch defaults
+    DEFAULT_PREFETCH_BATCH_SIZE,
+    DEFAULT_PREFETCH_CONE_ANGLE,
+    DEFAULT_PREFETCH_CONE_DISTANCE_NM,
+    DEFAULT_PREFETCH_MAX_IN_FLIGHT,
+    DEFAULT_PREFETCH_RADIAL_RADIUS,
+    DEFAULT_PREFETCH_RADIAL_RADIUS_NM,
+    DEFAULT_PREFETCH_UDP_PORT,
+    DEFAULT_REQUEST_TIMEOUT_SECS,
+    DEFAULT_RETRY_BASE_DELAY_MS,
 };
 pub use keys::{ConfigKey, ConfigKeyError};
 pub use size::{format_size, parse_size, Size, SizeParseError};

--- a/xearthlayer/src/config/texture.rs
+++ b/xearthlayer/src/config/texture.rs
@@ -1,5 +1,6 @@
 //! Texture encoding configuration.
 
+use super::file::DEFAULT_MIPMAP_COUNT;
 use crate::dds::DdsFormat;
 
 /// Configuration for texture encoding.
@@ -35,11 +36,11 @@ pub struct TextureConfig {
 impl TextureConfig {
     /// Create a new texture configuration with the specified format.
     ///
-    /// Uses default mipmap count of 5 (suitable for 4096×4096 → 256×256 chain).
+    /// Uses default mipmap count (suitable for 4096×4096 → 256×256 chain).
     pub fn new(format: DdsFormat) -> Self {
         Self {
             format,
-            mipmap_count: 5,
+            mipmap_count: DEFAULT_MIPMAP_COUNT,
         }
     }
 
@@ -69,7 +70,7 @@ impl Default for TextureConfig {
     fn default() -> Self {
         Self {
             format: DdsFormat::BC1,
-            mipmap_count: 5,
+            mipmap_count: DEFAULT_MIPMAP_COUNT,
         }
     }
 }
@@ -82,14 +83,14 @@ mod tests {
     fn test_default_config() {
         let config = TextureConfig::default();
         assert_eq!(config.format(), DdsFormat::BC1);
-        assert_eq!(config.mipmap_count(), 5);
+        assert_eq!(config.mipmap_count(), DEFAULT_MIPMAP_COUNT);
     }
 
     #[test]
     fn test_new_with_format() {
         let config = TextureConfig::new(DdsFormat::BC3);
         assert_eq!(config.format(), DdsFormat::BC3);
-        assert_eq!(config.mipmap_count(), 5); // Default mipmaps
+        assert_eq!(config.mipmap_count(), DEFAULT_MIPMAP_COUNT); // Default mipmaps
     }
 
     #[test]

--- a/xearthlayer/src/service/facade.rs
+++ b/xearthlayer/src/service/facade.rs
@@ -417,11 +417,17 @@ impl XEarthLayerService {
     ///
     /// Uses `DdsHandlerBuilder` for clean configuration of the pipeline.
     fn create_dds_handler(&self) -> DdsHandler {
+        let pipeline = self.config.pipeline();
         let mut builder = DdsHandlerBuilder::new(&self.provider_name)
             .with_format(self.config.texture().format())
             .with_mipmap_count(self.config.texture().mipmap_count())
-            .with_timeout(Duration::from_secs(self.config.download().timeout_secs()))
-            .with_max_retries(self.config.download().max_retries())
+            .with_timeout(Duration::from_secs(pipeline.request_timeout_secs))
+            .with_max_retries(pipeline.max_retries)
+            .with_max_global_http_requests(pipeline.max_http_concurrent)
+            .with_max_cpu_concurrent(pipeline.max_cpu_concurrent)
+            .with_max_prefetch_in_flight(pipeline.max_prefetch_in_flight)
+            .with_retry_base_delay_ms(pipeline.retry_base_delay_ms)
+            .with_coalesce_channel_capacity(pipeline.coalesce_channel_capacity)
             .with_metrics(Arc::clone(&self.metrics));
 
         // Configure provider (prefer async, fallback to sync)


### PR DESCRIPTION
## Summary

- Move hardcoded concurrency limits, timeouts, and retry behavior to centralized constants in `config/file.rs`
- Add new `[pipeline]` INI config section for advanced tuning
- Establish single source of truth for all default values, used consistently across `PipelineConfig`, `DdsHandlerBuilder`, `DownloadConfig`, and `TextureConfig`

## New Configuration Options

### Pipeline Settings (`[pipeline]` section)
| Key | Default | Description |
|-----|---------|-------------|
| `max_http_concurrent` | `min(cpus×16, 256)` | Global HTTP request limit |
| `max_cpu_concurrent` | `max(cpus×1.25, cpus+2)` | CPU-bound operation limit |
| `max_prefetch_in_flight` | `max(cpus/4, 2)` | Prefetch job limit |
| `request_timeout_secs` | `10` | HTTP timeout per chunk |
| `max_retries` | `3` | Retry attempts per chunk |
| `retry_base_delay_ms` | `100` | Exponential backoff base |
| `coalesce_channel_capacity` | `16` | Request coalescing capacity |

### Other Centralized Defaults
- Cache: `DEFAULT_MEMORY_CACHE_SIZE` (2GB), `DEFAULT_DISK_CACHE_SIZE` (20GB)
- Download: `DEFAULT_DOWNLOAD_TIMEOUT_SECS` (30), `DEFAULT_PARALLEL_DOWNLOADS` (32)
- Generation: `DEFAULT_GENERATION_TIMEOUT_SECS` (10)
- Texture: `DEFAULT_MIPMAP_COUNT` (5)
- Prefetch: UDP port, cone angle, distances, batch size, etc.

## Test plan

- [x] All 1160 tests pass
- [x] `make verify` passes (format, lint, test)
- [ ] Manual testing with `xearthlayer run` to verify defaults work correctly
- [ ] Verify INI file parsing with custom `[pipeline]` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)