### PR TITLE
Add tile patches support for custom mesh/elevation from airport addons

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -458,6 +458,30 @@ temp_dir = ~/Downloads/xearthlayer-temp
 - When `auto_install_overlays` is enabled, installing an ortho package will automatically install the matching overlay package for the same region (if available)
 - If `custom_scenery_path` is not set, it falls back to `[xplane] scenery_dir` or auto-detects from X-Plane installation
 
+---
+
+### `[patches]` - Tile Patches
+
+Settings for tile patches - pre-built Ortho4XP tiles with custom mesh/elevation from airport addons.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Enable/disable patches functionality |
+| `directory` | path | `~/.xearthlayer/patches` | Directory containing patch tiles |
+
+**Example:**
+```ini
+[patches]
+enabled = true
+directory = ~/.xearthlayer/patches
+```
+
+**Notes:**
+- Patches allow using custom elevation/mesh from airport addons (like SFD KLAX) while XEL generates textures
+- Each patch folder must contain `Earth nav data/` with DSF files
+- Patches are merged using a union filesystem; alphabetically-first folder wins on collision
+- See [docs/patches.md](patches.md) for detailed usage instructions
+
 ## Complete Example
 
 ```ini
@@ -539,6 +563,11 @@ file = ~/.xearthlayer/xearthlayer.log
 ; custom_scenery_path = /path/to/X-Plane 12/Custom Scenery
 ; auto_install_overlays = true
 ; temp_dir = ~/Downloads/xearthlayer-temp
+
+[patches]
+; Tile patches for custom mesh/elevation from airport addons
+enabled = true
+; directory = ~/.xearthlayer/patches
 ```
 
 ## Config CLI Commands

--- a/docs/dev/tile-patches.md
+++ b/docs/dev/tile-patches.md
@@ -1,0 +1,538 @@
+# Tile Patches Feature Design
+
+**Status**: Phase 1 In Progress
+**Created**: 2026-01-07
+**Last Updated**: 2026-01-07
+
+## Overview
+
+The Tile Patches feature enables XEarthLayer to serve pre-built Ortho4XP tiles containing custom mesh/elevation data from third-party airport addons, while generating textures dynamically using XEL's configured imagery provider.
+
+### Goals
+
+1. **Addon Compatibility** - Support airport addons that require custom elevation/mesh
+2. **Visual Consistency** - Use XEL's provider for all textures (no seams at tile boundaries)
+3. **Provider Flexibility** - Enable providers not available in Ortho4XP (Apple Maps, Mapbox)
+4. **Non-Destructive** - Never modify user's patch source files
+5. **Simple User Workflow** - Just copy built Ortho4XP tile to patches folder
+
+### Non-Goals
+
+- Automatic patch detection from existing scenery packages
+- Integration with Ortho4XP build process
+- Provider-specific texture matching
+
+---
+
+## Problem Statement
+
+Third-party X-Plane scenery developers (airport addons) provide custom elevation/mesh data that requires ortho tiles built with matching elevation. The challenge is that if users build these tiles with a different imagery provider than XEL uses, there will be visible seams at tile boundaries.
+
+### Root Cause
+
+Airport addons like SFD KLAX or X-Codr KDEN include custom DSF files with corrected elevation for the airport area. When users build ortho tiles:
+
+1. **With standard elevation**: Airport mesh doesn't match, causing visual artifacts
+2. **With addon's elevation but different provider**: Imagery doesn't match adjacent XEL tiles
+
+### Real-World Examples
+
+**KLAX (SFD):**
+- Location: `/run/media/sdefreyssinet/FlightSim/X-Plane Scenery/SFD_KLAX_Los_Angeles_HD_1_Airport`
+- Provides: `!Ortho4XP_Patch/Elevations/+33-119.tif` (custom elevation)
+- Provides: `!Ortho4XP_Patch/Patches/+30-120/+33-119/KLAX.patch.osm` (OSM modifications)
+
+**KDEN (X-Codr):**
+- Location: `/run/media/sdefreyssinet/FlightSim/X-Plane Scenery/KDEN Ortho/Z KDEN Mesh`
+- Structure: Complete Ortho4XP output with `Earth nav data/`, `terrain/`, `textures/`
+
+---
+
+## Design Decisions
+
+### D1: Patches = Complete Ortho4XP Tiles
+
+**Decision**: Patches are complete Ortho4XP tile folders, NOT individual DDS files.
+
+**Patch structure:**
+```
+~/.xearthlayer/patches/
+└── KLAX_Mesh/                        # User-named folder
+    ├── Earth nav data/
+    │   └── +30-120/
+    │       └── +33-119.dsf           # DSF with custom mesh
+    ├── terrain/
+    │   ├── 94800_47888_BI18.ter      # Terrain definition files
+    │   └── ...
+    └── textures/                      # May be empty or sparse
+        └── ...                        # XEL generates these on-demand
+```
+
+**Rationale:**
+- Matches standard Ortho4XP output structure
+- User simply moves built tile to patches folder
+- DSF contains the custom mesh/elevation data
+- Terrain files define texture references
+
+### D2: XEL Generates Textures Dynamically
+
+**Decision**: When X-Plane requests DDS textures from a patch, XEL generates them using its configured imagery provider.
+
+**Rationale:**
+- Ensures consistent imagery across all tiles (no seams)
+- Supports providers not available in Ortho4XP
+- User doesn't need to pre-generate textures
+- Patch provides mesh, XEL provides imagery
+
+### D3: Patches Have Highest Priority
+
+**Decision**: Patches ALWAYS have higher priority than any regional package.
+
+**Mount order:**
+1. Patches folder (highest priority - `zzy` prefix)
+2. Regional ortho packages (`zz` prefix)
+3. Overlays (`yz` prefix - loaded first by X-Plane)
+
+**Rationale:**
+- When a tile exists in patches, use patch's mesh
+- Ensures addon elevation data is used
+- Simple, predictable behavior
+
+### D4: Union Filesystem for Patches
+
+**Decision**: Present all patches as a **single unified scenery package** via FUSE, merging contents from all patch folders non-destructively.
+
+**Rationale:**
+- Non-destructive: Real filesystem unchanged
+- Single mount point: Simple for X-Plane scenery.ini
+- Predictable priority: Users control via folder naming
+- Reusable: This pattern extends to consolidated regional mounts later
+
+---
+
+## Architecture
+
+### Union Filesystem Pattern
+
+The patches FUSE mount implements an **overlay/union** pattern similar to Linux OverlayFS:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                         REAL FILESYSTEM (Source)                                 │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│  ~/.xearthlayer/patches/                                                         │
+│  ├── A_KDEN_Mesh/                      # 'A' prefix - highest priority          │
+│  │   ├── Earth nav data/+30-110/+39-105.dsf                                     │
+│  │   └── terrain/24800_13648_USA_216.ter                                        │
+│  ├── B_KLAX_Mesh/                      # 'B' prefix - second priority           │
+│  │   ├── Earth nav data/+30-120/+33-119.dsf                                     │
+│  │   └── terrain/94800_47888_BI18.ter                                           │
+│  └── Z_SomeOther/                      # 'Z' prefix - lowest priority           │
+│      └── ...                                                                     │
+└───────────────────────────────────────┬─────────────────────────────────────────┘
+                                        │
+                                        │ FUSE Union Mount
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                         VIRTUAL FILESYSTEM (FUSE)                                │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│  Custom Scenery/zzyXEL_patches_ortho/                                            │
+│  ├── Earth nav data/                                                             │
+│  │   ├── +30-110/+39-105.dsf            # From A_KDEN_Mesh (first alphabetically)│
+│  │   └── +30-120/+33-119.dsf            # From B_KLAX_Mesh                       │
+│  ├── terrain/                                                                    │
+│  │   ├── 24800_13648_USA_216.ter        # From A_KDEN_Mesh                       │
+│  │   └── 94800_47888_BI18.ter           # From B_KLAX_Mesh                       │
+│  └── textures/                                                                   │
+│      └── (XEL generates on-demand via DdsHandler)                               │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Collision resolution**: When multiple patches contain the same file path, the patch with the alphabetically-first folder name wins (A < B < Z).
+
+### Integration with Existing Pipeline
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                              MountManager                                        │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│  1. Mount patches folder (if patches.enabled && patches exist)                  │
+│     └── zzyXEL_patches_ortho/  (higher priority mount)                          │
+│  2. Mount regional packages (existing)                                           │
+│     └── zzXEL_na_ortho, zzXEL_eu_ortho, etc.                                    │
+└───────────────────────────────────────┬─────────────────────────────────────────┘
+                                        │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                         Fuse3UnionFS                                             │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│  PatchUnionIndex: Merged index of all files across patches                      │
+│                                                                                  │
+│  lookup() / read():                                                              │
+│  ├── DSF files  → passthrough from source patch folder                          │
+│  ├── .ter files → passthrough from source patch folder                          │
+│  └── .dds files → check cache, then generate via DdsHandler                     │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Data Structures
+
+```rust
+/// Merged index of all files across all patches.
+pub struct PatchUnionIndex {
+    /// Map from virtual path → (source_patch_name, real_path)
+    /// Sorted by patch name so first match wins
+    files: HashMap<PathBuf, (String, PathBuf)>,
+
+    /// Virtual directory structure for readdir
+    directories: HashMap<PathBuf, Vec<DirEntry>>,
+}
+
+impl PatchUnionIndex {
+    /// Build index from all patches (sorted alphabetically by name)
+    pub fn build(patches_dir: &Path) -> Result<Self> {
+        let mut patches: Vec<_> = fs::read_dir(patches_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().join("Earth nav data").exists())
+            .collect();
+
+        // Sort by name (alphabetically) for priority
+        patches.sort_by_key(|e| e.file_name());
+
+        let mut index = Self::new();
+        for patch in patches {
+            index.add_patch(&patch.path())?;
+        }
+        Ok(index)
+    }
+
+    /// Add files from a patch, respecting existing entries (first wins)
+    fn add_patch(&mut self, patch_path: &Path) -> Result<()> {
+        for entry in WalkDir::new(patch_path) {
+            let entry = entry?;
+            let relative = entry.path().strip_prefix(patch_path)?;
+
+            // Only insert if not already present (first patch wins)
+            if !self.files.contains_key(relative) {
+                let patch_name = patch_path.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string();
+                self.files.insert(
+                    relative.to_path_buf(),
+                    (patch_name, entry.path().to_path_buf())
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Resolve virtual path to real file path
+    pub fn resolve(&self, virtual_path: &Path) -> Option<&PathBuf> {
+        self.files.get(virtual_path).map(|(_, real)| real)
+    }
+}
+```
+
+### FUSE Operations
+
+```rust
+impl Fuse3UnionFS {
+    /// readdir: Return merged directory listing
+    async fn readdir(&self, path: &Path) -> Vec<DirEntry> {
+        self.index.directories.get(path).cloned().unwrap_or_default()
+    }
+
+    /// lookup: Check if file exists in union
+    async fn lookup(&self, parent: &Path, name: &str) -> Option<FileAttr> {
+        let virtual_path = parent.join(name);
+
+        if let Some(real_path) = self.index.resolve(&virtual_path) {
+            // Return attributes of real file
+            return Some(self.get_attr(real_path).await?);
+        }
+
+        // For .dds files, may be virtual (generated on-demand)
+        if name.ends_with(".dds") {
+            return Some(self.create_virtual_dds_attr(name));
+        }
+
+        None
+    }
+
+    /// read: Passthrough or generate DDS
+    async fn read(&self, path: &Path, offset: u64, size: u32) -> Vec<u8> {
+        if let Some(real_path) = self.index.resolve(path) {
+            // Passthrough read from real file
+            return self.read_file(real_path, offset, size).await;
+        }
+
+        if path.extension() == Some("dds") {
+            // Generate DDS on-demand using shared DdsHandler
+            return self.dds_handler.request_dds(path).await;
+        }
+
+        vec![]
+    }
+}
+```
+
+---
+
+## Configuration
+
+### New Config Section: `[patches]`
+
+```ini
+[patches]
+; Enable/disable patches functionality (default: true)
+enabled = true
+
+; Directory containing patch tiles (default: ~/.xearthlayer/patches)
+directory = ~/.xearthlayer/patches
+```
+
+### New ConfigKeys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `patches.enabled` | bool | `true` | Enable patches folder mounting |
+| `patches.directory` | path | `~/.xearthlayer/patches` | Location of patch tiles |
+
+---
+
+## Module Structure
+
+### New Files
+
+```
+xearthlayer/src/
+├── patches/
+│   ├── mod.rs               # Module exports
+│   ├── discovery.rs         # Patch folder discovery and validation
+│   └── union_index.rs       # Merged file index with priority handling
+├── fuse/fuse3/
+│   └── union_fs.rs          # Union FUSE filesystem implementation (new)
+└── ...
+
+xearthlayer-cli/src/commands/
+└── patches.rs               # CLI commands (list, validate, path) (new)
+
+docs/
+└── patches.md               # User documentation and workflow guide (new)
+```
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `xearthlayer/src/lib.rs` | Add `pub mod patches;` |
+| `xearthlayer/src/config/keys.rs` | Add `PatchesEnabled`, `PatchesDirectory` |
+| `xearthlayer/src/config/file.rs` | Add `PatchesConfig` struct |
+| `xearthlayer/src/fuse/fuse3/mod.rs` | Export `union_fs` module |
+| `xearthlayer/src/manager/mounts.rs` | Mount patches before regional packages |
+| `xearthlayer-cli/src/commands/run.rs` | Wire patches into mount flow |
+| `xearthlayer-cli/src/commands/mod.rs` | Add patches subcommand |
+| `docs/configuration.md` | Document patches config |
+
+---
+
+## Implementation Plan
+
+### Phase 1: Configuration
+
+1. Add `PatchesEnabled` and `PatchesDirectory` to ConfigKey enum
+2. Add `PatchesConfig` struct to config/file.rs
+3. Add `[patches]` section parsing
+4. Update `config upgrade` to add new keys
+
+**Files:**
+- `xearthlayer/src/config/keys.rs`
+- `xearthlayer/src/config/file.rs`
+
+### Phase 2: Patch Discovery & Union Index
+
+1. Create `xearthlayer/src/patches/` module
+2. Implement `PatchDiscovery` to find and validate patch folders
+3. Implement `PatchUnionIndex` to build merged file index
+4. Handle priority via alphabetical folder name sorting
+
+**Files:**
+- `xearthlayer/src/patches/mod.rs`
+- `xearthlayer/src/patches/discovery.rs`
+- `xearthlayer/src/patches/union_index.rs`
+
+### Phase 3: Union FUSE Filesystem
+
+1. Create `Fuse3UnionFS` that wraps `PatchUnionIndex`
+2. Implement `readdir` to return merged directory listings
+3. Implement `lookup` to resolve files via union index
+4. Implement `read` with passthrough for real files, DDS generation for textures
+5. Reuse existing `DdsHandler` for texture generation
+
+**Files:**
+- `xearthlayer/src/fuse/fuse3/union_fs.rs` (new)
+- `xearthlayer/src/fuse/fuse3/mod.rs`
+
+### Phase 4: Mount Integration
+
+1. Update `MountManager` to mount patches union FS before regional packages
+2. Create mount point: `Custom Scenery/zzyXEL_patches_ortho/`
+3. Wire DdsHandler and shared resources to union FS
+4. Ensure patches only mount if patches directory exists and has content
+
+**Files:**
+- `xearthlayer/src/manager/mounts.rs`
+- `xearthlayer-cli/src/commands/run.rs`
+
+### Phase 5: CLI Commands
+
+1. Add `xearthlayer patches list` - show installed patches with priority order
+2. Add `xearthlayer patches validate` - check patch structure (Earth nav data/, terrain/)
+3. Add `xearthlayer patches path` - show patches directory location
+
+**Files:**
+- `xearthlayer-cli/src/commands/patches.rs`
+- `xearthlayer-cli/src/commands/mod.rs`
+
+### Phase 6: Documentation
+
+1. Document patch creation workflow (Ortho4XP + elevation data)
+2. Document XEL-compatible Ortho4XP configuration
+3. Document folder naming for priority control
+4. Add patches section to configuration.md
+
+**Files:**
+- `docs/patches.md` (new)
+- `docs/configuration.md`
+
+---
+
+## User Workflow
+
+### Creating a Patch Tile
+
+1. **Get addon's Ortho4XP patch data**
+   - Elevation TIF: `!Ortho4XP_Patch/Elevations/+33-119.tif`
+   - OSM patches: `!Ortho4XP_Patch/Patches/+30-120/+33-119/*.osm`
+
+2. **Configure Ortho4XP for XEL compatibility**
+   - Use addon's elevation data source
+   - Build tile with standard Ortho4XP workflow
+
+3. **Build tile in Ortho4XP**
+   - Use addon's elevation data
+   - Output: Complete tile with DSF, terrain, (optional textures)
+
+4. **Install patch**
+   ```bash
+   mv ~/Ortho4XP/Tiles/+33-119/ ~/.xearthlayer/patches/KLAX_Mesh/
+   ```
+
+5. **Restart XEL**
+   - Patch automatically mounted with higher priority
+   - XEL generates textures using configured provider
+
+---
+
+## CLI Commands
+
+```bash
+# List installed patches with priority order
+xearthlayer patches list
+
+# Example output:
+# Installed Patches (priority order):
+#   1. A_KDEN_Mesh       - 1 DSF, 193 terrain files
+#   2. B_KLAX_Mesh       - 1 DSF, 156 terrain files
+#   3. Z_Custom_Airport  - 2 DSF, 342 terrain files
+
+# Validate patch structure
+xearthlayer patches validate [--name <patch_name>]
+
+# Example output:
+# Validating: B_KLAX_Mesh
+#   ✓ Earth nav data/ found
+#   ✓ DSF file found: +30-120/+33-119.dsf
+#   ✓ terrain/ found (156 .ter files)
+#   ✓ Valid Ortho4XP tile structure
+
+# Show patches directory location
+xearthlayer patches path
+
+# Example output:
+# ~/.xearthlayer/patches
+```
+
+---
+
+## X-Plane Scenery Loading Order
+
+XEL mount points are prefixed to control X-Plane's loading order:
+
+| Prefix | Type | Example | Load Order |
+|--------|------|---------|------------|
+| `yz*` | Overlays | `yzXEL_na_overlay` | First (highest priority) |
+| `zzy*` | **Patches** | `zzyXEL_patches_ortho` | Second |
+| `zz*` | Orthos | `zzXEL_na_ortho` | Last (lowest priority) |
+
+This ensures patches override regional ortho tiles, while overlays remain on top of everything.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `PatchUnionIndex::build()` correctly scans and indexes patches
+- Alphabetical priority ordering works correctly
+- Collision resolution (first wins) works as expected
+- Empty patches directory handled gracefully
+- Invalid patch structures detected and skipped
+
+### Integration Tests
+
+- Union FS correctly resolves files to source patches
+- DSF and terrain files pass through correctly
+- DDS requests are routed to DdsHandler
+- Multiple patches merge correctly
+- Mount/unmount lifecycle works
+
+### Manual Testing
+
+- End-to-end with X-Plane using KDEN or KLAX mesh patches
+- Verify correct elevation at airport
+- Verify consistent textures with surrounding scenery
+- Verify no visual seams at tile boundaries
+
+---
+
+## Future Considerations
+
+### Consolidated FUSE Mounting (v0.2.11 follow-up)
+
+The union filesystem pattern developed for patches will be extended to consolidate all regional scenery packages into a single FUSE mount. This provides:
+
+- Single scenery.ini entry instead of one per region
+- Foundation for selective package enable/disable
+- Simplified mount management
+
+### Hot Reload
+
+Currently patches require restart to detect. Future enhancement could monitor patches directory for changes and rebuild index dynamically.
+
+### Patch Validation Tool
+
+A more comprehensive validation tool could:
+- Verify DSF mesh integrity
+- Check terrain file references
+- Detect missing texture definitions
+- Suggest fixes for common issues
+
+---
+
+## Revision History
+
+| Date | Change |
+|------|--------|
+| 2026-01-07 | Initial design document |

