### PR TITLE
refactor(service): consolidate XEarthLayerService into single start() constructor

### DIFF
--- a/xearthlayer/src/lib.rs
+++ b/xearthlayer/src/lib.rs
@@ -12,7 +12,7 @@
 //! use xearthlayer::provider::ProviderConfig;
 //!
 //! let config = ServiceConfig::default();
-//! let service = XEarthLayerService::new(config, ProviderConfig::bing())?;
+//! let service = XEarthLayerService::start(config, ProviderConfig::bing(), logger).await?;
 //!
 //! // Mount FUSE filesystem for a scenery package
 //! let handle = service.mount_package_async(package_path).await?;

--- a/xearthlayer/src/manager/mod.rs
+++ b/xearthlayer/src/manager/mod.rs
@@ -59,9 +59,7 @@ pub use error::{ManagerError, ManagerResult};
 pub use extractor::{check_required_tools, ShellExtractor};
 pub use installer::{InstallProgressCallback, InstallResult, InstallStage, PackageInstaller};
 pub use local::{InstalledPackage, LocalPackageStore, MountStatus};
-pub use mounts::{
-    ActiveMount, CacheBridges, ConsolidatedOrthoMountResult, MountManager, ServiceBuilder,
-};
+pub use mounts::{ActiveMount, ConsolidatedOrthoMountResult, MountManager, ServiceBuilder};
 pub use symlinks::{
     consolidated_overlay_exists, create_consolidated_overlay, remove_consolidated_overlay,
     remove_overlay_symlink, ConsolidatedOverlayResult, CONSOLIDATED_OVERLAY_NAME,

--- a/xearthlayer/src/manager/mounts.rs
+++ b/xearthlayer/src/manager/mounts.rs
@@ -11,11 +11,9 @@ use std::time::Duration;
 
 use tokio::sync::mpsc;
 
-use crate::cache::adapters::{DiskCacheBridge, MemoryCacheBridge};
-use crate::cache::MemoryCache;
 use crate::config::defaults::{DEFAULT_FUSE_CONGESTION_THRESHOLD, DEFAULT_FUSE_MAX_BACKGROUND};
 use crate::config::DiskIoProfile;
-use crate::executor::{MemoryCacheAdapter, StorageConcurrencyLimiter};
+use crate::executor::StorageConcurrencyLimiter;
 use crate::fuse::fuse3::Fuse3OrthoUnionFS;
 use crate::fuse::SpawnedMountHandle;
 use crate::geo_index::{DsfRegion, GeoIndex, PatchCoverage};
@@ -33,7 +31,7 @@ use crate::prefetch::TileRequestCallback;
 use crate::scene_tracker::{DefaultSceneTracker, FuseAccessEvent};
 use crate::service::{ServiceConfig, ServiceError, XEarthLayerService};
 
-use super::local::{InstalledPackage, LocalPackageStore};
+use super::local::LocalPackageStore;
 use super::{ManagerError, ManagerResult};
 
 /// Information about an active mount.
@@ -421,46 +419,29 @@ impl MountManager {
         }
 
         // Create the service (owns the Tokio runtime for DDS generation)
-        // Use async service creation if no cache bridges are set (new architecture)
-        // Fall back to sync creation when cache bridges are pre-configured (legacy)
-        let service = if service_builder.cache_bridges().is_some() {
-            // Legacy path: use pre-configured cache bridges from CacheLayer
-            match service_builder.build_patches_service() {
-                Ok(s) => s,
-                Err(e) => {
-                    return ConsolidatedOrthoMountResult::failure(
-                        mountpoint,
-                        format!("Failed to create service: {}", e),
-                    );
-                }
+        // Use XEarthLayerService::start() with integrated cache and metrics
+        let runtime = match tokio::runtime::Runtime::new() {
+            Ok(r) => r,
+            Err(e) => {
+                return ConsolidatedOrthoMountResult::failure(
+                    mountpoint,
+                    format!("Failed to create runtime for service: {}", e),
+                );
             }
-        } else {
-            // New path: use XEarthLayerService::start() with integrated cache and metrics
-            // We need a runtime to run the async service creation
-            let runtime = match tokio::runtime::Runtime::new() {
-                Ok(r) => r,
-                Err(e) => {
-                    return ConsolidatedOrthoMountResult::failure(
-                        mountpoint,
-                        format!("Failed to create runtime for service: {}", e),
-                    );
-                }
-            };
-
-            let mut service = match runtime.block_on(service_builder.build_service_async()) {
-                Ok(s) => s,
-                Err(e) => {
-                    return ConsolidatedOrthoMountResult::failure(
-                        mountpoint,
-                        format!("Failed to create service: {}", e),
-                    );
-                }
-            };
-
-            // Transfer runtime ownership to the service so it stays alive
-            service.set_owned_runtime(runtime);
-            service
         };
+
+        let mut service = match runtime.block_on(service_builder.build_service_async()) {
+            Ok(s) => s,
+            Err(e) => {
+                return ConsolidatedOrthoMountResult::failure(
+                    mountpoint,
+                    format!("Failed to create service: {}", e),
+                );
+            }
+        };
+
+        // Transfer runtime ownership to the service so it stays alive
+        service.set_owned_runtime(runtime);
 
         // Get DdsClient and runtime from the service
         let dds_client = match service.dds_client() {
@@ -854,9 +835,8 @@ impl Drop for MountManager {
 /// Builder for creating services for each package.
 ///
 /// This helper creates properly configured service instances for mounting.
-/// When multiple packages are mounted, all services share:
-/// - A single disk I/O concurrency limiter to prevent I/O exhaustion
-/// - A single memory cache to respect the configured memory limit globally
+/// Uses [`XEarthLayerService::start()`] to create services with integrated
+/// cache and metrics.
 pub struct ServiceBuilder {
     service_config: ServiceConfig,
     provider_config: crate::provider::ProviderConfig,
@@ -866,38 +846,9 @@ pub struct ServiceBuilder {
     /// Kept for potential future use with shared I/O limiting.
     #[allow(dead_code)]
     disk_io_limiter: Arc<StorageConcurrencyLimiter>,
-    /// Shared memory cache across all service instances (legacy).
-    /// Without this, each package would have its own cache with the full
-    /// configured limit, potentially using N times the expected memory.
-    shared_memory_cache: Option<Arc<MemoryCache>>,
-    /// Shared memory cache adapter (wraps cache with provider/format context).
-    shared_memory_cache_adapter: Option<Arc<MemoryCacheAdapter>>,
-    /// Cache bridges from the new CacheService architecture.
-    /// When set, these are used instead of the legacy cache system.
-    /// The DiskCacheBridge includes internal GC daemon (no external GC needed!).
-    cache_bridges: Option<CacheBridges>,
     /// Shared tile request callback for FUSE-based position inference.
     /// When set, all services forward tile requests to this callback.
     tile_request_callback: Option<TileRequestCallback>,
-}
-
-/// Cache bridges from the new CacheService architecture.
-///
-/// These bridges wrap `CacheService` instances that own their own lifecycle,
-/// including internal GC daemons. This eliminates the need for external
-/// GC daemon management.
-///
-/// The `runtime_handle` provides access to the Tokio runtime that manages
-/// the cache services, ensuring async operations can be executed even from
-/// non-async contexts.
-#[derive(Clone)]
-pub struct CacheBridges {
-    /// Memory cache bridge (implements executor::MemoryCache).
-    pub memory: Arc<MemoryCacheBridge>,
-    /// Disk cache bridge (implements executor::DiskCache, has internal GC!).
-    pub disk: Arc<DiskCacheBridge>,
-    /// Handle to the runtime managing the cache services.
-    pub runtime_handle: tokio::runtime::Handle,
 }
 
 impl ServiceBuilder {
@@ -957,76 +908,13 @@ impl ServiceBuilder {
             "Created shared disk I/O limiter for multi-package mounting"
         );
 
-        // Create shared memory cache if caching is enabled
-        // This ensures the configured memory limit is respected globally across all packages
-        let (shared_memory_cache, shared_memory_cache_adapter) = if service_config.cache_enabled() {
-            // Get memory cache size from config (or use default)
-            let mem_size = service_config
-                .cache_memory_size()
-                .unwrap_or(2 * 1024 * 1024 * 1024); // 2GB default
-
-            let cache = Arc::new(MemoryCache::new(mem_size));
-            let adapter = Arc::new(MemoryCacheAdapter::new(
-                Arc::clone(&cache),
-                provider_config.name(),
-                service_config.texture().format(),
-            ));
-
-            tracing::info!(
-                max_size_mb = mem_size / (1024 * 1024),
-                "Created shared memory cache for multi-package mounting"
-            );
-
-            (Some(cache), Some(adapter))
-        } else {
-            (None, None)
-        };
-
         Self {
             service_config,
             provider_config,
             logger,
             disk_io_limiter,
-            shared_memory_cache,
-            shared_memory_cache_adapter,
-            cache_bridges: None,
             tile_request_callback: None,
         }
-    }
-
-    /// Set the cache bridges from the CacheService architecture.
-    ///
-    /// When cache bridges are set, services will use the cache infrastructure
-    /// with internal GC daemons instead of the legacy external GC daemon.
-    ///
-    /// # Arguments
-    ///
-    /// * `bridges` - Cache bridges from `CacheLayer`
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// use xearthlayer::service::CacheLayer;
-    /// use xearthlayer::manager::{ServiceBuilder, CacheBridges};
-    ///
-    /// let cache_layer = CacheLayer::start(cache_config).await?;
-    /// let bridges = CacheBridges {
-    ///     memory: cache_layer.memory_bridge(),
-    ///     disk: cache_layer.disk_bridge(),
-    ///     runtime_handle: cache_layer.runtime_handle(),
-    /// };
-    ///
-    /// let builder = ServiceBuilder::new(service_config, provider_config, logger)
-    ///     .with_cache_bridges(bridges);
-    /// ```
-    pub fn with_cache_bridges(mut self, bridges: CacheBridges) -> Self {
-        self.cache_bridges = Some(bridges);
-        self
-    }
-
-    /// Get the cache bridges if set.
-    pub fn cache_bridges(&self) -> Option<&CacheBridges> {
-        self.cache_bridges.as_ref()
     }
 
     /// Set the tile request callback for FUSE-based position inference.
@@ -1043,95 +931,10 @@ impl ServiceBuilder {
         self
     }
 
-    /// Build a service for the given package.
+    /// Build a service using `XEarthLayerService::start()`.
     ///
-    /// The service will share the disk I/O concurrency limiter and memory cache
-    /// with all other services built by this builder.
-    ///
-    /// If cache bridges are set (via `with_cache_bridges()`), the service uses
-    /// the new cache service architecture with internal GC. Otherwise, it uses
-    /// the legacy cache system.
-    pub fn build(&self, _package: &InstalledPackage) -> Result<XEarthLayerService, ServiceError> {
-        let mut service = self.build_service_internal()?;
-
-        // Wire tile request callback for FUSE-based position inference
-        if let Some(ref callback) = self.tile_request_callback {
-            service.set_tile_request_callback(callback.clone());
-        }
-
-        Ok(service)
-    }
-
-    /// Build a service for patches (no package required).
-    ///
-    /// This creates a service that can generate DDS textures for the patches
-    /// union filesystem. The service shares the same resources (disk I/O limiter,
-    /// memory cache, etc.) as services built for regional packages.
-    pub fn build_patches_service(&self) -> Result<XEarthLayerService, ServiceError> {
-        let mut service = self.build_service_internal()?;
-
-        // Wire tile request callback for FUSE-based position inference
-        if let Some(ref callback) = self.tile_request_callback {
-            service.set_tile_request_callback(callback.clone());
-        }
-
-        Ok(service)
-    }
-
-    /// Internal helper to build a service with either cache bridges or legacy cache.
-    fn build_service_internal(&self) -> Result<XEarthLayerService, ServiceError> {
-        // Use cache bridges if available (new architecture with internal GC)
-        if let Some(ref bridges) = self.cache_bridges {
-            // Use the runtime handle from cache bridges - this was provided by CacheLayer
-            // and ensures we have a valid Tokio runtime even from non-async contexts
-            let runtime_handle = bridges.runtime_handle.clone();
-            let service = XEarthLayerService::with_cache_bridges(
-                self.service_config.clone(),
-                self.provider_config.clone(),
-                self.logger.clone(),
-                runtime_handle,
-                Arc::clone(&bridges.memory),
-                Arc::clone(&bridges.disk),
-            )?;
-
-            tracing::debug!("Built service with cache bridges (internal GC)");
-            return Ok(service);
-        }
-
-        // Fall back to legacy cache system
-        let mut service = XEarthLayerService::new(
-            self.service_config.clone(),
-            self.provider_config.clone(),
-            self.logger.clone(),
-        )?;
-
-        // Set shared memory cache to ensure global memory limit is respected
-        // Without this, each package would have its own cache potentially using
-        // N times the configured memory limit
-        if let (Some(ref cache), Some(ref adapter)) =
-            (&self.shared_memory_cache, &self.shared_memory_cache_adapter)
-        {
-            service.set_shared_memory_cache(Arc::clone(cache), Arc::clone(adapter));
-        }
-
-        tracing::debug!("Built service with legacy cache (external GC required)");
-        Ok(service)
-    }
-
-    /// Build a service using `XEarthLayerService::start()` (recommended).
-    ///
-    /// This async method creates a service with integrated metrics and cache,
-    /// using the new architecture where:
-    /// - MetricsSystem is created first
-    /// - CacheLayer is created with MetricsClient (enables GC reporting)
-    /// - All components are properly wired
-    ///
-    /// This is the recommended way to create services as it ensures the GC
-    /// daemon has access to metrics for reporting cache evictions.
-    ///
-    /// # Returns
-    ///
-    /// A fully initialized `XEarthLayerService` with integrated cache and metrics.
+    /// Creates a service with integrated metrics and cache, ensuring
+    /// MetricsSystem, CacheLayer, and GC daemon are properly wired.
     ///
     /// # Errors
     ///

--- a/xearthlayer/src/service/builder.rs
+++ b/xearthlayer/src/service/builder.rs
@@ -5,65 +5,11 @@
 
 use super::config::ServiceConfig;
 use super::error::ServiceError;
-use crate::cache::{MemoryCache, MemoryCacheConfig};
 use crate::provider::{
-    AsyncProviderFactory, AsyncProviderType, AsyncReqwestClient, Provider, ProviderConfig,
-    ProviderFactory, ReqwestClient,
+    AsyncProviderFactory, AsyncProviderType, AsyncReqwestClient, ProviderConfig,
 };
 use crate::texture::DdsTextureEncoder;
 use std::sync::Arc;
-use tokio::runtime::Handle;
-
-/// Result of provider initialization (sync constructors).
-pub struct ProviderComponents {
-    /// Sync provider (unused - kept for API compatibility, will be removed)
-    #[allow(dead_code)]
-    pub sync_provider: Arc<dyn Provider>,
-    /// Async provider for async pipeline (optional)
-    pub async_provider: Option<Arc<AsyncProviderType>>,
-    /// Provider name for cache directories
-    pub name: String,
-    /// Maximum zoom level supported
-    pub max_zoom: u8,
-}
-
-/// Result of cache initialization.
-pub struct CacheComponents {
-    /// Shared memory cache for async pipeline (DDS tiles in memory with LRU eviction).
-    pub memory_cache: Option<Arc<MemoryCache>>,
-}
-
-/// Create sync and async providers from configuration.
-pub fn create_providers(
-    config: &ProviderConfig,
-    runtime_handle: &Handle,
-) -> Result<ProviderComponents, ServiceError> {
-    // Create sync HTTP client for legacy pipeline
-    let http_client =
-        ReqwestClient::new().map_err(|e| ServiceError::HttpClientError(e.to_string()))?;
-
-    // Create sync provider using factory
-    let factory = ProviderFactory::new(http_client);
-    let (sync_provider, name, max_zoom) = factory.create(config)?;
-
-    // Create async HTTP client for async pipeline
-    let async_http_client =
-        AsyncReqwestClient::new().map_err(|e| ServiceError::HttpClientError(e.to_string()))?;
-
-    // Create async provider (optional - gracefully handle failures)
-    let async_factory = AsyncProviderFactory::new(async_http_client);
-    let async_provider = runtime_handle
-        .block_on(async_factory.create(config))
-        .map(|(provider, _, _)| Arc::new(provider))
-        .ok();
-
-    Ok(ProviderComponents {
-        sync_provider,
-        async_provider,
-        name,
-        max_zoom,
-    })
-}
 
 /// Result of async-only provider initialization.
 ///
@@ -186,37 +132,6 @@ pub fn create_encoder(config: &ServiceConfig) -> Result<EncoderComponents, Servi
     })
 }
 
-/// Create cache components from configuration.
-///
-/// The async pipeline uses:
-/// - `MemoryCache` for DDS tiles (LRU eviction, shared across requests)
-/// - `ParallelDiskCache` for chunks (configured via `DdsHandlerBuilder::with_disk_cache`)
-pub fn create_cache(
-    config: &ServiceConfig,
-    _provider_name: &str,
-) -> Result<CacheComponents, ServiceError> {
-    if !config.cache_enabled() {
-        return Ok(CacheComponents { memory_cache: None });
-    }
-
-    // Get defaults from config types
-    let memory_defaults = MemoryCacheConfig::default();
-
-    let mut mem_size = memory_defaults.max_size_bytes;
-
-    // Apply user-configured overrides
-    if let Some(size) = config.cache_memory_size() {
-        mem_size = size;
-    }
-
-    // Create shared memory cache for async pipeline
-    let memory_cache = Arc::new(MemoryCache::new(mem_size));
-
-    Ok(CacheComponents {
-        memory_cache: Some(memory_cache),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -324,12 +239,5 @@ mod tests {
             components.gpu_worker_handle.is_none(),
             "ISPC compressor should not have a GPU worker handle"
         );
-    }
-
-    #[test]
-    fn test_cache_disabled_returns_noop() {
-        let config = ServiceConfig::builder().cache_enabled(false).build();
-        let result = create_cache(&config, "test").unwrap();
-        assert!(result.memory_cache.is_none());
     }
 }

--- a/xearthlayer/src/service/facade.rs
+++ b/xearthlayer/src/service/facade.rs
@@ -1,15 +1,14 @@
 //! XEarthLayer service facade implementation.
 
-use super::builder::{self, AsyncProviderComponents, CacheComponents, ProviderComponents};
+use super::builder::{self, AsyncProviderComponents};
 use super::cache_layer::CacheLayer;
 use super::config::ServiceConfig;
 use super::error::ServiceError;
 use super::fuse_mount::{FuseMountConfig, FuseMountService};
 use super::runtime_builder::RuntimeBuilder;
-use crate::cache::adapters::{DiskCacheBridge, MemoryCacheBridge};
-use crate::cache::{disk_cache_stats, GcSchedulerDaemon, MemoryCache};
-use crate::config::DiskIoProfile;
-use crate::executor::{DdsClient, MemoryCacheAdapter};
+use crate::cache::adapters::MemoryCacheBridge;
+use crate::cache::GcSchedulerDaemon;
+use crate::executor::DdsClient;
 use crate::fuse::{MountHandle, SpawnedMountHandle};
 use crate::log::Logger;
 use crate::metrics::{MetricsSystem, TelemetrySnapshot, TuiReporter};
@@ -17,7 +16,6 @@ use crate::prefetch::TileRequestCallback;
 use crate::provider::ProviderConfig;
 use crate::runtime::{SharedRuntimeHealth, SharedTileProgressTracker, XEarthLayerRuntime};
 use crate::texture::{DdsTextureEncoder, TextureEncoder};
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::{Handle, Runtime};
@@ -29,19 +27,13 @@ use tokio_util::sync::CancellationToken;
 /// Encapsulates all component creation and wiring, providing a simplified
 /// API for serving satellite imagery tiles via FUSE.
 ///
-/// # Runtime Management
+/// # Construction
 ///
-/// The service can be created with either a default runtime or an injected handle:
+/// Use [`start()`](Self::start) to create a service instance. This is the
+/// only constructor and must be called from within an async context:
 ///
 /// ```ignore
-/// // Option 1: Default runtime (convenience)
-/// let service = XEarthLayerService::new(config, provider_config, logger)?;
-///
-/// // Option 2: Injected runtime handle (for DI/testing)
-/// let runtime = Runtime::new()?;
-/// let service = XEarthLayerService::with_runtime(
-///     config, provider_config, logger, runtime.handle().clone()
-/// )?;
+/// let service = XEarthLayerService::start(config, provider_config, logger).await?;
 /// ```
 ///
 /// # Example
@@ -50,12 +42,8 @@ use tokio_util::sync::CancellationToken;
 /// use xearthlayer::service::{XEarthLayerService, ServiceConfig};
 /// use xearthlayer::provider::ProviderConfig;
 ///
-/// // Create service with default configuration
 /// let config = ServiceConfig::default();
-/// let service = XEarthLayerService::new(config, ProviderConfig::bing(), logger)?;
-///
-/// // Mount FUSE filesystem
-/// let handle = service.mount_package_async(package_path).await?;
+/// let service = XEarthLayerService::start(config, ProviderConfig::bing(), logger).await?;
 /// ```
 pub struct XEarthLayerService {
     /// Service configuration
@@ -82,10 +70,6 @@ pub struct XEarthLayerService {
 
     /// Texture encoder for DDS generation
     dds_encoder: Arc<DdsTextureEncoder>,
-    /// Shared memory cache for tile-level caching
-    memory_cache: Option<Arc<MemoryCache>>,
-    /// Shared memory cache adapter (implements executor::MemoryCache trait)
-    memory_cache_adapter: Option<Arc<MemoryCacheAdapter>>,
     /// Metrics system for event-based telemetry
     metrics_system: Option<MetricsSystem>,
     /// XEarthLayer runtime (job executor daemon)
@@ -110,152 +94,6 @@ pub struct XEarthLayerService {
 }
 
 impl XEarthLayerService {
-    /// Create a new XEarthLayer service with a default Tokio runtime.
-    ///
-    /// This is a convenience constructor that creates its own runtime internally
-    /// with default SSD disk profile settings.
-    /// For advanced use cases or testing, use [`with_runtime`] instead.
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - Service configuration
-    /// * `provider_config` - Provider-specific configuration
-    /// * `logger` - Logger implementation
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any component fails to initialize.
-    pub fn new(
-        config: ServiceConfig,
-        provider_config: ProviderConfig,
-        logger: Arc<dyn Logger>,
-    ) -> Result<Self, ServiceError> {
-        Self::with_disk_profile(config, provider_config, logger, DiskIoProfile::default())
-    }
-
-    /// Create a new XEarthLayer service with a Tokio runtime tuned for the disk profile.
-    ///
-    /// This constructor configures the Tokio runtime's blocking thread pool
-    /// based on the storage profile:
-    /// - **HDD**: Conservative blocking threads (seek-bound operations)
-    /// - **SSD**: Moderate blocking threads (SATA queue depth)
-    /// - **NVMe**: Higher blocking threads (multiple queues)
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - Service configuration
-    /// * `provider_config` - Provider-specific configuration
-    /// * `logger` - Logger implementation
-    /// * `disk_profile` - Storage profile for tuning (use Auto for detection)
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any component fails to initialize.
-    pub fn with_disk_profile(
-        config: ServiceConfig,
-        provider_config: ProviderConfig,
-        logger: Arc<dyn Logger>,
-        disk_profile: DiskIoProfile,
-    ) -> Result<Self, ServiceError> {
-        // Get CPU count for worker threads
-        const DEFAULT_CPU_FALLBACK: usize = 4;
-        let num_cpus = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(DEFAULT_CPU_FALLBACK);
-
-        // Get max blocking threads based on disk profile
-        let max_blocking_threads = disk_profile.max_blocking_threads();
-
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(num_cpus)
-            .max_blocking_threads(max_blocking_threads)
-            .enable_all()
-            .thread_name("xearthlayer-tokio")
-            .build()
-            .map_err(|e| ServiceError::RuntimeError(format!("failed to create runtime: {}", e)))?;
-
-        tracing::info!(
-            worker_threads = num_cpus,
-            max_blocking_threads = max_blocking_threads,
-            disk_profile = %disk_profile,
-            "Created Tokio runtime with configured thread pools"
-        );
-
-        let handle = runtime.handle().clone();
-
-        Self::build(config, provider_config, logger, handle, Some(runtime), None)
-    }
-
-    /// Create a new XEarthLayer service with a provided runtime handle.
-    ///
-    /// Use this constructor when you want to control the runtime lifecycle
-    /// externally, or for testing with injected runtimes.
-    pub fn with_runtime(
-        config: ServiceConfig,
-        provider_config: ProviderConfig,
-        logger: Arc<dyn Logger>,
-        runtime_handle: Handle,
-    ) -> Result<Self, ServiceError> {
-        Self::build(config, provider_config, logger, runtime_handle, None, None)
-    }
-
-    /// Create a new XEarthLayer service with cache bridges from the new cache service.
-    ///
-    /// This constructor uses the new `CacheService` architecture where:
-    /// - `MemoryCacheBridge` implements `executor::MemoryCache`
-    /// - `DiskCacheBridge` implements `executor::DiskCache` with **internal GC daemon**
-    ///
-    /// This eliminates the need for external GC daemon management and ensures
-    /// garbage collection runs regardless of how the application is started
-    /// (TUI vs non-TUI modes).
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - Service configuration
-    /// * `provider_config` - Provider-specific configuration
-    /// * `logger` - Logger implementation
-    /// * `runtime_handle` - Handle to an existing Tokio runtime
-    /// * `memory_bridge` - Memory cache bridge from `CacheLayer`
-    /// * `disk_bridge` - Disk cache bridge from `CacheLayer`
-    ///
-    /// # Note
-    ///
-    /// This method is primarily for internal use. Prefer using
-    /// [`XEarthLayerService::start()`] which handles cache lifecycle automatically.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// use xearthlayer::service::XEarthLayerService;
-    /// use xearthlayer::cache::adapters::{MemoryCacheBridge, DiskCacheBridge};
-    ///
-    /// let service = XEarthLayerService::with_cache_bridges(
-    ///     service_config,
-    ///     provider_config,
-    ///     logger,
-    ///     runtime_handle,
-    ///     memory_bridge,
-    ///     disk_bridge,
-    /// )?;
-    /// ```
-    pub fn with_cache_bridges(
-        config: ServiceConfig,
-        provider_config: ProviderConfig,
-        logger: Arc<dyn Logger>,
-        runtime_handle: Handle,
-        memory_bridge: Arc<MemoryCacheBridge>,
-        disk_bridge: Arc<DiskCacheBridge>,
-    ) -> Result<Self, ServiceError> {
-        Self::build(
-            config,
-            provider_config,
-            logger,
-            runtime_handle,
-            None,
-            Some((memory_bridge, disk_bridge)),
-        )
-    }
-
     /// Start a new XEarthLayerService with integrated cache and metrics.
     ///
     /// This is the recommended way to create a service. It ensures:
@@ -364,8 +202,6 @@ impl XEarthLayerService {
             _owned_runtime: None, // Caller owns the runtime
             runtime_handle,
             dds_encoder,
-            memory_cache: None,
-            memory_cache_adapter: None,
             metrics_system: Some(metrics_system),
             xearthlayer_runtime: Some(xel_runtime),
             dds_client: Some(dds_client),
@@ -375,168 +211,6 @@ impl XEarthLayerService {
             cache_layer: Some(cache_layer),
             gc_scheduler_handle,
             gc_scheduler_shutdown,
-            gpu_worker_handle,
-            gpu_shutdown,
-        })
-    }
-
-    /// Internal builder that does the actual construction.
-    ///
-    /// Unified construction path for both legacy cache and cache bridge modes.
-    /// When `bridges` is `Some`, the runtime uses cache bridges (internal GC).
-    /// When `None`, falls back to legacy memory cache + disk cache directory.
-    #[allow(clippy::too_many_arguments)]
-    fn build(
-        config: ServiceConfig,
-        provider_config: ProviderConfig,
-        logger: Arc<dyn Logger>,
-        runtime_handle: Handle,
-        owned_runtime: Option<Runtime>,
-        bridges: Option<(Arc<MemoryCacheBridge>, Arc<DiskCacheBridge>)>,
-    ) -> Result<Self, ServiceError> {
-        // 1. Create providers
-        let ProviderComponents {
-            sync_provider: _,
-            async_provider,
-            name: provider_name,
-            max_zoom,
-        } = builder::create_providers(&provider_config, &runtime_handle)?;
-
-        // 2. Create texture encoder
-        let encoder_components = builder::create_encoder(&config)?;
-        let dds_encoder = encoder_components.encoder;
-        let gpu_worker_handle = encoder_components.gpu_worker_handle;
-        let gpu_shutdown = encoder_components.gpu_shutdown;
-
-        // 3. Create metrics system
-        let metrics_system = MetricsSystem::new(&runtime_handle);
-
-        // 4. Cache setup — bridge mode or legacy mode
-        let (memory_cache, memory_cache_adapter, memory_cache_bridge) =
-            if let Some((ref mem_bridge, _)) = bridges {
-                // Bridge mode: no legacy cache, store bridge for prefetch
-                (None, None, Some(Arc::clone(mem_bridge)))
-            } else {
-                // Legacy mode: create memory cache and adapter
-                let CacheComponents { memory_cache } =
-                    builder::create_cache(&config, &provider_name)?;
-
-                let adapter = memory_cache.as_ref().map(|cache| {
-                    Arc::new(MemoryCacheAdapter::new(
-                        Arc::clone(cache),
-                        &provider_name,
-                        config.texture().format(),
-                    ))
-                });
-
-                (memory_cache, adapter, None)
-            };
-
-        // 5. Scan existing disk cache in background (legacy mode only)
-        if bridges.is_none() {
-            if let Some(cache_dir) = config.cache_directory() {
-                let cache_path = cache_dir.clone();
-                let metrics_client = metrics_system.client();
-                runtime_handle.spawn(async move {
-                    let path = cache_path;
-                    let result = tokio::task::spawn_blocking(move || disk_cache_stats(&path)).await;
-                    match result {
-                        Ok(Ok((_files, bytes))) => {
-                            metrics_client.disk_cache_initial_size(bytes);
-                            tracing::debug!(bytes, "Disk cache initial size scanned (background)");
-                        }
-                        Ok(Err(e)) => {
-                            tracing::debug!(error = %e, "Failed to scan disk cache size");
-                        }
-                        Err(e) => {
-                            tracing::debug!(error = %e, "Disk cache scan task panicked");
-                        }
-                    }
-                });
-            }
-        }
-
-        // 6. Create XEarthLayer runtime with job executor daemon
-        let (xearthlayer_runtime, dds_client) = if let Some(ref async_prov) = async_provider {
-            let rb = RuntimeBuilder::new(
-                &provider_name,
-                config.texture().format(),
-                Arc::clone(&dds_encoder),
-            )
-            .with_async_provider(Arc::clone(async_prov))
-            .with_runtime_handle(runtime_handle.clone())
-            .with_metrics_client(metrics_system.client());
-
-            let runtime = if let Some((mem_bridge, disk_bridge)) = bridges.clone() {
-                rb.build_with_cache_service(mem_bridge, disk_bridge)
-            } else if memory_cache.is_some() {
-                let cache_dir = config
-                    .cache_directory()
-                    .cloned()
-                    .unwrap_or_else(|| PathBuf::from("/tmp/xearthlayer"));
-                rb.with_memory_cache(
-                    memory_cache
-                        .clone()
-                        .unwrap_or_else(|| Arc::new(MemoryCache::new(0))),
-                )
-                .with_cache_dir(cache_dir)
-                .build()
-            } else {
-                return Ok(Self {
-                    config,
-                    provider_name,
-                    max_zoom,
-                    logger,
-                    _owned_runtime: owned_runtime,
-                    runtime_handle,
-                    dds_encoder,
-                    memory_cache: None,
-                    memory_cache_adapter: None,
-                    metrics_system: Some(metrics_system),
-                    xearthlayer_runtime: None,
-                    dds_client: None,
-                    tile_request_callback: None,
-
-                    memory_cache_bridge: None,
-                    cache_layer: None,
-                    gc_scheduler_handle: None,
-                    gc_scheduler_shutdown: None,
-                    gpu_worker_handle,
-                    gpu_shutdown,
-                });
-            };
-
-            let client = runtime.dds_client();
-            (Some(runtime), Some(client))
-        } else {
-            (None, None)
-        };
-
-        tracing::info!(
-            provider = %provider_name,
-            bridge_mode = bridges.is_some(),
-            "XEarthLayerService created"
-        );
-
-        Ok(Self {
-            config,
-            provider_name,
-            max_zoom,
-            logger,
-            _owned_runtime: owned_runtime,
-            runtime_handle,
-            dds_encoder,
-            memory_cache,
-            memory_cache_adapter,
-            metrics_system: Some(metrics_system),
-            xearthlayer_runtime,
-            dds_client,
-            tile_request_callback: None,
-
-            memory_cache_bridge,
-            cache_layer: None,
-            gc_scheduler_handle: None,
-            gc_scheduler_shutdown: None,
             gpu_worker_handle,
             gpu_shutdown,
         })
@@ -647,33 +321,12 @@ impl XEarthLayerService {
         self.config.texture().format()
     }
 
-    /// Get the raw memory cache for size queries.
-    ///
-    /// Returns a reference to the shared memory cache, if enabled.
-    /// For prefetch operations that need to check cache contents,
-    /// use `memory_cache_adapter()` instead.
-    pub fn memory_cache(&self) -> Option<Arc<MemoryCache>> {
-        self.memory_cache.clone()
-    }
-
-    /// Get the shared memory cache adapter.
-    ///
-    /// Returns the adapter that implements `executor::MemoryCache` trait.
-    /// This is the same adapter instance used by the executor daemon, ensuring
-    /// the prefetcher sees the same cached tiles.
-    ///
-    /// Returns `None` if caching is disabled.
-    pub fn memory_cache_adapter(&self) -> Option<Arc<MemoryCacheAdapter>> {
-        self.memory_cache_adapter.clone()
-    }
-
-    /// Get the memory cache bridge from the new cache service architecture.
+    /// Get the memory cache bridge for tile existence checks.
     ///
     /// Returns the `MemoryCacheBridge` that implements `executor::MemoryCache` trait.
-    /// This is available when the service is created with cache bridges
-    /// (via `with_cache_bridges()` constructor).
+    /// Used by the prefetch and prewarm systems to check if tiles are already cached.
     ///
-    /// Returns `None` if using legacy cache system.
+    /// Returns `None` if caching is disabled.
     pub fn memory_cache_bridge(&self) -> Option<Arc<MemoryCacheBridge>> {
         self.memory_cache_bridge.clone()
     }
@@ -770,28 +423,6 @@ impl XEarthLayerService {
     /// This is typically called by the `MountManager` after creating the service.
     pub fn set_owned_runtime(&mut self, runtime: Runtime) {
         self._owned_runtime = Some(runtime);
-    }
-
-    /// Set the shared memory cache.
-    ///
-    /// When multiple packages are mounted, sharing a single memory cache across
-    /// all services ensures the configured memory limit is respected globally,
-    /// not per-package. Without this, mounting N packages could use N times
-    /// the configured memory limit.
-    ///
-    /// This should be called before mounting the filesystem.
-    ///
-    /// # Arguments
-    ///
-    /// * `cache` - The shared memory cache
-    /// * `adapter` - The shared memory cache adapter (wraps the cache with provider/format context)
-    pub fn set_shared_memory_cache(
-        &mut self,
-        cache: Arc<MemoryCache>,
-        adapter: Arc<MemoryCacheAdapter>,
-    ) {
-        self.memory_cache = Some(cache);
-        self.memory_cache_adapter = Some(adapter);
     }
 
     /// Calculate the expected DDS file size based on encoder configuration.

--- a/xearthlayer/src/service/mod.rs
+++ b/xearthlayer/src/service/mod.rs
@@ -18,7 +18,7 @@
 //!     .build();
 //!
 //! // Create service
-//! let service = XEarthLayerService::new(config, ProviderConfig::bing())?;
+//! let service = XEarthLayerService::start(config, ProviderConfig::bing(), logger).await?;
 //!
 //! // Mount FUSE filesystem
 //! let handle = service.mount_package_async(package_path).await?;

--- a/xearthlayer/src/service/orchestrator/prefetch.rs
+++ b/xearthlayer/src/service/orchestrator/prefetch.rs
@@ -40,10 +40,7 @@ impl ServiceOrchestrator {
 
         let runtime_handle = service.runtime_handle().clone();
 
-        // Try legacy adapter first, then new cache bridge architecture
-        if let Some(memory_cache) = service.memory_cache_adapter() {
-            self.start_prefetch_with_cache(&runtime_handle, dds_client, memory_cache)?;
-        } else if let Some(memory_cache) = service.memory_cache_bridge() {
+        if let Some(memory_cache) = service.memory_cache_bridge() {
             self.start_prefetch_with_cache(&runtime_handle, dds_client, memory_cache)?;
         } else {
             tracing::warn!("Memory cache not available, prefetch disabled");

--- a/xearthlayer/src/service/prewarm.rs
+++ b/xearthlayer/src/service/prewarm.rs
@@ -206,18 +206,8 @@ impl PrewarmOrchestrator {
         // Get GeoIndex for patch-region filtering
         let geo_index = orchestrator.geo_index();
 
-        // Start prewarm with appropriate cache type
-        let handle = if let Some(memory_cache) = service.memory_cache_adapter() {
-            Self::start_prewarm_with_cache(
-                icao,
-                tiles,
-                dds_client,
-                memory_cache,
-                Arc::clone(&ortho_index),
-                geo_index.clone(),
-                runtime_handle,
-            )
-        } else if let Some(memory_cache) = service.memory_cache_bridge() {
+        // Start prewarm with memory cache for tile existence checks
+        let handle = if let Some(memory_cache) = service.memory_cache_bridge() {
             Self::start_prewarm_with_cache(
                 icao,
                 tiles,


### PR DESCRIPTION
Fixes #91

## Summary

- Removed 4 unused constructors (`new`, `with_disk_profile`, `with_runtime`, `with_cache_bridges`) and the private `build()` method from `XEarthLayerService`
- The async `start()` is the only production path — the sync constructors were dead code (`ServiceBuilder.cache_bridges` was never set)
- Removed legacy `ServiceBuilder` methods (`build_service_internal`, `build_patches_service`, `CacheBridges`)
- Simplified prefetch and prewarm cache lookup to use `memory_cache_bridge()` directly

## Investigation

Call-path tracing showed that in production:
```
orchestrator → mount_consolidated_ortho_with_progress()
  → ServiceBuilder.cache_bridges is None (never set by anyone)
  → always takes else branch → build_service_async() → XEarthLayerService::start()
```

The legacy `build()` path, `build_service_internal()`, `build_patches_service()`, and all 4 sync constructors were unreachable dead code.

## Changes

| File | Delta | What |
|------|-------|------|
| `service/facade.rs` | -393 | Delete 4 constructors, `build()`, legacy fields/accessors |
| `manager/mounts.rs` | -251 | Delete `CacheBridges`, legacy builder methods, simplify mount path |
| `service/builder.rs` | -94 | Delete `create_providers()`, `create_cache()`, their types |
| `orchestrator/prefetch.rs` | -4 | Remove `memory_cache_adapter()` fallback |
| `service/prewarm.rs` | -10 | Remove `memory_cache_adapter()` fallback |
| `lib.rs`, `service/mod.rs` | ~2 | Update doc examples to `start()` |

**Net: -719 lines, 8 files**

## Test plan

- [x] All 2,233 tests pass
- [x] No clippy warnings
- [x] `cargo fmt -- --check` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)