### PR TITLE
Release v0.3.0

### DIFF
--- a/docs/dev/async-pipeline-architecture.md
+++ b/docs/dev/async-pipeline-architecture.md
@@ -1102,7 +1102,9 @@ pub struct PipelineMetrics {
     pub memory_cache_misses: AtomicU64,
     pub memory_cache_size_bytes: AtomicUsize,
     pub memory_cache_entries: AtomicUsize,
-    pub disk_cache_size_bytes: AtomicU64,
+    // Note: disk_cache_size_bytes is now updated via absolute DiskCacheSizeUpdate
+    // events from the LRU index, not computed from initial + written - evicted.
+    pub disk_cache_size_bytes: u64,
     pub disk_cache_entries: AtomicU64,
 
     // FUSE metrics

--- a/docs/dev/cache-service-design.md
+++ b/docs/dev/cache-service-design.md
@@ -506,7 +506,8 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
 
 ## References
 
-- Current eviction daemon: `xearthlayer/src/cache/disk_eviction.rs`
+- Disk cache provider with internal GC: `xearthlayer/src/cache/providers/disk.rs`
+- GC scheduler daemon: `xearthlayer/src/cache/gc_scheduler.rs`
 - Current memory cache: `xearthlayer/src/cache/memory.rs`
 - Current adapters: `xearthlayer/src/executor/adapters/`
 - Moka documentation: https://docs.rs/moka/


### PR DESCRIPTION
## Release v0.3.0

Major release introducing the Adaptive Prefetch System and a complete rewrite of the execution core.

### Highlights

- **Adaptive Prefetch System** — Self-calibrating tile prediction with flight phase detection (Ground vs Cruise), circuit breaker for scene loading, and three-tier filtering (local → memory → disk)
- **Job Executor Framework** — Async, non-blocking execution with priority scheduling (`ON_DEMAND` > `PREFETCH` > `HOUSEKEEPING`), resource pools, cancellation support, and stall detection
- **Aircraft Position & Telemetry (APT)** — Real-time UDP telemetry from X-Plane (ForeFlight protocol) with flight path tracking and dashboard integration
- **Self-Contained Cache Services** — `CacheLayer` with internal LRU index, job-based GC, and authoritative disk cache size reporting

### Bug Fixes

- **Directory Listing (#38)**: `ls` now works in FUSE mounted directories
- **Skip Installed Ortho Tiles (#39)**: Prefetch checks `OrthoUnionIndex` before downloading
- **Disk Cache Size Reporting**: Fixed double-counting in `populate_from_disk()` and replaced fragile metrics formula with authoritative LRU index values

### Breaking Changes

- `pipeline.*` config keys replaced by `executor.*` — run `xearthlayer config upgrade` to migrate
- Legacy `TileGenerator` API removed (use `DdsClient` trait)
- `run_eviction_daemon` removed (GC now internal to `DiskCacheProvider`)

### ⚠️ Notes for Testers

The new Job Executor Framework is aggressive with system resources. If you experience instability:

1. Run `xearthlayer diagnostics` and include the system report
2. Collect X-Plane `Log.txt` and XEarthLayer log output
3. Report at https://github.com/samsoir/xearthlayer/issues
4. Use `xearthlayer run --debug` for additional diagnostics

### Release Process

Per the [release runbook](docs/dev/app-release-runbook.md):

- [ ] CI passes on this PR
- [ ] Tag `v0.3.0` created on release branch (BEFORE merge)
- [ ] Release workflow completes successfully
- [ ] PR merged (AFTER workflow completes)
- [ ] `version.json` updated
- [ ] Website shows v0.3.0

See [CHANGELOG.md](CHANGELOG.md) for full release notes.