--- a/docs/patches.md
+++ b/docs/patches.md
@@ -1,0 +1,248 @@
+# Tile Patches
+
+Tile patches allow you to use custom mesh/elevation data from third-party airport addons while XEarthLayer generates consistent textures using your configured imagery provider.
+
+## Overview
+
+Many airport scenery addons (like SFD KLAX, X-Codr KDEN) include custom elevation data to ensure accurate airport terrain. When you build ortho tiles using their elevation data in Ortho4XP, you get a complete tile with:
+
+- **DSF files** - Custom mesh with corrected elevation
+- **Terrain files** - Texture coordinate definitions
+- **Textures** (optional) - Pre-built DDS files
+
+With tile patches, XEL mounts these tiles and **generates textures dynamically** using your configured provider (Bing, Google, etc.), ensuring consistent imagery across your entire scenery library.
+
+## Quick Start
+
+1. **Create the patches directory**:
+   ```bash
+   mkdir -p ~/.xearthlayer/patches
+   ```
+
+2. **Add your patch tiles**:
+   ```bash
+   mv ~/Ortho4XP/Tiles/+33-119/ ~/.xearthlayer/patches/KLAX_Mesh/
+   ```
+
+3. **Verify patches are detected**:
+   ```bash
+   xearthlayer patches list
+   ```
+
+4. **Start XEL** - Patches are mounted automatically:
+   ```bash
+   xearthlayer run
+   ```
+
+## Directory Structure
+
+```
+~/.xearthlayer/patches/
+├── A_KDEN_Mesh/                      # 'A' prefix = highest priority
+│   ├── Earth nav data/
+│   │   └── +30-110/
+│   │       └── +39-105.dsf           # Custom mesh DSF
+│   └── terrain/
+│       └── 24800_13648_USA_216.ter
+├── B_KLAX_Mesh/                      # 'B' prefix = second priority
+│   ├── Earth nav data/
+│   │   └── +30-120/
+│   │       └── +33-119.dsf
+│   └── terrain/
+│       └── 94800_47888_BI18.ter
+└── SomeOther/                        # No prefix = lowest priority
+    └── ...
+```
+
+### Required Structure
+
+Each patch folder **must** contain:
+- `Earth nav data/` directory with at least one `.dsf` file
+
+Optional directories:
+- `terrain/` - Terrain definition files
+- `textures/` - Pre-built DDS textures (XEL ignores these and generates its own)
+
+## Priority Order
+
+When multiple patches contain the same file path, XEL uses **alphabetical folder name** for priority. The patch with the alphabetically-first name wins.
+
+**Example**: If both `A_KLAX/` and `B_KLAX/` contain `+33-119.dsf`, the file from `A_KLAX/` is used.
+
+To control priority, prefix your folder names:
+- `A_` or `AA_` - Highest priority
+- `B_` or `BA_` - Medium priority
+- `Z_` or `ZZ_` - Lowest priority
+
+## Creating Patch Tiles
+
+### Step 1: Get Addon Patch Data
+
+Airport addons typically include an `!Ortho4XP_Patch/` folder containing:
+- **Elevation data**: `Elevations/+33-119.tif`
+- **OSM patches**: `Patches/+30-120/+33-119/*.osm`
+
+**Example locations**:
+- SFD KLAX: `SFD_KLAX_Los_Angeles_HD_1_Airport/!Ortho4XP_Patch/`
+- X-Codr KDEN: `KDEN Ortho/Z KDEN Mesh/`
+
+### Step 2: Configure Ortho4XP
+
+Build the tile in Ortho4XP using the addon's elevation data:
+
+1. Copy elevation TIF to Ortho4XP's elevation folder
+2. Import OSM patches if provided
+3. Configure tile settings:
+   - Use the addon's elevation source
+   - **Important**: Build the full tile (DSF + terrain)
+
+### Step 3: Install the Patch
+
+Move the built tile to your patches directory:
+
+```bash
+mv ~/Ortho4XP/Tiles/+33-119/ ~/.xearthlayer/patches/KLAX_Mesh/
+```
+
+### Step 4: Verify
+
+```bash
+xearthlayer patches validate --name KLAX_Mesh
+```
+
+## CLI Commands
+
+### List Patches
+
+```bash
+xearthlayer patches list
+```
+
+Shows all patches with their priority order, validation status, and file counts.
+
+### Validate Patches
+
+```bash
+# Validate all patches
+xearthlayer patches validate
+
+# Validate a specific patch
+xearthlayer patches validate --name KLAX_Mesh
+```
+
+Checks that patches have the required directory structure.
+
+### Show Patches Directory
+
+```bash
+xearthlayer patches path
+```
+
+Displays the configured patches directory location.
+
+## Configuration
+
+Patches settings in `~/.xearthlayer/config.ini`:
+
+```ini
+[patches]
+; Enable/disable patches functionality (default: true)
+enabled = true
+
+; Directory containing patch tiles (default: ~/.xearthlayer/patches)
+directory = ~/.xearthlayer/patches
+```
+
+### Configuration Keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `patches.enabled` | bool | `true` | Enable/disable patches mounting |
+| `patches.directory` | path | `~/.xearthlayer/patches` | Location of patch tiles |
+
+## X-Plane Scenery Order
+
+XEL mount points are prefixed to control X-Plane's loading order:
+
+| Prefix | Type | Example | Priority |
+|--------|------|---------|----------|
+| `yz*` | Overlays | `yzXEL_na_overlay` | Highest (loaded first) |
+| `zzy*` | Patches | `zzyXEL_patches_ortho` | After overlays |
+| `zz*` | Orthos | `zzXEL_na_ortho` | Lowest (loaded last) |
+
+This ensures:
+1. Overlays (trees, buildings) appear on top
+2. Patches override regional ortho tiles for their specific areas
+3. Regional orthos fill in everywhere else
+
+## Troubleshooting
+
+### Patches Not Detected
+
+```bash
+xearthlayer patches list
+```
+
+Check that:
+- Patches directory exists (`~/.xearthlayer/patches/`)
+- Each patch has `Earth nav data/` directory
+- DSF files are present in `Earth nav data/+XX-XXX/` subdirectories
+
+### Invalid Patch
+
+```bash
+xearthlayer patches validate --name MyPatch
+```
+
+Common issues:
+- Missing `Earth nav data/` directory
+- No DSF files found
+- Empty directories
+
+### Patches Not Loading in X-Plane
+
+1. Verify patches are mounted:
+   ```bash
+   ls -la ~/X-Plane\ 12/Custom\ Scenery/zzyXEL_patches_ortho/
+   ```
+
+2. Check X-Plane scenery_packs.ini:
+   - `zzyXEL_patches_ortho` should appear before `zzXEL_*_ortho` entries
+
+3. Restart X-Plane after adding new patches
+
+## Example Workflows
+
+### SFD KLAX Integration
+
+```bash
+# 1. Navigate to KLAX addon
+cd "/path/to/SFD_KLAX_Los_Angeles_HD_1_Airport"
+
+# 2. Check for patch data
+ls !Ortho4XP_Patch/
+# Shows: Elevations/  Patches/
+
+# 3. Build tile in Ortho4XP with KLAX elevation
+# (Use Ortho4XP GUI or CLI)
+
+# 4. Install the patch
+mkdir -p ~/.xearthlayer/patches
+mv ~/Ortho4XP/Tiles/+33-119 ~/.xearthlayer/patches/A_KLAX_Mesh/
+
+# 5. Verify
+xearthlayer patches list
+```
+
+### Multiple Airport Patches
+
+```bash
+# Install multiple patches with priority control
+mv ~/Ortho4XP/Tiles/+33-119 ~/.xearthlayer/patches/A_KLAX/
+mv ~/Ortho4XP/Tiles/+39-105 ~/.xearthlayer/patches/B_KDEN/
+mv ~/Ortho4XP/Tiles/+40-074 ~/.xearthlayer/patches/C_KJFK/
+
+# Verify all patches
+xearthlayer patches list
+xearthlayer patches validate
+```

