### PR TITLE
chore(ci): upgrade GitHub Actions to v5 for Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -40,7 +40,7 @@ jobs:
     name: Check GPU Feature
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       release_tag: ${{ steps.tag.outputs.RELEASE_TAG }}
       version: ${{ steps.tag.outputs.VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine release tag
         id: tag
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
         run: cargo build --release
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-binary
           path: target/release/xearthlayer
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |
@@ -99,7 +99,7 @@ jobs:
         run: cargo build --release --features gpu-encode
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-binary-gpu
           path: target/release/xearthlayer
@@ -110,10 +110,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify, build-binary]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download release binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-binary
           path: target/release
@@ -130,7 +130,7 @@ jobs:
           tar czvf xearthlayer-${RELEASE_TAG}-x86_64-linux.tar.gz xearthlayer README.md LICENSE
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: linux-binary
           path: dist/*.tar.gz
@@ -141,12 +141,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify, build-binary]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Download release binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-binary
           path: target/release
@@ -165,7 +165,7 @@ jobs:
           cp ../target/debian/*.deb ../dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: debian-package
           path: dist/*.deb
@@ -176,10 +176,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify, build-binary-gpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download GPU release binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-binary-gpu
           path: target/release
@@ -196,7 +196,7 @@ jobs:
           tar czvf xearthlayer-gpu-${RELEASE_TAG}-x86_64-linux.tar.gz xearthlayer README.md LICENSE
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: linux-binary-gpu
           path: dist/*.tar.gz
@@ -207,12 +207,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify, build-binary-gpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Download GPU release binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-binary-gpu
           path: target/release
@@ -237,7 +237,7 @@ jobs:
           done
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: debian-package-gpu
           path: dist/*.deb
@@ -250,7 +250,7 @@ jobs:
     container:
       image: fedora:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install build dependencies
         run: |
@@ -281,7 +281,7 @@ jobs:
           cp ~/rpmbuild/RPMS/*/*.rpm dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: rpm-package
           path: dist/*.rpm
@@ -292,7 +292,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Generate PKGBUILD and .SRCINFO
         env:
@@ -358,7 +358,7 @@ jobs:
           rm "pkg/aur/xearthlayer-${VERSION}.tar.gz"
 
       - name: Upload AUR package files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: aur-package
           path: |
@@ -373,10 +373,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` v4 → v5, `actions/upload-artifact` v4 → v5, `actions/download-artifact` v4 → v5
- Resolves Node.js 20 deprecation warnings ahead of the June 2026 forced migration

Closes #78 (xearthlayer portion)

## Test plan

- [x] CI workflow passes on this branch
- [x] Verify no deprecation annotations in workflow run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)