### PR TITLE
fix(packages): use consolidated overlay for install/remove/update

### DIFF
--- a/xearthlayer-cli/src/commands/packages/args.rs
+++ b/xearthlayer-cli/src/commands/packages/args.rs
@@ -170,6 +170,8 @@ pub struct UpdateArgs {
     pub install_dir: PathBuf,
     pub temp_dir: PathBuf,
     pub all: bool,
+    /// Path to X-Plane Custom Scenery directory for overlay symlinks.
+    pub custom_scenery_path: Option<PathBuf>,
 }
 
 /// Arguments for the remove command.

--- a/xearthlayer-cli/src/commands/packages/mod.rs
+++ b/xearthlayer-cli/src/commands/packages/mod.rs
@@ -172,6 +172,7 @@ pub fn run(command: PackagesCommands) -> Result<(), CliError> {
                 install_dir: install_dir.unwrap_or_else(|| default_install_dir(&config)),
                 temp_dir: temp_dir.unwrap_or_else(|| default_temp_dir(&config)),
                 all,
+                custom_scenery_path: default_custom_scenery_dir(&config),
             },
             &ctx,
         ),

--- a/xearthlayer/src/manager/mod.rs
+++ b/xearthlayer/src/manager/mod.rs
@@ -63,8 +63,7 @@ pub use mounts::{
     ActiveMount, CacheBridges, ConsolidatedOrthoMountResult, MountManager, ServiceBuilder,
 };
 pub use symlinks::{
-    consolidated_overlay_exists, create_consolidated_overlay, create_overlay_symlink,
-    overlay_symlink_exists, overlay_symlink_path, remove_consolidated_overlay,
+    consolidated_overlay_exists, create_consolidated_overlay, remove_consolidated_overlay,
     remove_overlay_symlink, ConsolidatedOverlayResult, CONSOLIDATED_OVERLAY_NAME,
 };
 pub use traits::{ArchiveExtractor, LibraryClient, PackageDownloader, ProgressCallback};


### PR DESCRIPTION
## Summary

- **Install handler** was creating per-region overlay symlinks (`yzXEL_<region>_overlay`) instead of rebuilding the consolidated overlay (`yzXEL_overlay/`), causing duplicate overlay entries in X-Plane
- Replaced `create_symlink_if_configured` with `rebuild_consolidated_overlay` that calls `create_consolidated_overlay` for all overlay operations (install, remove, update)
- Added scan-based cleanup of stale per-region symlinks during every consolidated overlay rebuild, including regions no longer installed
- Added overlay rebuild to `UpdateHandler` (was missing entirely)

## Test plan

- [x] `make pre-commit` passes (2007 unit tests + 62 doc tests, zero warnings)
- [x] Manual: install overlay → `yzXEL_overlay/` created (not per-region symlink)
- [x] Manual: remove overlay → `yzXEL_overlay/` rebuilt without that region
- [x] Manual: `xearthlayer run` with existing stale per-region symlinks → cleaned up automatically
- [x] CI build passes on branch

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)