--- a/xearthlayer-cli/src/commands/mod.rs
+++ b/xearthlayer-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@
 //! - [`download`] - Single tile download
 //! - [`init`] - Configuration initialization
 //! - [`packages`] - Package management (install, remove, update)
+//! - [`patches`] - Tile patches management (list, validate, path)
 //! - [`publish`] - Package publishing (for scenery creators)
 //! - [`run`] - Main command (mount all packages)
 //! - [`scenery_index`] - SceneryIndex cache management (update, clear, status)
@@ -23,6 +24,7 @@ pub mod diagnostics;
 pub mod download;
 pub mod init;
 pub mod packages;
+pub mod patches;
 pub mod publish;
 pub mod run;
 pub mod scenery_index;

--- a/xearthlayer-cli/src/commands/patches.rs
+++ b/xearthlayer-cli/src/commands/patches.rs
@@ -1,0 +1,263 @@
+//! Patches management CLI commands.
+//!
+//! Commands for managing tile patches - pre-built Ortho4XP tiles with custom
+//! mesh/elevation that XEL overlays with dynamically generated textures.
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+use xearthlayer::config::ConfigFile;
+use xearthlayer::patches::{PatchDiscovery, PatchInfo, PatchUnionIndex};
+
+use crate::error::CliError;
+use crate::runner::CliRunner;
+
+/// Patches subcommands.
+#[derive(Subcommand)]
+pub enum PatchesCommands {
+    /// List installed patches
+    ///
+    /// Shows all valid patches in the patches directory, their priority order,
+    /// and file counts (DSF, terrain, textures).
+    List,
+
+    /// Validate patch structure
+    ///
+    /// Checks that patches have the required directory structure and files.
+    Validate {
+        /// Name of a specific patch to validate (optional)
+        #[arg(long)]
+        name: Option<String>,
+    },
+
+    /// Show the patches directory path
+    ///
+    /// Displays the configured patches directory where patch tiles should be placed.
+    Path,
+}
+
+/// Run the patches command.
+pub fn run(command: PatchesCommands) -> Result<(), CliError> {
+    match command {
+        PatchesCommands::List => list_patches(),
+        PatchesCommands::Validate { name } => validate_patches(name),
+        PatchesCommands::Path => show_path(),
+    }
+}
+
+/// Get the patches directory from config.
+fn get_patches_dir(config: &ConfigFile) -> PathBuf {
+    config.patches.directory.clone().unwrap_or_else(|| {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".xearthlayer")
+            .join("patches")
+    })
+}
+
+/// List all patches.
+fn list_patches() -> Result<(), CliError> {
+    let runner = CliRunner::new()?;
+    let config = runner.config();
+    let patches_dir = get_patches_dir(config);
+
+    println!("Patches directory: {}", patches_dir.display());
+    println!();
+
+    if !patches_dir.exists() {
+        println!("No patches directory found.");
+        println!();
+        println!("To add patches, create the directory and place Ortho4XP tiles inside:");
+        println!("  mkdir -p {}", patches_dir.display());
+        return Ok(());
+    }
+
+    let discovery = PatchDiscovery::new(&patches_dir);
+    let all_patches = discovery
+        .find_patches()
+        .map_err(|e| CliError::Config(format!("Failed to scan patches: {}", e)))?;
+
+    if all_patches.is_empty() {
+        println!("No patches found.");
+        println!();
+        println!("Place Ortho4XP tile folders in the patches directory.");
+        println!("Each patch folder should contain 'Earth nav data/' with DSF files.");
+        return Ok(());
+    }
+
+    // Separate valid and invalid patches
+    let valid_patches: Vec<_> = all_patches.iter().filter(|p| p.is_valid).collect();
+    let invalid_patches: Vec<_> = all_patches.iter().filter(|p| !p.is_valid).collect();
+
+    println!(
+        "Found {} patch(es) ({} valid, {} invalid):",
+        all_patches.len(),
+        valid_patches.len(),
+        invalid_patches.len()
+    );
+    println!();
+
+    // Show valid patches with priority order
+    if !valid_patches.is_empty() {
+        println!("Valid patches (in priority order):");
+        for (i, patch) in valid_patches.iter().enumerate() {
+            let priority = i + 1;
+            print_patch_info(patch, Some(priority));
+        }
+        println!();
+    }
+
+    // Show invalid patches
+    if !invalid_patches.is_empty() {
+        println!("Invalid patches:");
+        for patch in &invalid_patches {
+            print_patch_info(patch, None);
+            for error in &patch.validation_errors {
+                println!("      ⚠ {}", error);
+            }
+        }
+        println!();
+    }
+
+    // Build union index and show summary
+    if !valid_patches.is_empty() {
+        let valid_infos: Vec<_> = valid_patches.iter().cloned().cloned().collect();
+        if let Ok(index) = PatchUnionIndex::build(&valid_infos) {
+            println!(
+                "Union index: {} files across {} directories",
+                index.file_count(),
+                index.directory_count()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Print information about a single patch.
+fn print_patch_info(patch: &PatchInfo, priority: Option<usize>) {
+    let status = if patch.is_valid { "✓" } else { "✗" };
+    let priority_str = priority.map(|p| format!("#{} ", p)).unwrap_or_default();
+
+    println!(
+        "  {} {}{} ({} DSF, {} terrain, {} texture files)",
+        status, priority_str, patch.name, patch.dsf_count, patch.terrain_count, patch.texture_count
+    );
+    println!("      Path: {}", patch.path.display());
+}
+
+/// Validate patches.
+fn validate_patches(name: Option<String>) -> Result<(), CliError> {
+    let runner = CliRunner::new()?;
+    let config = runner.config();
+    let patches_dir = get_patches_dir(config);
+
+    if !patches_dir.exists() {
+        return Err(CliError::Config(format!(
+            "Patches directory does not exist: {}",
+            patches_dir.display()
+        )));
+    }
+
+    let discovery = PatchDiscovery::new(&patches_dir);
+    let all_patches = discovery
+        .find_patches()
+        .map_err(|e| CliError::Config(format!("Failed to scan patches: {}", e)))?;
+
+    // Filter by name if specified
+    let patches_to_validate: Vec<_> = if let Some(ref patch_name) = name {
+        all_patches
+            .iter()
+            .filter(|p| p.name.eq_ignore_ascii_case(patch_name))
+            .collect()
+    } else {
+        all_patches.iter().collect()
+    };
+
+    if patches_to_validate.is_empty() {
+        if let Some(patch_name) = name {
+            return Err(CliError::Config(format!(
+                "Patch '{}' not found in {}",
+                patch_name,
+                patches_dir.display()
+            )));
+        } else {
+            println!("No patches found to validate.");
+            return Ok(());
+        }
+    }
+
+    let mut all_valid = true;
+
+    for patch in &patches_to_validate {
+        println!("Validating: {}", patch.name);
+        println!("  Path: {}", patch.path.display());
+
+        // Check directory structure
+        let earth_nav_data = patch.path.join("Earth nav data");
+        let terrain_dir = patch.path.join("terrain");
+        let textures_dir = patch.path.join("textures");
+
+        println!(
+            "  Earth nav data/: {}",
+            if earth_nav_data.exists() {
+                "✓"
+            } else {
+                "✗"
+            }
+        );
+        println!(
+            "  terrain/: {}",
+            if terrain_dir.exists() {
+                "✓"
+            } else {
+                "- (optional)"
+            }
+        );
+        println!(
+            "  textures/: {}",
+            if textures_dir.exists() {
+                "✓"
+            } else {
+                "- (optional)"
+            }
+        );
+
+        // Show file counts
+        println!("  DSF files: {}", patch.dsf_count);
+        println!("  Terrain files: {}", patch.terrain_count);
+        println!("  Texture files: {}", patch.texture_count);
+
+        // Show validation result
+        if patch.is_valid {
+            println!("  Status: ✓ Valid");
+        } else {
+            println!("  Status: ✗ Invalid");
+            for error in &patch.validation_errors {
+                println!("    Error: {}", error);
+            }
+            all_valid = false;
+        }
+        println!();
+    }
+
+    if all_valid {
+        println!("All patches are valid.");
+    } else {
+        println!("Some patches have validation errors. Fix them to enable mounting.");
+    }
+
+    Ok(())
+}
+
+/// Show the patches directory path.
+fn show_path() -> Result<(), CliError> {
+    let runner = CliRunner::new()?;
+    let config = runner.config();
+    let patches_dir = get_patches_dir(config);
+
+    println!("{}", patches_dir.display());
+
+    Ok(())
+}

--- a/xearthlayer-cli/src/main.rs
+++ b/xearthlayer-cli/src/main.rs
@@ -85,6 +85,15 @@ enum Commands {
         command: commands::packages::PackagesCommands,
     },
 
+    /// Tile patches management commands (custom mesh/elevation tiles)
+    ///
+    /// Patches are pre-built Ortho4XP tiles with custom mesh/elevation data
+    /// from airport addons. XEL generates textures dynamically for these tiles.
+    Patches {
+        #[command(subcommand)]
+        command: commands::patches::PatchesCommands,
+    },
+
     /// Start XEarthLayer with a scenery pack (passthrough for real files, on-demand DDS generation)
     Start {
         /// Source scenery pack directory to overlay
@@ -229,6 +238,7 @@ fn main() {
         Some(Commands::Diagnostics) => commands::diagnostics::run(),
         Some(Commands::Publish { command }) => commands::publish::run(command),
         Some(Commands::Packages { command }) => commands::packages::run(command),
+        Some(Commands::Patches { command }) => commands::patches::run(command),
         Some(Commands::Start {
             source,
             mountpoint,

--- a/xearthlayer/src/config/keys.rs
+++ b/xearthlayer/src/config/keys.rs
@@ -94,6 +94,10 @@ pub enum ConfigKey {
 
     // Prewarm settings
     PrewarmRadiusNm,
+
+    // Patches settings
+    PatchesEnabled,
+    PatchesDirectory,
 }
 
 impl FromStr for ConfigKey {
@@ -162,6 +166,10 @@ impl FromStr for ConfigKey {
             // Prewarm settings
             "prewarm.radius_nm" => Ok(ConfigKey::PrewarmRadiusNm),
 
+            // Patches settings
+            "patches.enabled" => Ok(ConfigKey::PatchesEnabled),
+            "patches.directory" => Ok(ConfigKey::PatchesDirectory),
+
             _ => Err(ConfigKeyError::UnknownKey(s.to_string())),
         }
     }
@@ -219,6 +227,10 @@ impl ConfigKey {
 
             // Prewarm settings
             ConfigKey::PrewarmRadiusNm => "prewarm.radius_nm",
+
+            // Patches settings
+            ConfigKey::PatchesEnabled => "patches.enabled",
+            ConfigKey::PatchesDirectory => "patches.directory",
         }
     }
 
@@ -329,6 +341,15 @@ impl ConfigKey {
 
             // Prewarm settings
             ConfigKey::PrewarmRadiusNm => config.prewarm.radius_nm.to_string(),
+
+            // Patches settings
+            ConfigKey::PatchesEnabled => config.patches.enabled.to_string(),
+            ConfigKey::PatchesDirectory => config
+                .patches
+                .directory
+                .as_ref()
+                .map(|p| path_to_display(p))
+                .unwrap_or_default(),
         }
     }
 
@@ -480,6 +501,15 @@ impl ConfigKey {
             ConfigKey::PrewarmRadiusNm => {
                 config.prewarm.radius_nm = value.parse().unwrap();
             }
+
+            // Patches settings
+            ConfigKey::PatchesEnabled => {
+                let v = value.to_lowercase();
+                config.patches.enabled = v == "true" || v == "1" || v == "yes" || v == "on";
+            }
+            ConfigKey::PatchesDirectory => {
+                config.patches.directory = optional_path(value);
+            }
         }
     }
 
@@ -546,6 +576,10 @@ impl ConfigKey {
 
             // Prewarm settings
             ConfigKey::PrewarmRadiusNm => Box::new(PositiveNumberSpec),
+
+            // Patches settings
+            ConfigKey::PatchesEnabled => Box::new(BooleanSpec),
+            ConfigKey::PatchesDirectory => Box::new(OptionalPathSpec),
         }
     }
 
@@ -595,6 +629,9 @@ impl ConfigKey {
             ConfigKey::ControlPlaneSemaphoreTimeoutSecs,
             // Prewarm settings
             ConfigKey::PrewarmRadiusNm,
+            // Patches settings
+            ConfigKey::PatchesEnabled,
+            ConfigKey::PatchesDirectory,
         ]
     }
 }

--- a/xearthlayer/src/fuse/fuse3/mod.rs
+++ b/xearthlayer/src/fuse/fuse3/mod.rs
@@ -29,6 +29,8 @@
 mod filesystem;
 mod inode;
 mod types;
+mod union_fs;
 
 pub use filesystem::Fuse3PassthroughFS;
 pub use types::{Fuse3Error, Fuse3Result, MountHandle, SpawnedMountHandle};
+pub use union_fs::Fuse3UnionFS;

--- a/xearthlayer/src/fuse/fuse3/union_fs.rs
+++ b/xearthlayer/src/fuse/fuse3/union_fs.rs
@@ -1,0 +1,813 @@
+//! Union FUSE filesystem for patch tiles.
+//!
+//! This module provides a FUSE filesystem that presents multiple patch folders
+//! as a single unified view. It uses [`PatchUnionIndex`] to merge files from
+//! different patches with priority-based collision resolution.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ~/.xearthlayer/patches/
+//! ├── A_KDEN_Mesh/            ─┐
+//! │   ├── Earth nav data/      │
+//! │   └── terrain/             │   PatchUnionIndex
+//! └── B_KLAX_Mesh/            ─┼─────────────────────► Fuse3UnionFS
+//!     ├── Earth nav data/      │                              │
+//!     └── terrain/            ─┘                              ▼
+//!                                                    FUSE Mount Point
+//!                                              Custom Scenery/zzyXEL_patches_ortho/
+//! ```
+//!
+//! # DDS Texture Generation
+//!
+//! When X-Plane requests a DDS texture:
+//! 1. Check if the texture exists in a patch folder → passthrough read
+//! 2. If not, parse the filename for coordinates → generate via DdsHandler
+//!
+//! This ensures patches can include pre-built textures, but XEL generates
+//! missing textures dynamically using its configured imagery provider.
+
+use super::inode::InodeManager;
+use super::types::{Fuse3Error, Fuse3Result};
+use crate::coord::TileCoord;
+use crate::fuse::async_passthrough::{DdsHandler, DdsRequest};
+use crate::fuse::{get_default_placeholder, parse_dds_filename, validate_dds_or_placeholder};
+use crate::patches::PatchUnionIndex;
+use crate::pipeline::{JobId, StorageConcurrencyLimiter};
+use crate::prefetch::TileRequestCallback;
+use bytes::Bytes;
+use fuse3::raw::prelude::*;
+use fuse3::raw::reply::{
+    DirectoryEntry, DirectoryEntryPlus, FileAttr, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry,
+    ReplyInit, ReplyStatFs,
+};
+use fuse3::raw::Filesystem;
+use fuse3::{Errno, MountOptions, Result as Fuse3InternalResult};
+use futures::stream::{self, BoxStream, StreamExt};
+use std::ffi::{OsStr, OsString};
+use std::num::NonZeroU32;
+use std::os::unix::fs::MetadataExt;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::fs;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, trace, warn};
+
+/// Time-to-live for attribute caching.
+const TTL: Duration = Duration::from_secs(1);
+
+/// Configuration for virtual DDS file attributes.
+struct VirtualDdsConfig {
+    /// Expected size of generated DDS files
+    size: u64,
+    /// Block size for filesystem reporting
+    blksize: u32,
+}
+
+impl VirtualDdsConfig {
+    fn new(size: u64) -> Self {
+        Self {
+            size,
+            blksize: 4096,
+        }
+    }
+
+    fn blocks(&self) -> u64 {
+        self.size.div_ceil(self.blksize as u64)
+    }
+}
+
+/// Union FUSE filesystem for patch tiles.
+///
+/// This filesystem merges multiple patch folders into a single virtual view:
+/// - Files from patches are passed through from their real locations
+/// - DDS textures that don't exist are generated via the async pipeline
+/// - Priority is determined by alphabetical patch folder naming (A < B < Z)
+///
+/// Unlike `Fuse3PassthroughFS` which overlays a single directory, this
+/// filesystem uses a `PatchUnionIndex` to present a merged view of all patches.
+pub struct Fuse3UnionFS {
+    /// Union index mapping virtual paths to real file locations
+    index: Arc<PatchUnionIndex>,
+    /// Handler for DDS generation requests
+    dds_handler: DdsHandler,
+    /// Inode manager for path mappings
+    inode_manager: InodeManager,
+    /// Configuration for virtual DDS attributes
+    virtual_dds_config: VirtualDdsConfig,
+    /// Timeout for DDS generation
+    generation_timeout: Duration,
+    /// Limiter for concurrent disk I/O operations
+    disk_io_limiter: Arc<StorageConcurrencyLimiter>,
+    /// Optional callback for tile request tracking
+    tile_request_callback: Option<TileRequestCallback>,
+}
+
+impl Fuse3UnionFS {
+    /// Create a new union filesystem.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - Pre-built union index of all patches
+    /// * `dds_handler` - Handler for DDS generation requests
+    /// * `expected_dds_size` - Expected size of generated DDS files
+    pub fn new(index: PatchUnionIndex, dds_handler: DdsHandler, expected_dds_size: usize) -> Self {
+        let disk_io_limiter = Arc::new(StorageConcurrencyLimiter::with_defaults("union_disk_io"));
+        debug!(
+            max_concurrent = disk_io_limiter.max_concurrent(),
+            patches = index.patch_names().len(),
+            files = index.file_count(),
+            "Union FUSE filesystem initialized"
+        );
+
+        // Use a virtual root path for the inode manager
+        let virtual_root = PathBuf::from("/");
+
+        Self {
+            index: Arc::new(index),
+            dds_handler,
+            inode_manager: InodeManager::new(virtual_root),
+            virtual_dds_config: VirtualDdsConfig::new(expected_dds_size as u64),
+            generation_timeout: Duration::from_secs(30),
+            disk_io_limiter,
+            tile_request_callback: None,
+        }
+    }
+
+    /// Create with custom disk I/O limiter.
+    pub fn with_disk_io_limiter(
+        index: PatchUnionIndex,
+        dds_handler: DdsHandler,
+        expected_dds_size: usize,
+        disk_io_limiter: Arc<StorageConcurrencyLimiter>,
+    ) -> Self {
+        let virtual_root = PathBuf::from("/");
+
+        Self {
+            index: Arc::new(index),
+            dds_handler,
+            inode_manager: InodeManager::new(virtual_root),
+            virtual_dds_config: VirtualDdsConfig::new(expected_dds_size as u64),
+            generation_timeout: Duration::from_secs(30),
+            disk_io_limiter,
+            tile_request_callback: None,
+        }
+    }
+
+    /// Set the timeout for DDS generation.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.generation_timeout = timeout;
+        self
+    }
+
+    /// Set the callback for tile request tracking.
+    pub fn with_tile_request_callback(mut self, callback: TileRequestCallback) -> Self {
+        self.tile_request_callback = Some(callback);
+        self
+    }
+
+    /// Returns the disk I/O limiter for monitoring/metrics.
+    pub fn disk_io_limiter(&self) -> &Arc<StorageConcurrencyLimiter> {
+        &self.disk_io_limiter
+    }
+
+    /// Get the union index.
+    pub fn index(&self) -> &PatchUnionIndex {
+        &self.index
+    }
+
+    /// Mount the filesystem at the given path.
+    pub async fn mount(self, mountpoint: &str) -> Fuse3Result<super::types::MountHandle> {
+        let mut mount_options = MountOptions::default();
+        mount_options.read_only(true);
+        mount_options.force_readdir_plus(false);
+
+        let mount_path = PathBuf::from(mountpoint);
+
+        #[cfg(target_os = "linux")]
+        let handle = fuse3::raw::Session::new(mount_options)
+            .mount_with_unprivileged(self, mount_path)
+            .await
+            .map_err(|e| Fuse3Error::MountFailed(e.to_string()))?;
+
+        #[cfg(not(target_os = "linux"))]
+        let handle = fuse3::raw::Session::new(mount_options)
+            .mount(self, mount_path)
+            .await
+            .map_err(|e| Fuse3Error::MountFailed(e.to_string()))?;
+
+        Ok(super::types::MountHandle::new(handle))
+    }
+
+    /// Mount the filesystem as a spawned background task.
+    pub async fn mount_spawned(
+        self,
+        mountpoint: &str,
+    ) -> Fuse3Result<super::types::SpawnedMountHandle> {
+        let mut mount_options = MountOptions::default();
+        mount_options.read_only(true);
+        mount_options.force_readdir_plus(false);
+
+        let mount_path = PathBuf::from(mountpoint);
+        let mount_path_for_handle = mount_path.clone();
+
+        let (unmount_tx, unmount_rx) = oneshot::channel::<()>();
+
+        #[cfg(target_os = "linux")]
+        let handle = fuse3::raw::Session::new(mount_options)
+            .mount_with_unprivileged(self, mount_path)
+            .await
+            .map_err(|e| Fuse3Error::MountFailed(e.to_string()))?;
+
+        #[cfg(not(target_os = "linux"))]
+        let handle = fuse3::raw::Session::new(mount_options)
+            .mount(self, mount_path)
+            .await
+            .map_err(|e| Fuse3Error::MountFailed(e.to_string()))?;
+
+        let task = tokio::spawn(async move {
+            tokio::select! {
+                result = handle => result,
+                _ = unmount_rx => Ok(()),
+            }
+        });
+
+        Ok(super::types::SpawnedMountHandle::new(
+            task,
+            unmount_tx,
+            mount_path_for_handle,
+        ))
+    }
+
+    /// Request DDS generation from the async pipeline.
+    async fn request_dds(&self, name_str: &str) -> Option<Vec<u8>> {
+        let coords = parse_dds_filename(name_str).ok()?;
+        let job_id = JobId::new();
+
+        // Convert chunk coordinates to tile coordinates
+        let tile = Self::chunk_to_tile_coords(&coords);
+
+        // Notify tile request callback for FUSE inference
+        if let Some(ref callback) = self.tile_request_callback {
+            callback(tile);
+        }
+
+        debug!(
+            job_id = %job_id,
+            chunk_row = coords.row,
+            chunk_col = coords.col,
+            chunk_zoom = coords.zoom,
+            tile_row = tile.row,
+            tile_col = tile.col,
+            tile_zoom = tile.zoom,
+            "Requesting DDS generation (union fs)"
+        );
+
+        let (tx, rx) = oneshot::channel();
+        let cancellation_token = CancellationToken::new();
+
+        let request = DdsRequest {
+            job_id,
+            tile,
+            result_tx: tx,
+            cancellation_token: cancellation_token.clone(),
+            is_prefetch: false,
+        };
+
+        (self.dds_handler)(request);
+
+        let data = match tokio::time::timeout(self.generation_timeout, rx).await {
+            Ok(Ok(response)) => {
+                debug!(
+                    tile_row = tile.row,
+                    tile_col = tile.col,
+                    tile_zoom = tile.zoom,
+                    cache_hit = response.cache_hit,
+                    duration_ms = response.duration.as_millis(),
+                    "Patch DDS generated"
+                );
+                response.data
+            }
+            Ok(Err(_)) => {
+                error!(job_id = %job_id, "DDS generation channel closed unexpectedly");
+                cancellation_token.cancel();
+                get_default_placeholder()
+            }
+            Err(_) => {
+                warn!(
+                    job_id = %job_id,
+                    timeout_secs = self.generation_timeout.as_secs(),
+                    "DDS generation timed out - cancelling pipeline"
+                );
+                cancellation_token.cancel();
+                get_default_placeholder()
+            }
+        };
+
+        let context = format!("patch_tile({},{},{})", tile.row, tile.col, tile.zoom);
+        Some(validate_dds_or_placeholder(data, &context))
+    }
+
+    /// Convert chunk-level coordinates to tile-level coordinates.
+    fn chunk_to_tile_coords(coords: &crate::fuse::DdsFilename) -> TileCoord {
+        let tile_zoom = coords.zoom.saturating_sub(4);
+        TileCoord {
+            row: coords.row / 16,
+            col: coords.col / 16,
+            zoom: tile_zoom,
+        }
+    }
+
+    /// Convert std metadata to fuse3 FileAttr.
+    fn metadata_to_attr(&self, ino: u64, metadata: &std::fs::Metadata) -> FileAttr {
+        let kind = if metadata.is_dir() {
+            FileType::Directory
+        } else if metadata.is_symlink() {
+            FileType::Symlink
+        } else {
+            FileType::RegularFile
+        };
+
+        FileAttr {
+            ino,
+            size: metadata.len(),
+            blocks: metadata.blocks(),
+            atime: metadata.accessed().unwrap_or(UNIX_EPOCH).into(),
+            mtime: metadata.modified().unwrap_or(UNIX_EPOCH).into(),
+            ctime: UNIX_EPOCH.into(),
+            kind,
+            perm: (metadata.mode() & 0o7777) as u16,
+            nlink: metadata.nlink() as u32,
+            uid: metadata.uid(),
+            gid: metadata.gid(),
+            rdev: metadata.rdev() as u32,
+            blksize: 4096,
+        }
+    }
+
+    /// Create attributes for a virtual DDS file.
+    fn virtual_dds_attr(&self, ino: u64) -> FileAttr {
+        let now = SystemTime::now().into();
+
+        FileAttr {
+            ino,
+            size: self.virtual_dds_config.size,
+            blocks: self.virtual_dds_config.blocks(),
+            atime: now,
+            mtime: now,
+            ctime: now,
+            kind: FileType::RegularFile,
+            perm: 0o444,
+            nlink: 1,
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            rdev: 0,
+            blksize: self.virtual_dds_config.blksize,
+        }
+    }
+
+    /// Create attributes for the root directory.
+    fn root_dir_attr(&self) -> FileAttr {
+        let now = SystemTime::now().into();
+
+        FileAttr {
+            ino: 1,
+            size: 4096,
+            blocks: 1,
+            atime: now,
+            mtime: now,
+            ctime: now,
+            kind: FileType::Directory,
+            perm: 0o555,
+            nlink: 2,
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            rdev: 0,
+            blksize: 4096,
+        }
+    }
+
+    /// Create attributes for a virtual directory.
+    fn virtual_dir_attr(&self, ino: u64) -> FileAttr {
+        let now = SystemTime::now().into();
+
+        FileAttr {
+            ino,
+            size: 4096,
+            blocks: 1,
+            atime: now,
+            mtime: now,
+            ctime: now,
+            kind: FileType::Directory,
+            perm: 0o555,
+            nlink: 2,
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            rdev: 0,
+            blksize: 4096,
+        }
+    }
+}
+
+impl Filesystem for Fuse3UnionFS {
+    type DirEntryStream<'a>
+        = BoxStream<'a, Fuse3InternalResult<DirectoryEntry>>
+    where
+        Self: 'a;
+    type DirEntryPlusStream<'a>
+        = BoxStream<'a, Fuse3InternalResult<DirectoryEntryPlus>>
+    where
+        Self: 'a;
+
+    async fn init(&self, _req: Request) -> Fuse3InternalResult<ReplyInit> {
+        debug!(
+            patches = self.index.patch_names().len(),
+            "fuse3 union: init"
+        );
+        Ok(ReplyInit {
+            max_write: NonZeroU32::new(1024 * 1024).unwrap(),
+        })
+    }
+
+    async fn destroy(&self, _req: Request) {
+        debug!("fuse3 union: destroy");
+    }
+
+    async fn lookup(
+        &self,
+        _req: Request,
+        parent: u64,
+        name: &OsStr,
+    ) -> Fuse3InternalResult<ReplyEntry> {
+        trace!(parent = parent, name = ?name, "fuse3 union: lookup");
+
+        // Get parent path (virtual path)
+        let parent_path = if parent == 1 {
+            PathBuf::new() // Root
+        } else {
+            self.inode_manager
+                .get_path(parent)
+                .ok_or(Errno::from(libc::ENOENT))?
+        };
+
+        let child_path = parent_path.join(name);
+        let name_str = name.to_string_lossy();
+
+        // Check if this path exists in the union index
+        if let Some(source) = self.index.resolve(&child_path) {
+            // Real file from a patch
+            if let Ok(metadata) = fs::metadata(&source.real_path).await {
+                let inode = self.inode_manager.get_or_create_inode(&child_path);
+                let attr = self.metadata_to_attr(inode, &metadata);
+                return Ok(ReplyEntry {
+                    ttl: TTL,
+                    attr,
+                    generation: 0,
+                });
+            }
+        }
+
+        // Check if it's a virtual directory in the union
+        if self.index.is_directory(&child_path) {
+            let inode = self.inode_manager.get_or_create_inode(&child_path);
+            let attr = self.virtual_dir_attr(inode);
+            return Ok(ReplyEntry {
+                ttl: TTL,
+                attr,
+                generation: 0,
+            });
+        }
+
+        // Check if it's a DDS file we can generate
+        if name_str.ends_with(".dds") {
+            if let Ok(coords) = parse_dds_filename(&name_str) {
+                let inode = self.inode_manager.create_virtual_inode(coords);
+                let attr = self.virtual_dds_attr(inode);
+                return Ok(ReplyEntry {
+                    ttl: TTL,
+                    attr,
+                    generation: 0,
+                });
+            }
+        }
+
+        Err(Errno::from(libc::ENOENT))
+    }
+
+    async fn getattr(
+        &self,
+        _req: Request,
+        ino: u64,
+        _fh: Option<u64>,
+        _flags: u32,
+    ) -> Fuse3InternalResult<ReplyAttr> {
+        trace!(ino = ino, "fuse3 union: getattr");
+
+        // Root inode
+        if ino == 1 {
+            return Ok(ReplyAttr {
+                ttl: TTL,
+                attr: self.root_dir_attr(),
+            });
+        }
+
+        // Virtual DDS inode
+        if InodeManager::is_virtual_inode(ino) {
+            if self.inode_manager.get_virtual_dds(ino).is_some() {
+                let attr = self.virtual_dds_attr(ino);
+                return Ok(ReplyAttr { ttl: TTL, attr });
+            }
+            return Err(Errno::from(libc::ENOENT));
+        }
+
+        // Real file or virtual directory
+        let virtual_path = self
+            .inode_manager
+            .get_path(ino)
+            .ok_or(Errno::from(libc::ENOENT))?;
+
+        // Check if it's a directory in the union
+        if self.index.is_directory(&virtual_path) {
+            let attr = self.virtual_dir_attr(ino);
+            return Ok(ReplyAttr { ttl: TTL, attr });
+        }
+
+        // Must be a real file
+        if let Some(source) = self.index.resolve(&virtual_path) {
+            let metadata = fs::metadata(&source.real_path)
+                .await
+                .map_err(|_| Errno::from(libc::ENOENT))?;
+            let attr = self.metadata_to_attr(ino, &metadata);
+            return Ok(ReplyAttr { ttl: TTL, attr });
+        }
+
+        Err(Errno::from(libc::ENOENT))
+    }
+
+    async fn read(
+        &self,
+        _req: Request,
+        ino: u64,
+        _fh: u64,
+        offset: u64,
+        size: u32,
+    ) -> Fuse3InternalResult<ReplyData> {
+        trace!(ino = ino, offset = offset, size = size, "fuse3 union: read");
+
+        // Virtual DDS file - generate on demand
+        if InodeManager::is_virtual_inode(ino) {
+            let coords = self
+                .inode_manager
+                .get_virtual_dds(ino)
+                .ok_or(Errno::from(libc::ENOENT))?;
+
+            // Build filename for request_dds
+            let filename = format!("{}_{}_{}18.dds", coords.row, coords.col, coords.map_type);
+
+            let data = self
+                .request_dds(&filename)
+                .await
+                .unwrap_or_else(get_default_placeholder);
+
+            let offset = offset as usize;
+            let size = size as usize;
+
+            if offset >= data.len() {
+                return Ok(ReplyData { data: Bytes::new() });
+            }
+
+            let end = std::cmp::min(offset + size, data.len());
+            return Ok(ReplyData {
+                data: Bytes::copy_from_slice(&data[offset..end]),
+            });
+        }
+
+        // Real file from union index
+        let virtual_path = self
+            .inode_manager
+            .get_path(ino)
+            .ok_or(Errno::from(libc::ENOENT))?;
+
+        let source = self
+            .index
+            .resolve(&virtual_path)
+            .ok_or(Errno::from(libc::ENOENT))?;
+
+        // Acquire disk I/O permit
+        let _permit = self.disk_io_limiter.acquire().await;
+        let data = fs::read(&source.real_path)
+            .await
+            .map_err(|_| Errno::from(libc::EIO))?;
+
+        let offset = offset as usize;
+        let size = size as usize;
+
+        if offset >= data.len() {
+            return Ok(ReplyData { data: Bytes::new() });
+        }
+
+        let end = std::cmp::min(offset + size, data.len());
+        Ok(ReplyData {
+            data: Bytes::copy_from_slice(&data[offset..end]),
+        })
+    }
+
+    async fn readdir(
+        &self,
+        _req: Request,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+    ) -> Fuse3InternalResult<ReplyDirectory<Self::DirEntryStream<'_>>> {
+        trace!(ino = ino, offset = offset, "fuse3 union: readdir");
+
+        // Get virtual path for this directory
+        let virtual_path = if ino == 1 {
+            PathBuf::new()
+        } else {
+            self.inode_manager
+                .get_path(ino)
+                .ok_or(Errno::from(libc::ENOENT))?
+        };
+
+        // Verify it's a directory
+        if ino != 1 && !self.index.is_directory(&virtual_path) {
+            return Err(Errno::from(libc::ENOTDIR));
+        }
+
+        let mut entries: Vec<DirectoryEntry> = Vec::new();
+
+        // Add . and ..
+        entries.push(DirectoryEntry {
+            inode: ino,
+            kind: FileType::Directory,
+            name: OsString::from("."),
+            offset: 1,
+        });
+
+        // Parent inode
+        let parent_inode = if ino == 1 {
+            1 // Root's parent is itself
+        } else if let Some(parent) = virtual_path.parent() {
+            if parent.as_os_str().is_empty() {
+                1 // Parent is root
+            } else {
+                self.inode_manager.get_inode(parent).unwrap_or(1)
+            }
+        } else {
+            1
+        };
+
+        entries.push(DirectoryEntry {
+            inode: parent_inode,
+            kind: FileType::Directory,
+            name: OsString::from(".."),
+            offset: 2,
+        });
+
+        // Get entries from union index
+        let mut entry_offset = 3i64;
+        for dir_entry in self.index.list_directory(&virtual_path) {
+            let child_path = virtual_path.join(&dir_entry.name);
+            let entry_inode = self.inode_manager.get_or_create_inode(&child_path);
+
+            let kind = if dir_entry.is_dir {
+                FileType::Directory
+            } else {
+                FileType::RegularFile
+            };
+
+            entries.push(DirectoryEntry {
+                inode: entry_inode,
+                kind,
+                name: dir_entry.name.clone(),
+                offset: entry_offset,
+            });
+            entry_offset += 1;
+        }
+
+        // Skip entries based on offset
+        let entries: Vec<_> = entries.into_iter().skip(offset as usize).map(Ok).collect();
+
+        Ok(ReplyDirectory {
+            entries: stream::iter(entries).boxed(),
+        })
+    }
+
+    async fn access(&self, _req: Request, _ino: u64, _mask: u32) -> Fuse3InternalResult<()> {
+        Ok(())
+    }
+
+    async fn flush(
+        &self,
+        _req: Request,
+        _ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+    ) -> Fuse3InternalResult<()> {
+        Ok(())
+    }
+
+    async fn fsync(
+        &self,
+        _req: Request,
+        _ino: u64,
+        _fh: u64,
+        _datasync: bool,
+    ) -> Fuse3InternalResult<()> {
+        Ok(())
+    }
+
+    async fn statfs(&self, _req: Request, _ino: u64) -> Fuse3InternalResult<ReplyStatFs> {
+        Ok(ReplyStatFs {
+            blocks: 1000000,
+            bfree: 0,
+            bavail: 0,
+            files: self.index.file_count() as u64,
+            ffree: 0,
+            bsize: 4096,
+            namelen: 255,
+            frsize: 4096,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fuse::async_passthrough::DdsResponse;
+    use crate::patches::PatchInfo;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn create_test_handler() -> DdsHandler {
+        Arc::new(|req: DdsRequest| {
+            let response = DdsResponse {
+                data: vec![0xDD, 0x53, 0x20, 0x00],
+                cache_hit: false,
+                duration: Duration::from_millis(100),
+            };
+            let _ = req.result_tx.send(response);
+        })
+    }
+
+    fn create_test_patch(temp: &TempDir, name: &str) -> PatchInfo {
+        let patch_dir = temp.path().join(name);
+        std::fs::create_dir_all(patch_dir.join("Earth nav data/+30-120")).unwrap();
+        std::fs::write(
+            patch_dir.join("Earth nav data/+30-120/+33-119.dsf"),
+            b"fake dsf",
+        )
+        .unwrap();
+        std::fs::create_dir_all(patch_dir.join("terrain")).unwrap();
+        std::fs::write(patch_dir.join("terrain/test.ter"), b"fake terrain").unwrap();
+
+        PatchInfo {
+            name: name.to_string(),
+            path: patch_dir,
+            dsf_count: 1,
+            terrain_count: 1,
+            texture_count: 0,
+            is_valid: true,
+            validation_errors: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_union_fs_creation() {
+        let temp = TempDir::new().unwrap();
+        let patch = create_test_patch(&temp, "TestPatch");
+        let index = PatchUnionIndex::build(&[patch]).unwrap();
+
+        let handler = create_test_handler();
+        let fs = Fuse3UnionFS::new(index, handler, 1024);
+
+        assert_eq!(fs.index().patch_names(), &["TestPatch"]);
+    }
+
+    #[test]
+    fn test_virtual_dds_config() {
+        let config = VirtualDdsConfig::new(11_174_016);
+        assert_eq!(config.size, 11_174_016);
+        assert_eq!(config.blksize, 4096);
+        assert_eq!(config.blocks(), 2729);
+    }
+
+    #[test]
+    fn test_chunk_to_tile_coords() {
+        let coords = crate::fuse::DdsFilename {
+            row: 160000,
+            col: 84000,
+            zoom: 20,
+            map_type: "BI".to_string(),
+        };
+
+        let tile = Fuse3UnionFS::chunk_to_tile_coords(&coords);
+
+        assert_eq!(tile.row, 10000);
+        assert_eq!(tile.col, 5250);
+        assert_eq!(tile.zoom, 16);
+    }
+}

--- a/xearthlayer/src/lib.rs
+++ b/xearthlayer/src/lib.rs
@@ -29,6 +29,7 @@ pub mod manager;
 pub mod orchestrator;
 pub mod package;
 pub mod panic;
+pub mod patches;
 pub mod pipeline;
 pub mod prefetch;
 pub mod provider;

--- a/xearthlayer/src/manager/mod.rs
+++ b/xearthlayer/src/manager/mod.rs
@@ -59,7 +59,7 @@ pub use error::{ManagerError, ManagerResult};
 pub use extractor::{check_required_tools, ShellExtractor};
 pub use installer::{InstallProgressCallback, InstallResult, InstallStage, PackageInstaller};
 pub use local::{InstalledPackage, LocalPackageStore, MountStatus};
-pub use mounts::{ActiveMount, MountManager, MountResult, ServiceBuilder};
+pub use mounts::{ActiveMount, MountManager, MountResult, PatchesMountResult, ServiceBuilder};
 pub use symlinks::{
     create_overlay_symlink, overlay_symlink_exists, overlay_symlink_path, remove_overlay_symlink,
 };

--- a/xearthlayer/src/patches/discovery.rs
+++ b/xearthlayer/src/patches/discovery.rs
@@ -1,0 +1,448 @@
+//! Patch folder discovery and validation.
+//!
+//! This module provides functionality to discover and validate patch tiles
+//! in the configured patches directory.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Errors that can occur during patch validation.
+#[derive(Debug, Error, Clone)]
+pub enum ValidationError {
+    /// The patch folder is missing the Earth nav data directory.
+    #[error("Missing 'Earth nav data' directory")]
+    MissingEarthNavData,
+
+    /// The patch folder has no DSF files.
+    #[error("No DSF files found in 'Earth nav data'")]
+    NoDsfFiles,
+
+    /// The patch folder path doesn't exist.
+    #[error("Patch folder does not exist: {0}")]
+    FolderNotFound(PathBuf),
+
+    /// I/O error during validation.
+    #[error("I/O error: {0}")]
+    IoError(String),
+}
+
+/// Information about a discovered patch.
+#[derive(Debug, Clone)]
+pub struct PatchInfo {
+    /// Name of the patch (folder name).
+    pub name: String,
+
+    /// Full path to the patch folder.
+    pub path: PathBuf,
+
+    /// Number of DSF files found.
+    pub dsf_count: usize,
+
+    /// Number of terrain (.ter) files found.
+    pub terrain_count: usize,
+
+    /// Number of texture (.dds) files found.
+    pub texture_count: usize,
+
+    /// Whether this patch passed validation.
+    pub is_valid: bool,
+
+    /// Validation errors, if any.
+    pub validation_errors: Vec<ValidationError>,
+}
+
+impl PatchInfo {
+    /// Create a new PatchInfo for a valid patch.
+    pub fn new(name: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            name: name.into(),
+            path: path.into(),
+            dsf_count: 0,
+            terrain_count: 0,
+            texture_count: 0,
+            is_valid: true,
+            validation_errors: Vec::new(),
+        }
+    }
+
+    /// Add a validation error and mark as invalid.
+    pub fn add_error(&mut self, error: ValidationError) {
+        self.is_valid = false;
+        self.validation_errors.push(error);
+    }
+}
+
+/// Result of validating a patch folder.
+#[derive(Debug, Clone)]
+pub struct PatchValidation {
+    /// Whether the patch is valid (has required structure).
+    pub is_valid: bool,
+
+    /// Validation errors encountered.
+    pub errors: Vec<ValidationError>,
+
+    /// Number of DSF files found.
+    pub dsf_count: usize,
+
+    /// Number of terrain files found.
+    pub terrain_count: usize,
+
+    /// Number of texture files found.
+    pub texture_count: usize,
+}
+
+impl PatchValidation {
+    /// Create a validation result indicating success.
+    pub fn valid(dsf_count: usize, terrain_count: usize, texture_count: usize) -> Self {
+        Self {
+            is_valid: true,
+            errors: Vec::new(),
+            dsf_count,
+            terrain_count,
+            texture_count,
+        }
+    }
+
+    /// Create a validation result indicating failure.
+    pub fn invalid(errors: Vec<ValidationError>) -> Self {
+        Self {
+            is_valid: false,
+            errors,
+            dsf_count: 0,
+            terrain_count: 0,
+            texture_count: 0,
+        }
+    }
+}
+
+/// Discovers and validates patch tiles in a directory.
+#[derive(Debug, Clone)]
+pub struct PatchDiscovery {
+    /// Root patches directory.
+    patches_dir: PathBuf,
+}
+
+impl PatchDiscovery {
+    /// Create a new patch discovery for the given directory.
+    pub fn new(patches_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            patches_dir: patches_dir.into(),
+        }
+    }
+
+    /// Get the patches directory.
+    pub fn patches_dir(&self) -> &Path {
+        &self.patches_dir
+    }
+
+    /// Check if the patches directory exists.
+    pub fn exists(&self) -> bool {
+        self.patches_dir.exists() && self.patches_dir.is_dir()
+    }
+
+    /// Find all patch folders in the patches directory.
+    ///
+    /// Returns patches sorted alphabetically by folder name (priority order).
+    /// Invalid patches are included but marked as invalid.
+    pub fn find_patches(&self) -> Result<Vec<PatchInfo>, std::io::Error> {
+        if !self.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut patches = Vec::new();
+
+        for entry in std::fs::read_dir(&self.patches_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            // Skip non-directories
+            if !path.is_dir() {
+                continue;
+            }
+
+            let name = entry.file_name().to_string_lossy().to_string();
+
+            // Skip hidden folders
+            if name.starts_with('.') {
+                continue;
+            }
+
+            let validation = self.validate_patch(&path);
+            let mut info = PatchInfo::new(&name, &path);
+            info.dsf_count = validation.dsf_count;
+            info.terrain_count = validation.terrain_count;
+            info.texture_count = validation.texture_count;
+            info.is_valid = validation.is_valid;
+            info.validation_errors = validation.errors;
+
+            patches.push(info);
+        }
+
+        // Sort alphabetically by name (determines priority)
+        patches.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(patches)
+    }
+
+    /// Find only valid patches (ready for mounting).
+    pub fn find_valid_patches(&self) -> Result<Vec<PatchInfo>, std::io::Error> {
+        Ok(self
+            .find_patches()?
+            .into_iter()
+            .filter(|p| p.is_valid)
+            .collect())
+    }
+
+    /// Validate a single patch folder.
+    pub fn validate_patch(&self, patch_path: &Path) -> PatchValidation {
+        let mut errors = Vec::new();
+
+        // Check folder exists
+        if !patch_path.exists() {
+            return PatchValidation::invalid(vec![ValidationError::FolderNotFound(
+                patch_path.to_path_buf(),
+            )]);
+        }
+
+        // Check for Earth nav data directory
+        let earth_nav_data = patch_path.join("Earth nav data");
+        if !earth_nav_data.exists() {
+            errors.push(ValidationError::MissingEarthNavData);
+        }
+
+        // Count DSF files
+        let dsf_count = if earth_nav_data.exists() {
+            count_files_recursive(&earth_nav_data, "dsf")
+        } else {
+            0
+        };
+
+        if dsf_count == 0 && earth_nav_data.exists() {
+            errors.push(ValidationError::NoDsfFiles);
+        }
+
+        // Count terrain files (optional but useful info)
+        let terrain_dir = patch_path.join("terrain");
+        let terrain_count = if terrain_dir.exists() {
+            count_files_recursive(&terrain_dir, "ter")
+        } else {
+            0
+        };
+
+        // Count texture files (optional - XEL generates these)
+        let textures_dir = patch_path.join("textures");
+        let texture_count = if textures_dir.exists() {
+            count_files_recursive(&textures_dir, "dds")
+        } else {
+            0
+        };
+
+        if errors.is_empty() {
+            PatchValidation::valid(dsf_count, terrain_count, texture_count)
+        } else {
+            let mut validation = PatchValidation::invalid(errors);
+            validation.dsf_count = dsf_count;
+            validation.terrain_count = terrain_count;
+            validation.texture_count = texture_count;
+            validation
+        }
+    }
+
+    /// Check if a specific patch name exists and is valid.
+    pub fn has_valid_patch(&self, name: &str) -> bool {
+        let patch_path = self.patches_dir.join(name);
+        let validation = self.validate_patch(&patch_path);
+        validation.is_valid
+    }
+}
+
+/// Count files with a given extension recursively.
+fn count_files_recursive(dir: &Path, extension: &str) -> usize {
+    let mut count = 0;
+
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                count += count_files_recursive(&path, extension);
+            } else if path
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case(extension))
+            {
+                count += 1;
+            }
+        }
+    }
+
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_patch(
+        temp: &TempDir,
+        name: &str,
+        with_dsf: bool,
+        with_terrain: bool,
+    ) -> PathBuf {
+        let patch_dir = temp.path().join(name);
+        std::fs::create_dir_all(&patch_dir).unwrap();
+
+        // Create Earth nav data structure
+        let earth_nav = patch_dir.join("Earth nav data").join("+30-120");
+        std::fs::create_dir_all(&earth_nav).unwrap();
+
+        if with_dsf {
+            std::fs::write(earth_nav.join("+33-119.dsf"), b"fake dsf").unwrap();
+        }
+
+        if with_terrain {
+            let terrain = patch_dir.join("terrain");
+            std::fs::create_dir_all(&terrain).unwrap();
+            std::fs::write(terrain.join("12345_67890_BI18.ter"), b"fake terrain").unwrap();
+        }
+
+        patch_dir
+    }
+
+    #[test]
+    fn test_discovery_empty_dir() {
+        let temp = TempDir::new().unwrap();
+        let discovery = PatchDiscovery::new(temp.path());
+
+        let patches = discovery.find_patches().unwrap();
+        assert!(patches.is_empty());
+    }
+
+    #[test]
+    fn test_discovery_nonexistent_dir() {
+        let discovery = PatchDiscovery::new("/nonexistent/path");
+        assert!(!discovery.exists());
+
+        let patches = discovery.find_patches().unwrap();
+        assert!(patches.is_empty());
+    }
+
+    #[test]
+    fn test_discovery_finds_valid_patch() {
+        let temp = TempDir::new().unwrap();
+        create_test_patch(&temp, "A_KLAX_Mesh", true, true);
+
+        let discovery = PatchDiscovery::new(temp.path());
+        let patches = discovery.find_patches().unwrap();
+
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].name, "A_KLAX_Mesh");
+        assert!(patches[0].is_valid);
+        assert_eq!(patches[0].dsf_count, 1);
+        assert_eq!(patches[0].terrain_count, 1);
+    }
+
+    #[test]
+    fn test_discovery_invalid_patch_no_dsf() {
+        let temp = TempDir::new().unwrap();
+        create_test_patch(&temp, "A_Empty", false, true);
+
+        let discovery = PatchDiscovery::new(temp.path());
+        let patches = discovery.find_patches().unwrap();
+
+        assert_eq!(patches.len(), 1);
+        assert!(!patches[0].is_valid);
+        assert!(patches[0]
+            .validation_errors
+            .iter()
+            .any(|e| matches!(e, ValidationError::NoDsfFiles)));
+    }
+
+    #[test]
+    fn test_discovery_invalid_patch_no_earth_nav_data() {
+        let temp = TempDir::new().unwrap();
+        let patch_dir = temp.path().join("BadPatch");
+        std::fs::create_dir_all(&patch_dir).unwrap();
+        // Create just terrain, no Earth nav data
+        std::fs::create_dir_all(patch_dir.join("terrain")).unwrap();
+
+        let discovery = PatchDiscovery::new(temp.path());
+        let patches = discovery.find_patches().unwrap();
+
+        assert_eq!(patches.len(), 1);
+        assert!(!patches[0].is_valid);
+        assert!(patches[0]
+            .validation_errors
+            .iter()
+            .any(|e| matches!(e, ValidationError::MissingEarthNavData)));
+    }
+
+    #[test]
+    fn test_discovery_alphabetical_sorting() {
+        let temp = TempDir::new().unwrap();
+        create_test_patch(&temp, "C_Third", true, true);
+        create_test_patch(&temp, "A_First", true, true);
+        create_test_patch(&temp, "B_Second", true, true);
+
+        let discovery = PatchDiscovery::new(temp.path());
+        let patches = discovery.find_patches().unwrap();
+
+        assert_eq!(patches.len(), 3);
+        assert_eq!(patches[0].name, "A_First");
+        assert_eq!(patches[1].name, "B_Second");
+        assert_eq!(patches[2].name, "C_Third");
+    }
+
+    #[test]
+    fn test_discovery_skips_hidden_folders() {
+        let temp = TempDir::new().unwrap();
+        create_test_patch(&temp, "A_Visible", true, true);
+
+        // Create hidden folder
+        let hidden = temp.path().join(".hidden");
+        std::fs::create_dir_all(hidden.join("Earth nav data")).unwrap();
+
+        let discovery = PatchDiscovery::new(temp.path());
+        let patches = discovery.find_patches().unwrap();
+
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].name, "A_Visible");
+    }
+
+    #[test]
+    fn test_find_valid_patches_only() {
+        let temp = TempDir::new().unwrap();
+        create_test_patch(&temp, "A_Valid", true, true);
+        create_test_patch(&temp, "B_Invalid", false, true);
+
+        let discovery = PatchDiscovery::new(temp.path());
+        let valid_patches = discovery.find_valid_patches().unwrap();
+
+        assert_eq!(valid_patches.len(), 1);
+        assert_eq!(valid_patches[0].name, "A_Valid");
+    }
+
+    #[test]
+    fn test_has_valid_patch() {
+        let temp = TempDir::new().unwrap();
+        create_test_patch(&temp, "KLAX_Mesh", true, true);
+
+        let discovery = PatchDiscovery::new(temp.path());
+        assert!(discovery.has_valid_patch("KLAX_Mesh"));
+        assert!(!discovery.has_valid_patch("Nonexistent"));
+    }
+
+    #[test]
+    fn test_validate_patch_directly() {
+        let temp = TempDir::new().unwrap();
+        let patch_path = create_test_patch(&temp, "TestPatch", true, true);
+
+        let discovery = PatchDiscovery::new(temp.path());
+        let validation = discovery.validate_patch(&patch_path);
+
+        assert!(validation.is_valid);
+        assert_eq!(validation.dsf_count, 1);
+        assert_eq!(validation.terrain_count, 1);
+        assert_eq!(validation.texture_count, 0);
+    }
+}

