### PR TITLE
Release v0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,7 +3585,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xearthlayer"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "xearthlayer-cli"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 authors = ["XEarthLayer Contributors"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Disk cache eviction daemon (enforces size limits)
- SceneryIndex persistent cache (faster startup)
- SceneryIndex CLI commands (status/update/clear)
- Cold-start prewarm (`--airport` flag)
- Dashboard loading state with progress

## Bug Fixes

- Disk cache now respects configured size limits
- Config upgrade detection for deprecated keys
- Airport coordinate parsing and prewarm deadlock

## Breaking Changes

- Removed `prefetch.prediction_distance_nm` (use `inner_radius_nm`/`outer_radius_nm`)
- Removed `prefetch.time_horizon_secs` (no longer used)

## Upgrade Notes

Run `xearthlayer config upgrade` to add new settings with defaults.

## Changelog

See [CHANGELOG.md](./CHANGELOG.md) for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)