--- a/xearthlayer/src/patches/mod.rs
+++ b/xearthlayer/src/patches/mod.rs
@@ -1,0 +1,52 @@
+//! Tile patches module for custom Ortho4XP mesh/elevation support.
+//!
+//! This module provides functionality for managing patch tiles - pre-built
+//! Ortho4XP tiles with custom mesh/elevation data from airport addon developers.
+//!
+//! # Overview
+//!
+//! Patches enable users to use custom elevation/mesh data (from airport addons)
+//! while XEL generates textures dynamically using its configured imagery provider.
+//! This ensures visual consistency across tile boundaries.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ~/.xearthlayer/patches/
+//! ├── A_KDEN_Mesh/           # Patch folder (alphabetically-first = highest priority)
+//! │   ├── Earth nav data/    # Contains DSF files with custom mesh
+//! │   ├── terrain/           # Terrain definition files (.ter)
+//! │   └── textures/          # Optional - XEL generates these on-demand
+//! └── B_KLAX_Mesh/           # Second priority patch folder
+//!     └── ...
+//! ```
+//!
+//! The [`PatchUnionIndex`] merges all patch folders into a single virtual
+//! file structure for FUSE mounting. Collision resolution uses alphabetical
+//! folder naming (A < B < Z).
+//!
+//! # Example
+//!
+//! ```ignore
+//! use xearthlayer::patches::{PatchDiscovery, PatchUnionIndex};
+//! use std::path::Path;
+//!
+//! // Discover patches in the default directory
+//! let patches_dir = Path::new("~/.xearthlayer/patches");
+//! let discovery = PatchDiscovery::new(patches_dir);
+//! let patches = discovery.find_patches()?;
+//!
+//! // Build the union index for FUSE mounting
+//! let index = PatchUnionIndex::build(&patches)?;
+//!
+//! // Resolve a virtual path to its real source
+//! if let Some(real_path) = index.resolve(Path::new("Earth nav data/+30-120/+33-119.dsf")) {
+//!     println!("Real path: {:?}", real_path);
+//! }
+//! ```
+
+mod discovery;
+mod union_index;
+
+pub use discovery::{PatchDiscovery, PatchInfo, PatchValidation, ValidationError};
+pub use union_index::{DirEntry, PatchUnionIndex};

--- a/xearthlayer/src/patches/union_index.rs
+++ b/xearthlayer/src/patches/union_index.rs
@@ -1,0 +1,471 @@
+//! Union index for merging multiple patch folders into a single virtual filesystem.
+//!
+//! This module provides the [`PatchUnionIndex`] which maintains a merged view
+//! of all patch folders, similar to an overlay filesystem.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use super::discovery::PatchInfo;
+
+/// A directory entry in the union filesystem.
+#[derive(Debug, Clone)]
+pub struct DirEntry {
+    /// File or directory name.
+    pub name: OsString,
+
+    /// Whether this is a directory.
+    pub is_dir: bool,
+
+    /// File size (0 for directories).
+    pub size: u64,
+
+    /// Modification time.
+    pub mtime: SystemTime,
+}
+
+impl DirEntry {
+    /// Create a new directory entry.
+    pub fn new(name: impl Into<OsString>, is_dir: bool, size: u64, mtime: SystemTime) -> Self {
+        Self {
+            name: name.into(),
+            is_dir,
+            size,
+            mtime,
+        }
+    }
+
+    /// Create a directory entry from filesystem metadata.
+    pub fn from_path(path: &Path) -> std::io::Result<Self> {
+        let metadata = path.metadata()?;
+        let name = path
+            .file_name()
+            .map(|n| n.to_os_string())
+            .unwrap_or_default();
+
+        Ok(Self {
+            name,
+            is_dir: metadata.is_dir(),
+            size: metadata.len(),
+            mtime: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+        })
+    }
+}
+
+/// Source information for a file in the union index.
+#[derive(Debug, Clone)]
+pub struct FileSource {
+    /// Name of the source patch.
+    pub patch_name: String,
+
+    /// Real filesystem path to the file.
+    pub real_path: PathBuf,
+}
+
+impl FileSource {
+    /// Create a new file source.
+    pub fn new(patch_name: impl Into<String>, real_path: impl Into<PathBuf>) -> Self {
+        Self {
+            patch_name: patch_name.into(),
+            real_path: real_path.into(),
+        }
+    }
+}
+
+/// Merged index of all files across multiple patch folders.
+///
+/// The union index provides a single virtual filesystem view where files
+/// from multiple patches are merged together. When multiple patches contain
+/// the same file path, the first patch (alphabetically by name) wins.
+///
+/// # Example
+///
+/// ```ignore
+/// use xearthlayer::patches::{PatchUnionIndex, PatchDiscovery};
+///
+/// let discovery = PatchDiscovery::new("~/.xearthlayer/patches");
+/// let patches = discovery.find_valid_patches()?;
+/// let index = PatchUnionIndex::build(&patches)?;
+///
+/// // Resolve a virtual path to its real source
+/// if let Some(source) = index.resolve(Path::new("Earth nav data/+30-120/+33-119.dsf")) {
+///     println!("Found in patch '{}': {:?}", source.patch_name, source.real_path);
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct PatchUnionIndex {
+    /// Map from virtual path to file source.
+    /// Keys are relative paths (e.g., "Earth nav data/+30-120/+33-119.dsf").
+    files: HashMap<PathBuf, FileSource>,
+
+    /// Virtual directory structure for readdir operations.
+    /// Keys are directory paths, values are entries in that directory.
+    directories: HashMap<PathBuf, Vec<DirEntry>>,
+
+    /// Names of patches included in this index, in priority order.
+    patch_names: Vec<String>,
+
+    /// Total file count across all patches.
+    total_files: usize,
+}
+
+impl PatchUnionIndex {
+    /// Create an empty union index.
+    pub fn new() -> Self {
+        Self {
+            files: HashMap::new(),
+            directories: HashMap::new(),
+            patch_names: Vec::new(),
+            total_files: 0,
+        }
+    }
+
+    /// Build a union index from a list of patches.
+    ///
+    /// Patches should already be sorted by priority (alphabetically).
+    /// The first patch wins on collision.
+    pub fn build(patches: &[PatchInfo]) -> std::io::Result<Self> {
+        let mut index = Self::new();
+
+        for patch in patches {
+            if patch.is_valid {
+                index.add_patch(&patch.name, &patch.path)?;
+            }
+        }
+
+        Ok(index)
+    }
+
+    /// Add a patch to the index.
+    ///
+    /// Files from this patch are added to the index, but only if the path
+    /// doesn't already exist (first patch wins).
+    pub fn add_patch(&mut self, name: &str, patch_path: &Path) -> std::io::Result<()> {
+        self.patch_names.push(name.to_string());
+        self.add_directory_recursive(name, patch_path, &PathBuf::new())?;
+        Ok(())
+    }
+
+    /// Recursively add a directory and its contents to the index.
+    fn add_directory_recursive(
+        &mut self,
+        patch_name: &str,
+        real_dir: &Path,
+        virtual_dir: &Path,
+    ) -> std::io::Result<()> {
+        // Ensure the virtual directory has an entry list
+        if !self.directories.contains_key(virtual_dir) {
+            self.directories
+                .insert(virtual_dir.to_path_buf(), Vec::new());
+        }
+
+        for entry in std::fs::read_dir(real_dir)? {
+            let entry = entry?;
+            let real_path = entry.path();
+            let file_name = entry.file_name();
+            let virtual_path = virtual_dir.join(&file_name);
+            let is_dir = real_path.is_dir();
+
+            // Only add to files index if not already present (first patch wins)
+            let already_exists = self.files.contains_key(&virtual_path);
+            if !already_exists {
+                // Add to files index
+                self.files.insert(
+                    virtual_path.clone(),
+                    FileSource::new(patch_name, &real_path),
+                );
+                self.total_files += 1;
+
+                // Add to parent directory listing
+                if let Some(entries) = self.directories.get_mut(virtual_dir) {
+                    // Check if this entry name already exists in the directory listing
+                    if !entries.iter().any(|e| e.name == file_name) {
+                        if let Ok(dir_entry) = DirEntry::from_path(&real_path) {
+                            entries.push(dir_entry);
+                        }
+                    }
+                }
+            }
+
+            // Always recurse into directories to merge contents from different patches
+            // (even if the directory entry already exists, we need to add unique files)
+            if is_dir {
+                self.add_directory_recursive(patch_name, &real_path, &virtual_path)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Resolve a virtual path to its real file source.
+    ///
+    /// Returns `None` if the path doesn't exist in the index.
+    pub fn resolve(&self, virtual_path: &Path) -> Option<&FileSource> {
+        self.files.get(virtual_path)
+    }
+
+    /// Get the real filesystem path for a virtual path.
+    ///
+    /// This is a convenience method that returns just the path.
+    pub fn resolve_path(&self, virtual_path: &Path) -> Option<&PathBuf> {
+        self.resolve(virtual_path).map(|s| &s.real_path)
+    }
+
+    /// Check if a virtual path exists in the index.
+    pub fn contains(&self, virtual_path: &Path) -> bool {
+        self.files.contains_key(virtual_path)
+    }
+
+    /// Check if a virtual path is a directory.
+    pub fn is_directory(&self, virtual_path: &Path) -> bool {
+        self.directories.contains_key(virtual_path)
+    }
+
+    /// List entries in a virtual directory.
+    ///
+    /// Returns an empty vec for non-existent directories.
+    pub fn list_directory(&self, virtual_path: &Path) -> Vec<&DirEntry> {
+        self.directories
+            .get(virtual_path)
+            .map(|v| v.iter().collect())
+            .unwrap_or_default()
+    }
+
+    /// Get the total number of files in the index.
+    pub fn file_count(&self) -> usize {
+        self.total_files
+    }
+
+    /// Get the total number of directories in the index.
+    pub fn directory_count(&self) -> usize {
+        self.directories.len()
+    }
+
+    /// Get the names of patches included in this index, in priority order.
+    pub fn patch_names(&self) -> &[String] {
+        &self.patch_names
+    }
+
+    /// Check if the index is empty (no patches added).
+    pub fn is_empty(&self) -> bool {
+        self.patch_names.is_empty()
+    }
+
+    /// Iterate over all files in the index.
+    pub fn files(&self) -> impl Iterator<Item = (&PathBuf, &FileSource)> {
+        self.files.iter()
+    }
+}
+
+impl Default for PatchUnionIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_structure(temp: &TempDir) -> (PatchInfo, PatchInfo) {
+        // Create first patch (A_First - highest priority)
+        let patch_a = temp.path().join("A_First");
+        std::fs::create_dir_all(patch_a.join("Earth nav data/+30-120")).unwrap();
+        std::fs::write(
+            patch_a.join("Earth nav data/+30-120/+33-119.dsf"),
+            b"patch_a dsf",
+        )
+        .unwrap();
+        std::fs::create_dir_all(patch_a.join("terrain")).unwrap();
+        std::fs::write(patch_a.join("terrain/shared.ter"), b"patch_a terrain").unwrap();
+        std::fs::write(patch_a.join("terrain/unique_a.ter"), b"unique to a").unwrap();
+
+        // Create second patch (B_Second - lower priority)
+        let patch_b = temp.path().join("B_Second");
+        std::fs::create_dir_all(patch_b.join("Earth nav data/+30-110")).unwrap();
+        std::fs::write(
+            patch_b.join("Earth nav data/+30-110/+39-105.dsf"),
+            b"patch_b dsf",
+        )
+        .unwrap();
+        std::fs::create_dir_all(patch_b.join("terrain")).unwrap();
+        std::fs::write(
+            patch_b.join("terrain/shared.ter"),
+            b"patch_b terrain (should be shadowed)",
+        )
+        .unwrap();
+        std::fs::write(patch_b.join("terrain/unique_b.ter"), b"unique to b").unwrap();
+
+        let info_a = PatchInfo {
+            name: "A_First".to_string(),
+            path: patch_a,
+            dsf_count: 1,
+            terrain_count: 2,
+            texture_count: 0,
+            is_valid: true,
+            validation_errors: Vec::new(),
+        };
+
+        let info_b = PatchInfo {
+            name: "B_Second".to_string(),
+            path: patch_b,
+            dsf_count: 1,
+            terrain_count: 2,
+            texture_count: 0,
+            is_valid: true,
+            validation_errors: Vec::new(),
+        };
+
+        (info_a, info_b)
+    }
+
+    #[test]
+    fn test_empty_index() {
+        let index = PatchUnionIndex::new();
+        assert!(index.is_empty());
+        assert_eq!(index.file_count(), 0);
+        assert_eq!(index.directory_count(), 0);
+    }
+
+    #[test]
+    fn test_build_from_patches() {
+        let temp = TempDir::new().unwrap();
+        let (info_a, info_b) = create_test_structure(&temp);
+
+        let index = PatchUnionIndex::build(&[info_a, info_b]).unwrap();
+
+        assert!(!index.is_empty());
+        assert_eq!(index.patch_names(), &["A_First", "B_Second"]);
+    }
+
+    #[test]
+    fn test_resolve_path() {
+        let temp = TempDir::new().unwrap();
+        let (info_a, info_b) = create_test_structure(&temp);
+
+        let index = PatchUnionIndex::build(&[info_a, info_b]).unwrap();
+
+        // Resolve a file from patch A
+        let dsf_path = Path::new("Earth nav data/+30-120/+33-119.dsf");
+        let source = index.resolve(dsf_path).expect("Should resolve DSF");
+        assert_eq!(source.patch_name, "A_First");
+
+        // Resolve a file from patch B (not in A)
+        let dsf_path_b = Path::new("Earth nav data/+30-110/+39-105.dsf");
+        let source_b = index
+            .resolve(dsf_path_b)
+            .expect("Should resolve DSF from B");
+        assert_eq!(source_b.patch_name, "B_Second");
+    }
+
+    #[test]
+    fn test_first_patch_wins_collision() {
+        let temp = TempDir::new().unwrap();
+        let (info_a, info_b) = create_test_structure(&temp);
+
+        let index = PatchUnionIndex::build(&[info_a.clone(), info_b]).unwrap();
+
+        // shared.ter exists in both patches - A should win
+        let shared_path = Path::new("terrain/shared.ter");
+        let source = index
+            .resolve(shared_path)
+            .expect("Should resolve shared file");
+        assert_eq!(source.patch_name, "A_First");
+
+        // Verify the content is from patch A
+        let content = std::fs::read(&source.real_path).unwrap();
+        assert_eq!(content, b"patch_a terrain");
+    }
+
+    #[test]
+    fn test_directory_listing() {
+        let temp = TempDir::new().unwrap();
+        let (info_a, info_b) = create_test_structure(&temp);
+
+        let index = PatchUnionIndex::build(&[info_a, info_b]).unwrap();
+
+        // List terrain directory - should have merged entries
+        let entries = index.list_directory(Path::new("terrain"));
+
+        // Should have: shared.ter (from A), unique_a.ter, unique_b.ter
+        let names: Vec<_> = entries
+            .iter()
+            .map(|e| e.name.to_string_lossy().to_string())
+            .collect();
+        assert!(names.contains(&"shared.ter".to_string()));
+        assert!(names.contains(&"unique_a.ter".to_string()));
+        assert!(names.contains(&"unique_b.ter".to_string()));
+    }
+
+    #[test]
+    fn test_is_directory() {
+        let temp = TempDir::new().unwrap();
+        let (info_a, info_b) = create_test_structure(&temp);
+
+        let index = PatchUnionIndex::build(&[info_a, info_b]).unwrap();
+
+        assert!(index.is_directory(Path::new(""))); // Root
+        assert!(index.is_directory(Path::new("Earth nav data")));
+        assert!(index.is_directory(Path::new("terrain")));
+        assert!(!index.is_directory(Path::new("terrain/shared.ter"))); // File, not directory
+    }
+
+    #[test]
+    fn test_contains() {
+        let temp = TempDir::new().unwrap();
+        let (info_a, _) = create_test_structure(&temp);
+
+        let index = PatchUnionIndex::build(&[info_a]).unwrap();
+
+        assert!(index.contains(Path::new("Earth nav data/+30-120/+33-119.dsf")));
+        assert!(index.contains(Path::new("terrain/unique_a.ter")));
+        assert!(!index.contains(Path::new("nonexistent.file")));
+    }
+
+    #[test]
+    fn test_list_root_directory() {
+        let temp = TempDir::new().unwrap();
+        let (info_a, _) = create_test_structure(&temp);
+
+        let index = PatchUnionIndex::build(&[info_a]).unwrap();
+
+        // List root directory
+        let entries = index.list_directory(Path::new(""));
+        let names: Vec<_> = entries
+            .iter()
+            .map(|e| e.name.to_string_lossy().to_string())
+            .collect();
+
+        assert!(names.contains(&"Earth nav data".to_string()));
+        assert!(names.contains(&"terrain".to_string()));
+    }
+
+    #[test]
+    fn test_files_iterator() {
+        let temp = TempDir::new().unwrap();
+        let (info_a, _) = create_test_structure(&temp);
+
+        let index = PatchUnionIndex::build(&[info_a]).unwrap();
+
+        let file_count = index.files().count();
+        assert!(file_count > 0);
+        assert_eq!(file_count, index.file_count());
+    }
+
+    #[test]
+    fn test_invalid_patch_skipped() {
+        let temp = TempDir::new().unwrap();
+        let (mut info_a, _) = create_test_structure(&temp);
+
+        // Mark patch as invalid
+        info_a.is_valid = false;
+
+        let index = PatchUnionIndex::build(&[info_a]).unwrap();
+
+        // Should be empty since the only patch was invalid
+        assert!(index.is_empty());
+    }
+}

--- a/xearthlayer/src/service/facade.rs
+++ b/xearthlayer/src/service/facade.rs
@@ -604,7 +604,10 @@ impl XEarthLayerService {
     }
 
     /// Calculate the expected DDS file size based on encoder configuration.
-    fn expected_dds_size(&self) -> usize {
+    ///
+    /// Returns the expected file size for a standard 4096×4096 DDS texture
+    /// with the configured format and mipmap levels.
+    pub fn expected_dds_size(&self) -> usize {
         self.dds_encoder.expected_size(4096, 4096)
     }
 


### PR DESCRIPTION
## Summary

- Adds tile patches feature allowing users to use pre-built Ortho4XP tiles with custom mesh/elevation from third-party airport addons (e.g., SFD KLAX, X-Codr KDEN) while XEL generates consistent textures dynamically
- Implements union filesystem pattern to merge multiple patch folders into a single virtual view
- Patches mount at `zzyXEL_patches_ortho` ensuring they override regional ortho tiles while overlays remain on top

### Key Changes

- **Configuration**: New `[patches]` section with `enabled` and `directory` settings
- **Core Module**: `xearthlayer/src/patches/` with discovery and union index
- **FUSE**: `Fuse3UnionFS` implementation for mounting merged patch folders
- **CLI**: New `patches` subcommand with `list`, `validate`, and `path` actions
- **Documentation**: User guide (`docs/patches.md`) and design spec (`docs/dev/tile-patches.md`)

## Test plan

- [x] All 1489 unit tests pass
- [x] Pre-commit checks (format, clippy, test) pass
- [x] Manual testing: patches mount correctly when valid tiles are in patches directory
- [x] Manual testing: empty/missing patches directory silently skips (expected behavior)
- [ ] Test with real airport addon patch tiles (KLAX, KDEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)