### PR TITLE
fix(tui): coalesce tile queue by DSF region

### DIFF
--- a/xearthlayer-cli/src/ui/dashboard/render.rs
+++ b/xearthlayer-cli/src/ui/dashboard/render.rs
@@ -33,7 +33,7 @@ use ratatui::{
 };
 use xearthlayer::metrics::TelemetrySnapshot;
 use xearthlayer::prefetch::PrefetchStatusSnapshot;
-use xearthlayer::runtime::{HealthSnapshot, TileProgressEntry};
+use xearthlayer::runtime::{HealthSnapshot, RegionProgressEntry};
 
 use super::render_sections::inner_rect;
 use super::state::PrewarmProgress;
@@ -66,7 +66,7 @@ pub fn render_ui(
     confirmation_remaining: Option<Duration>,
     prewarm_status: Option<&PrewarmProgress>,
     prewarm_spinner: Option<char>,
-    tile_progress_entries: &[TileProgressEntry],
+    tile_progress_entries: &[RegionProgressEntry],
 ) {
     let size = frame.area();
 

--- a/xearthlayer-cli/src/ui/widgets/scenery_system.rs
+++ b/xearthlayer-cli/src/ui/widgets/scenery_system.rs
@@ -22,7 +22,7 @@ use ratatui::{
     widgets::{Paragraph, Widget},
 };
 use xearthlayer::metrics::TelemetrySnapshot;
-use xearthlayer::runtime::{HealthSnapshot, TileProgressEntry};
+use xearthlayer::runtime::{HealthSnapshot, RegionProgressEntry};
 
 use super::primitives::{Sparkline, SparklineHistory};
 
@@ -124,7 +124,7 @@ pub struct ScenerySystemWidget<'a> {
     snapshot: &'a TelemetrySnapshot,
     health: Option<&'a HealthSnapshot>,
     history: Option<&'a SceneryHistory>,
-    tile_progress: &'a [TileProgressEntry],
+    tile_progress: &'a [RegionProgressEntry],
 }
 
 impl<'a> ScenerySystemWidget<'a> {
@@ -151,7 +151,7 @@ impl<'a> ScenerySystemWidget<'a> {
     }
 
     /// Set tile progress entries for QUEUE column.
-    pub fn with_tile_progress(mut self, entries: &'a [TileProgressEntry]) -> Self {
+    pub fn with_tile_progress(mut self, entries: &'a [RegionProgressEntry]) -> Self {
         self.tile_progress = entries;
         self
     }
@@ -334,14 +334,9 @@ impl ScenerySystemWidget<'_> {
         }
     }
 
-    /// Render the QUEUE column showing active tile progress.
-    ///
-    /// Coalesces tiles by 1-degree coordinate and sorts by progress (highest first).
-    fn render_queue_column(area: Rect, buf: &mut Buffer, entries: &[TileProgressEntry]) {
-        // Coalesce entries by formatted coordinate (1-degree buckets)
-        let coalesced = Self::coalesce_entries(entries);
-
-        // Row 1: Title (centered, no depth indicator needed with coalesced feedback)
+    /// Render the QUEUE column showing active tile progress by DSF region.
+    fn render_queue_column(area: Rect, buf: &mut Buffer, entries: &[RegionProgressEntry]) {
+        // Row 1: Title
         if area.height >= 1 {
             let title_line = Line::from(Span::styled(
                 format!("{:^width$}", "QUEUE", width = area.width as usize),
@@ -350,10 +345,9 @@ impl ScenerySystemWidget<'_> {
             Paragraph::new(title_line).render(Rect { height: 1, ..area }, buf);
         }
 
-        // Row 2: Empty line for spacing between header and content
-        // Row 3+: Tile progress entries
-        if coalesced.is_empty() {
-            // Show placeholder when no tiles are being processed (with spacing)
+        // Row 2: Empty line for spacing
+        // Row 3+: Region progress entries
+        if entries.is_empty() {
             if area.height >= 3 {
                 let placeholder = Line::from(Span::styled(
                     format!(
@@ -366,7 +360,7 @@ impl ScenerySystemWidget<'_> {
                 Paragraph::new(placeholder).render(
                     Rect {
                         x: area.x,
-                        y: area.y + 2, // Skip row 1 (header) and row 2 (spacing)
+                        y: area.y + 2,
                         width: area.width,
                         height: 1,
                     },
@@ -376,30 +370,29 @@ impl ScenerySystemWidget<'_> {
             return;
         }
 
-        // Show up to 4 coalesced entries, sorted by progress (highest first = about to complete)
-        for (i, (coord, count, avg_percent)) in coalesced.iter().take(4).enumerate() {
-            let row = 2 + i as u16; // Start at row 2 (after header + spacing)
+        for (i, entry) in entries.iter().take(4).enumerate() {
+            let row = 2 + i as u16;
             if area.height <= row {
                 break;
             }
 
-            let progress_bar = Self::render_progress_bar(*avg_percent);
-            let color = Self::progress_color(*avg_percent);
+            let percent = entry.progress_percent();
+            let progress_bar = Self::render_progress_bar(percent);
+            let color = Self::progress_color(percent);
 
-            // Format: "140E,35S ████░░ 50%" or "140E,35S(3) ██░░ 25%" if multiple tiles
-            let coord_display = if *count > 1 {
-                format!("{}({})", coord, count)
-            } else {
-                coord.clone()
-            };
+            // Format: "15E,48N  ████░░ 12/45  27%"
+            let fraction = format!("{}/{}", entry.tiles_completed, entry.tiles_total);
 
             let line = Line::from(vec![
                 Span::styled(
-                    format!(" {:<11}", coord_display),
+                    format!(" {:<9}", entry.format_coordinate()),
                     Style::default().fg(Color::White),
                 ),
                 Span::styled(progress_bar, Style::default().fg(color)),
-                Span::styled(format!(" {:>3}%", avg_percent), Style::default().fg(color)),
+                Span::styled(
+                    format!(" {:>5} {:>3}%", fraction, percent),
+                    Style::default().fg(color),
+                ),
             ]);
 
             Paragraph::new(line).render(
@@ -412,37 +405,6 @@ impl ScenerySystemWidget<'_> {
                 buf,
             );
         }
-    }
-
-    /// Coalesce tile entries by 1-degree coordinate.
-    ///
-    /// Groups tiles that share the same formatted coordinate (e.g., "140E,35S")
-    /// and returns (coord, count, avg_progress) sorted by progress descending.
-    fn coalesce_entries(entries: &[TileProgressEntry]) -> Vec<(String, usize, u8)> {
-        use std::collections::HashMap;
-
-        // Group by formatted coordinate
-        let mut groups: HashMap<String, Vec<u8>> = HashMap::new();
-        for entry in entries {
-            let coord = entry.format_coordinate();
-            let percent = entry.progress_percent();
-            groups.entry(coord).or_default().push(percent);
-        }
-
-        // Convert to (coord, count, avg_percent) and sort by progress descending
-        let mut result: Vec<_> = groups
-            .into_iter()
-            .map(|(coord, percents)| {
-                let count = percents.len();
-                let avg = percents.iter().map(|&p| p as u32).sum::<u32>() / count as u32;
-                (coord, count, avg as u8)
-            })
-            .collect();
-
-        // Sort by progress descending (highest progress = about to complete = at top)
-        result.sort_by(|a, b| b.2.cmp(&a.2));
-
-        result
     }
 
     /// Render a progress bar string.

--- a/xearthlayer/src/runtime/mod.rs
+++ b/xearthlayer/src/runtime/mod.rs
@@ -106,6 +106,6 @@ pub use health::{HealthSnapshot, HealthStatus, RuntimeHealth, SharedRuntimeHealt
 pub use orchestrator::{RuntimeConfig, XEarthLayerRuntime};
 pub use request::{DdsResponse, JobRequest, RequestOrigin};
 pub use tile_progress::{
-    SharedTileProgressTracker, TileProgressEntry, TileProgressSink, TileProgressTracker,
-    MAX_DISPLAY_ENTRIES,
+    RegionProgressEntry, SharedTileProgressTracker, TileProgressSink, TileProgressTracker,
+    MAX_DISPLAY_REGIONS,
 };

--- a/xearthlayer/src/runtime/tile_progress.rs
+++ b/xearthlayer/src/runtime/tile_progress.rs
@@ -1,164 +1,204 @@
 //! Tile progress tracking for TUI display.
 //!
-//! Tracks the progress of active DDS tile generation jobs for display
-//! in the dashboard UI. Each tile shows completion percentage based on
-//! tasks completed (DownloadChunks → BuildAndCacheDds).
+//! Tracks DDS tile generation progress aggregated by 1°×1° DSF region.
+//! The executor reports individual tile events; this module coalesces them
+//! into per-region summaries for the TUI queue display.
 //!
 //! # Architecture
 //!
 //! ```text
 //! Executor                    TileProgressTracker              TUI
 //!    │                              │                           │
-//!    │ task_started(tile)           │                           │
-//!    ├─────────────────────────────►│                           │
-//!    │                              │ add entry (0%)            │
+//!    │ tile_started(tile)           │                           │
+//!    ├─────────────────────────────►│ derive DSF region         │
+//!    │                              │ increment tiles_total     │
 //!    │                              │                           │
-//!    │ task_completed(tile, 1/2)    │                           │
-//!    ├─────────────────────────────►│                           │
-//!    │                              │ update to 50%             │
+//!    │ tile_completed(tile)         │                           │
+//!    ├─────────────────────────────►│ increment tiles_completed │
 //!    │                              │                           │
 //!    │                              │ snapshot()                │
 //!    │                              │◄────────────────────────────
-//!    │                              │ Vec<TileProgressEntry>    │
+//!    │                              │ Vec<RegionProgressEntry>  │
 //!    │                              ├────────────────────────────►
 //! ```
 
 use crate::coord::TileCoord;
-use std::collections::VecDeque;
+use crate::geo_index::DsfRegion;
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
-/// Maximum number of tile entries to keep for display.
-/// Older entries are removed when this limit is exceeded.
-pub const MAX_DISPLAY_ENTRIES: usize = 4;
+/// Maximum number of region entries to return in a snapshot.
+pub const MAX_DISPLAY_REGIONS: usize = 4;
 
-/// Progress entry for a single tile being generated.
+/// Progress entry for a DSF region (1°×1° area).
+///
+/// Aggregates progress across all tiles being generated in this region.
 #[derive(Debug, Clone, PartialEq)]
-pub struct TileProgressEntry {
-    /// Tile coordinates being generated.
-    pub tile: TileCoord,
-    /// Number of tasks completed (0, 1, or 2).
-    pub tasks_completed: u8,
-    /// Total number of tasks (always 2 for DDS generation).
-    pub tasks_total: u8,
+pub struct RegionProgressEntry {
+    /// The 1°×1° DSF region.
+    pub region: DsfRegion,
+    /// Number of tiles submitted for generation in this region.
+    pub tiles_total: u16,
+    /// Number of tiles that have completed generation.
+    pub tiles_completed: u16,
+    /// When the first tile in this region was submitted.
+    pub started_at: Instant,
 }
 
-impl TileProgressEntry {
-    /// Create a new progress entry for a tile.
-    pub fn new(tile: TileCoord) -> Self {
-        Self {
-            tile,
-            tasks_completed: 0,
-            tasks_total: 2, // DownloadChunks + BuildAndCacheDds
-        }
-    }
-
+impl RegionProgressEntry {
     /// Get progress as a percentage (0-100).
     pub fn progress_percent(&self) -> u8 {
-        if self.tasks_total == 0 {
-            return 100;
+        if self.tiles_total == 0 {
+            return 0;
         }
-        ((self.tasks_completed as u16 * 100) / self.tasks_total as u16) as u8
+        ((self.tiles_completed as u32 * 100) / self.tiles_total as u32) as u8
     }
 
-    /// Check if the tile generation is complete.
+    /// Check if all tiles in this region are complete.
     pub fn is_complete(&self) -> bool {
-        self.tasks_completed >= self.tasks_total
+        self.tiles_total > 0 && self.tiles_completed >= self.tiles_total
     }
 
-    /// Format the tile coordinate for display (e.g., "140E,35S").
+    /// Format the region coordinate for display (e.g., "15E,48N").
     pub fn format_coordinate(&self) -> String {
-        let (lat, lon) = self.tile.to_lat_lon();
-        let lat_dir = if lat >= 0.0 { "N" } else { "S" };
-        let lon_dir = if lon >= 0.0 { "E" } else { "W" };
-        format!(
-            "{:.0}{},{}{}",
-            lon.abs(),
-            lon_dir,
-            lat.abs().floor(),
-            lat_dir
-        )
+        let lat = self.region.lat;
+        let lon = self.region.lon;
+        let lat_dir = if lat >= 0 { "N" } else { "S" };
+        let lon_dir = if lon >= 0 { "E" } else { "W" };
+        format!("{}{},{}{}", lon.abs(), lon_dir, lat.abs(), lat_dir)
     }
 }
 
-/// Thread-safe tracker for active tile generation progress.
+/// Internal tracking state for a single region.
+#[derive(Debug, Clone)]
+struct RegionState {
+    tiles_total: u16,
+    tiles_completed: u16,
+    /// Per-tile task counters (tasks_completed out of 2).
+    /// Tracks individual tiles so we know when a tile finishes.
+    tile_tasks: HashMap<TileCoord, u8>,
+    started_at: Instant,
+}
+
+/// Thread-safe tracker for tile generation progress, aggregated by DSF region.
 ///
-/// Maintains a bounded queue of recent tile progress entries for TUI display.
-/// Entries are added when tile generation starts and removed when complete
-/// or when the queue exceeds [`MAX_DISPLAY_ENTRIES`].
+/// Individual tile events are rolled up into per-region summaries.
+/// Completed regions are automatically removed.
 #[derive(Debug, Default)]
 pub struct TileProgressTracker {
-    /// Active tile progress entries (most recent first).
-    entries: RwLock<VecDeque<TileProgressEntry>>,
+    regions: RwLock<HashMap<DsfRegion, RegionState>>,
 }
 
 impl TileProgressTracker {
     /// Create a new tile progress tracker.
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
-            entries: RwLock::new(VecDeque::with_capacity(MAX_DISPLAY_ENTRIES + 1)),
+            regions: RwLock::new(HashMap::new()),
         })
     }
 
-    /// Start tracking a new tile.
+    /// Record that a tile has started generation.
     ///
-    /// Adds the tile to the front of the queue. If the queue exceeds
-    /// [`MAX_DISPLAY_ENTRIES`], the oldest entry is removed.
+    /// Derives the DSF region from the tile coordinate and increments
+    /// the region's total tile count.
     pub fn tile_started(&self, tile: TileCoord) {
-        let mut entries = self.entries.write().unwrap();
+        let (lat, lon) = tile.to_lat_lon();
+        let region = DsfRegion::from_lat_lon(lat, lon);
 
-        // Check if tile is already being tracked
-        if entries.iter().any(|e| e.tile == tile) {
-            return;
-        }
+        let mut regions = self.regions.write().unwrap();
+        let state = regions.entry(region).or_insert_with(|| RegionState {
+            tiles_total: 0,
+            tiles_completed: 0,
+            tile_tasks: HashMap::new(),
+            started_at: Instant::now(),
+        });
 
-        // Add to front (most recent first)
-        entries.push_front(TileProgressEntry::new(tile));
-
-        // Trim to max size
-        while entries.len() > MAX_DISPLAY_ENTRIES {
-            entries.pop_back();
+        // Only count if this tile hasn't been seen before
+        if !state.tile_tasks.contains_key(&tile) {
+            state.tiles_total += 1;
+            state.tile_tasks.insert(tile, 0);
         }
     }
 
-    /// Update progress for a tile (task completed).
+    /// Record that a task completed for a tile.
     ///
-    /// Increments the tasks_completed counter for the specified tile.
-    /// If the tile reaches 100% completion, it is removed from tracking.
+    /// Each tile has 2 tasks (DownloadChunks + BuildAndCacheDds).
+    /// When both tasks complete, the tile is marked as completed
+    /// in its region's counter.
     pub fn task_completed(&self, tile: TileCoord) {
-        let mut entries = self.entries.write().unwrap();
+        let (lat, lon) = tile.to_lat_lon();
+        let region = DsfRegion::from_lat_lon(lat, lon);
 
-        if let Some(entry) = entries.iter_mut().find(|e| e.tile == tile) {
-            entry.tasks_completed += 1;
+        let mut regions = self.regions.write().unwrap();
+        if let Some(state) = regions.get_mut(&region) {
+            if let Some(tasks) = state.tile_tasks.get_mut(&tile) {
+                *tasks += 1;
+                if *tasks >= 2 {
+                    // Tile is done — increment region completed count
+                    state.tiles_completed += 1;
+                    state.tile_tasks.remove(&tile);
+                }
+            }
 
-            // Remove completed entries
-            if entry.is_complete() {
-                entries.retain(|e| e.tile != tile);
+            // Remove region if fully complete
+            if state.tiles_completed >= state.tiles_total && state.tile_tasks.is_empty() {
+                regions.remove(&region);
             }
         }
     }
 
-    /// Mark a tile as failed/cancelled (remove from tracking).
+    /// Mark a tile as failed (remove from tracking without counting as completed).
     pub fn tile_failed(&self, tile: TileCoord) {
-        let mut entries = self.entries.write().unwrap();
-        entries.retain(|e| e.tile != tile);
+        let (lat, lon) = tile.to_lat_lon();
+        let region = DsfRegion::from_lat_lon(lat, lon);
+
+        let mut regions = self.regions.write().unwrap();
+        if let Some(state) = regions.get_mut(&region) {
+            if state.tile_tasks.remove(&tile).is_some() {
+                // Reduce total since this tile won't complete
+                state.tiles_total = state.tiles_total.saturating_sub(1);
+            }
+
+            // Remove region if nothing left
+            if state.tiles_total == 0
+                || (state.tiles_completed >= state.tiles_total && state.tile_tasks.is_empty())
+            {
+                regions.remove(&region);
+            }
+        }
     }
 
-    /// Get a snapshot of current progress entries for display.
+    /// Get a snapshot of current region progress for display.
     ///
-    /// Returns entries ordered by most recent first.
-    pub fn snapshot(&self) -> Vec<TileProgressEntry> {
-        let entries = self.entries.read().unwrap();
-        entries.iter().cloned().collect()
+    /// Returns up to [`MAX_DISPLAY_REGIONS`] entries, sorted by
+    /// most recently started first.
+    pub fn snapshot(&self) -> Vec<RegionProgressEntry> {
+        let regions = self.regions.read().unwrap();
+        let mut entries: Vec<RegionProgressEntry> = regions
+            .iter()
+            .map(|(region, state)| RegionProgressEntry {
+                region: *region,
+                tiles_total: state.tiles_total,
+                tiles_completed: state.tiles_completed,
+                started_at: state.started_at,
+            })
+            .collect();
+
+        // Sort by most recently started first
+        entries.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        entries.truncate(MAX_DISPLAY_REGIONS);
+        entries
     }
 
-    /// Get the number of tiles currently being tracked.
+    /// Get the number of regions currently being tracked.
     pub fn active_count(&self) -> usize {
-        self.entries.read().unwrap().len()
+        self.regions.read().unwrap().len()
     }
 
     /// Clear all tracked entries.
     pub fn clear(&self) {
-        self.entries.write().unwrap().clear();
+        self.regions.write().unwrap().clear();
     }
 }
 
@@ -173,8 +213,8 @@ use crate::executor::{TelemetryEvent, TelemetrySink};
 
 /// Telemetry sink that updates the tile progress tracker.
 ///
-/// This sink listens for job/task events and updates the progress tracker
-/// for DDS generation jobs. It extracts tile coordinates from the job ID
+/// Listens for job/task events and updates the progress tracker
+/// for DDS generation jobs. Extracts tile coordinates from the job ID
 /// format: `dds-{row}_{col}_ZL{zoom}`.
 #[derive(Debug)]
 pub struct TileProgressSink {
@@ -190,7 +230,6 @@ impl TileProgressSink {
     /// Parse tile coordinates from a DDS job ID.
     ///
     /// Job ID format: `dds-{row}_{col}_ZL{zoom}`
-    /// Returns (row, col, zoom) if parsing succeeds.
     fn parse_dds_job_id(job_id: &str) -> Option<TileCoord> {
         if !job_id.starts_with("dds-") {
             return None;
@@ -204,7 +243,6 @@ impl TileProgressSink {
         let row: u32 = parts[0].parse().ok()?;
         let col: u32 = parts[1].parse().ok()?;
 
-        // Parse zoom from "ZL{zoom}"
         let zoom_str = parts[2].strip_prefix("ZL")?;
         let zoom: u8 = zoom_str.parse().ok()?;
 
@@ -227,14 +265,12 @@ impl TelemetrySink for TileProgressSink {
             }
             TelemetryEvent::JobCompleted { job_id, status, .. } => {
                 if let Some(tile) = Self::parse_dds_job_id(job_id.as_str()) {
-                    // Remove from tracker if job failed or was cancelled
                     if status != crate::executor::JobStatus::Succeeded {
                         self.tracker.tile_failed(tile);
                     }
-                    // Successful completions are auto-removed when tasks_completed reaches 2
                 }
             }
-            _ => {} // Ignore other events
+            _ => {}
         }
     }
 }
@@ -244,74 +280,93 @@ mod tests {
     use super::*;
 
     fn test_tile(row: u32, col: u32) -> TileCoord {
-        TileCoord { row, col, zoom: 16 }
+        TileCoord { row, col, zoom: 12 }
+    }
+
+    /// Create two tiles that map to the same DSF region.
+    fn tiles_in_same_region() -> (TileCoord, TileCoord) {
+        // At zoom 12, tiles are ~0.088° wide. Two adjacent tiles
+        // in the same 1° region:
+        let t1 = TileCoord {
+            row: 1500,
+            col: 2200,
+            zoom: 12,
+        };
+        let t2 = TileCoord {
+            row: 1500,
+            col: 2201,
+            zoom: 12,
+        };
+
+        // Verify they're in the same DSF region
+        let (lat1, lon1) = t1.to_lat_lon();
+        let (lat2, lon2) = t2.to_lat_lon();
+        assert_eq!(lat1.floor() as i32, lat2.floor() as i32);
+        assert_eq!(lon1.floor() as i32, lon2.floor() as i32);
+
+        (t1, t2)
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // TileProgressEntry tests
+    // RegionProgressEntry tests
     // ─────────────────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_entry_new() {
-        let tile = test_tile(100, 200);
-        let entry = TileProgressEntry::new(tile);
-
-        assert_eq!(entry.tile, tile);
-        assert_eq!(entry.tasks_completed, 0);
-        assert_eq!(entry.tasks_total, 2);
-    }
 
     #[test]
     fn test_entry_progress_percent() {
-        let tile = test_tile(100, 200);
-        let mut entry = TileProgressEntry::new(tile);
+        let entry = RegionProgressEntry {
+            region: DsfRegion::new(48, 15),
+            tiles_total: 10,
+            tiles_completed: 3,
+            started_at: Instant::now(),
+        };
+        assert_eq!(entry.progress_percent(), 30);
+    }
 
+    #[test]
+    fn test_entry_progress_percent_zero_total() {
+        let entry = RegionProgressEntry {
+            region: DsfRegion::new(48, 15),
+            tiles_total: 0,
+            tiles_completed: 0,
+            started_at: Instant::now(),
+        };
         assert_eq!(entry.progress_percent(), 0);
-
-        entry.tasks_completed = 1;
-        assert_eq!(entry.progress_percent(), 50);
-
-        entry.tasks_completed = 2;
-        assert_eq!(entry.progress_percent(), 100);
     }
 
     #[test]
     fn test_entry_is_complete() {
-        let tile = test_tile(100, 200);
-        let mut entry = TileProgressEntry::new(tile);
-
+        let mut entry = RegionProgressEntry {
+            region: DsfRegion::new(48, 15),
+            tiles_total: 5,
+            tiles_completed: 4,
+            started_at: Instant::now(),
+        };
         assert!(!entry.is_complete());
 
-        entry.tasks_completed = 1;
-        assert!(!entry.is_complete());
-
-        entry.tasks_completed = 2;
+        entry.tiles_completed = 5;
         assert!(entry.is_complete());
     }
 
     #[test]
     fn test_entry_format_coordinate() {
-        // Test tile at approximately 140E, 35S (Sydney area)
-        // Row/col calculation is complex, so we test the format logic
-        let tile = TileCoord {
-            row: 39000,
-            col: 59000,
-            zoom: 16,
+        let entry = RegionProgressEntry {
+            region: DsfRegion::new(48, 15),
+            tiles_total: 1,
+            tiles_completed: 0,
+            started_at: Instant::now(),
         };
-        let entry = TileProgressEntry::new(tile);
-        let formatted = entry.format_coordinate();
+        assert_eq!(entry.format_coordinate(), "15E,48N");
+    }
 
-        // Should contain cardinal directions
-        assert!(
-            formatted.contains('E') || formatted.contains('W'),
-            "Should have E/W: {}",
-            formatted
-        );
-        assert!(
-            formatted.contains('N') || formatted.contains('S'),
-            "Should have N/S: {}",
-            formatted
-        );
+    #[test]
+    fn test_entry_format_coordinate_negative() {
+        let entry = RegionProgressEntry {
+            region: DsfRegion::new(-34, 151),
+            tiles_total: 1,
+            tiles_completed: 0,
+            started_at: Instant::now(),
+        };
+        assert_eq!(entry.format_coordinate(), "151E,34S");
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -325,17 +380,33 @@ mod tests {
     }
 
     #[test]
-    fn test_tracker_tile_started() {
+    fn test_tracker_tile_started_creates_region() {
         let tracker = TileProgressTracker::new();
         let tile = test_tile(100, 200);
 
         tracker.tile_started(tile);
 
         assert_eq!(tracker.active_count(), 1);
-        let snapshot = tracker.snapshot();
-        assert_eq!(snapshot.len(), 1);
-        assert_eq!(snapshot[0].tile, tile);
-        assert_eq!(snapshot[0].progress_percent(), 0);
+        let snap = tracker.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].tiles_total, 1);
+        assert_eq!(snap[0].tiles_completed, 0);
+        assert_eq!(snap[0].progress_percent(), 0);
+    }
+
+    #[test]
+    fn test_tracker_same_region_coalesces() {
+        let tracker = TileProgressTracker::new();
+        let (t1, t2) = tiles_in_same_region();
+
+        tracker.tile_started(t1);
+        tracker.tile_started(t2);
+
+        // Should be ONE region with 2 tiles
+        assert_eq!(tracker.active_count(), 1);
+        let snap = tracker.snapshot();
+        assert_eq!(snap[0].tiles_total, 2);
+        assert_eq!(snap[0].tiles_completed, 0);
     }
 
     #[test]
@@ -344,38 +415,84 @@ mod tests {
         let tile = test_tile(100, 200);
 
         tracker.tile_started(tile);
-        tracker.tile_started(tile); // Duplicate
+        tracker.tile_started(tile); // duplicate
 
-        assert_eq!(tracker.active_count(), 1);
+        let snap = tracker.snapshot();
+        assert_eq!(snap[0].tiles_total, 1);
     }
 
     #[test]
-    fn test_tracker_task_completed() {
+    fn test_tracker_tile_completes_after_two_tasks() {
+        let tracker = TileProgressTracker::new();
+        let (t1, t2) = tiles_in_same_region();
+
+        tracker.tile_started(t1);
+        tracker.tile_started(t2);
+
+        // Complete first tile (2 tasks)
+        tracker.task_completed(t1);
+        tracker.task_completed(t1);
+
+        let snap = tracker.snapshot();
+        assert_eq!(snap[0].tiles_total, 2);
+        assert_eq!(snap[0].tiles_completed, 1);
+        assert_eq!(snap[0].progress_percent(), 50);
+    }
+
+    #[test]
+    fn test_tracker_region_auto_removed_when_complete() {
         let tracker = TileProgressTracker::new();
         let tile = test_tile(100, 200);
 
         tracker.tile_started(tile);
-        tracker.task_completed(tile);
-
-        let snapshot = tracker.snapshot();
-        assert_eq!(snapshot.len(), 1);
-        assert_eq!(snapshot[0].progress_percent(), 50);
-    }
-
-    #[test]
-    fn test_tracker_tile_auto_removed_on_complete() {
-        let tracker = TileProgressTracker::new();
-        let tile = test_tile(100, 200);
-
-        tracker.tile_started(tile);
-        tracker.task_completed(tile); // 50%
-        tracker.task_completed(tile); // 100% - should be removed
+        tracker.task_completed(tile); // task 1/2
+        tracker.task_completed(tile); // task 2/2 — tile done, region complete
 
         assert_eq!(tracker.active_count(), 0);
     }
 
     #[test]
+    fn test_tracker_region_stays_until_all_tiles_complete() {
+        let tracker = TileProgressTracker::new();
+        let (t1, t2) = tiles_in_same_region();
+
+        tracker.tile_started(t1);
+        tracker.tile_started(t2);
+
+        // Complete t1 fully
+        tracker.task_completed(t1);
+        tracker.task_completed(t1);
+
+        // Region still active (t2 pending)
+        assert_eq!(tracker.active_count(), 1);
+        let snap = tracker.snapshot();
+        assert_eq!(snap[0].tiles_completed, 1);
+        assert_eq!(snap[0].tiles_total, 2);
+
+        // Complete t2
+        tracker.task_completed(t2);
+        tracker.task_completed(t2);
+
+        // Region removed
+        assert_eq!(tracker.active_count(), 0);
+    }
+
+    #[test]
     fn test_tracker_tile_failed() {
+        let tracker = TileProgressTracker::new();
+        let (t1, t2) = tiles_in_same_region();
+
+        tracker.tile_started(t1);
+        tracker.tile_started(t2);
+
+        tracker.tile_failed(t1);
+
+        let snap = tracker.snapshot();
+        assert_eq!(snap[0].tiles_total, 1); // reduced from 2
+    }
+
+    #[test]
+    fn test_tracker_tile_failed_removes_empty_region() {
         let tracker = TileProgressTracker::new();
         let tile = test_tile(100, 200);
 
@@ -386,31 +503,22 @@ mod tests {
     }
 
     #[test]
-    fn test_tracker_max_entries() {
+    fn test_tracker_snapshot_capped_at_max() {
         let tracker = TileProgressTracker::new();
 
-        // Add more tiles than MAX_DISPLAY_ENTRIES
-        for i in 0..(MAX_DISPLAY_ENTRIES + 3) {
-            tracker.tile_started(test_tile(i as u32, 0));
+        // Create tiles in distinct DSF regions
+        for i in 0..(MAX_DISPLAY_REGIONS + 3) {
+            // Use zoom 1 so each tile covers a large area → different DSF regions
+            let tile = TileCoord {
+                row: i as u32,
+                col: 0,
+                zoom: 1,
+            };
+            tracker.tile_started(tile);
         }
 
-        // Should be capped at MAX_DISPLAY_ENTRIES
-        assert_eq!(tracker.active_count(), MAX_DISPLAY_ENTRIES);
-    }
-
-    #[test]
-    fn test_tracker_most_recent_first() {
-        let tracker = TileProgressTracker::new();
-
-        tracker.tile_started(test_tile(1, 0));
-        tracker.tile_started(test_tile(2, 0));
-        tracker.tile_started(test_tile(3, 0));
-
-        let snapshot = tracker.snapshot();
-        // Most recently added should be first
-        assert_eq!(snapshot[0].tile.row, 3);
-        assert_eq!(snapshot[1].tile.row, 2);
-        assert_eq!(snapshot[2].tile.row, 1);
+        let snap = tracker.snapshot();
+        assert!(snap.len() <= MAX_DISPLAY_REGIONS);
     }
 
     #[test]
@@ -422,23 +530,6 @@ mod tests {
         tracker.clear();
 
         assert_eq!(tracker.active_count(), 0);
-    }
-
-    #[test]
-    fn test_tracker_snapshot_is_independent() {
-        let tracker = TileProgressTracker::new();
-        let tile = test_tile(100, 200);
-
-        tracker.tile_started(tile);
-        let snapshot1 = tracker.snapshot();
-
-        // Modify tracker after snapshot
-        tracker.task_completed(tile);
-        let snapshot2 = tracker.snapshot();
-
-        // Snapshots should be independent
-        assert_eq!(snapshot1[0].progress_percent(), 0);
-        assert_eq!(snapshot2[0].progress_percent(), 50);
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -458,15 +549,13 @@ mod tests {
     #[test]
     fn test_parse_dds_job_id_invalid_prefix() {
         assert!(TileProgressSink::parse_dds_job_id("prefetch-100_200_ZL16").is_none());
-        assert!(TileProgressSink::parse_dds_job_id("xyz-100_200_ZL16").is_none());
     }
 
     #[test]
     fn test_parse_dds_job_id_invalid_format() {
-        assert!(TileProgressSink::parse_dds_job_id("dds-100_200").is_none()); // Missing zoom
-        assert!(TileProgressSink::parse_dds_job_id("dds-100").is_none()); // Missing parts
+        assert!(TileProgressSink::parse_dds_job_id("dds-100_200").is_none());
+        assert!(TileProgressSink::parse_dds_job_id("dds-100").is_none());
         assert!(TileProgressSink::parse_dds_job_id("dds-abc_200_ZL16").is_none());
-        // Non-numeric
     }
 
     #[test]
@@ -481,9 +570,6 @@ mod tests {
         });
 
         assert_eq!(tracker.active_count(), 1);
-        let snapshot = tracker.snapshot();
-        assert_eq!(snapshot[0].tile.row, 100);
-        assert_eq!(snapshot[0].tile.col, 200);
     }
 
     #[test]
@@ -495,12 +581,10 @@ mod tests {
         let tracker = TileProgressTracker::new();
         let sink = TileProgressSink::new(Arc::clone(&tracker));
 
-        // Start job
         sink.emit(TelemetryEvent::JobStarted {
             job_id: JobId::new("dds-100_200_ZL16"),
         });
 
-        // Complete first task
         sink.emit(TelemetryEvent::TaskCompleted {
             job_id: JobId::new("dds-100_200_ZL16"),
             task_name: "DownloadChunks".to_string(),
@@ -508,8 +592,8 @@ mod tests {
             duration: Duration::from_millis(100),
         });
 
-        let snapshot = tracker.snapshot();
-        assert_eq!(snapshot[0].progress_percent(), 50);
+        // Still active (only 1/2 tasks done for this tile)
+        assert_eq!(tracker.active_count(), 1);
     }
 
     #[test]
@@ -520,13 +604,10 @@ mod tests {
         let tracker = TileProgressTracker::new();
         let sink = TileProgressSink::new(Arc::clone(&tracker));
 
-        // Start job
         sink.emit(TelemetryEvent::JobStarted {
             job_id: JobId::new("dds-100_200_ZL16"),
         });
-        assert_eq!(tracker.active_count(), 1);
 
-        // Job fails
         sink.emit(TelemetryEvent::JobCompleted {
             job_id: JobId::new("dds-100_200_ZL16"),
             status: JobStatus::Failed,
@@ -537,7 +618,6 @@ mod tests {
             children_failed: 0,
         });
 
-        // Should be removed
         assert_eq!(tracker.active_count(), 0);
     }
 
@@ -552,7 +632,6 @@ mod tests {
             job_id: JobId::new("prefetch-47.60_-122.33_ZL14_r5"),
         });
 
-        // Prefetch jobs should be ignored
         assert_eq!(tracker.active_count(), 0);
     }
 }


### PR DESCRIPTION
Fixes #104

## Summary

- Restructured `TileProgressTracker` to aggregate at the 1°×1° DSF region level instead of tracking individual DDS tiles
- Each queue row now shows one DSF region with completed/total tile counts and overall percentage
- Removed renderer-side `coalesce_entries()` — coalescing now happens at the data layer

## Before / After

**Before:** 4 individual tile entries, often repeated from the same region
```
        QUEUE
1305,235 ██░░░░░░░░  0%
1305,231 ████░░░░░░ 50%
1305,168 ██░░░░░░░░  0%
1305,235 ████████░░ 50%
```

**After:** 1 row per DSF region with aggregate progress
```
        QUEUE
15E,48N  ████░░░░░░ 12/45  27%
15E,49N  ██░░░░░░░░  3/38   8%
16E,48N  ░░░░░░░░░░  0/42   0%
```

## Changes

| File | What |
|------|------|
| `runtime/tile_progress.rs` | `TileProgressEntry` → `RegionProgressEntry`, tracker uses `HashMap<DsfRegion, RegionState>` |
| `runtime/mod.rs` | Updated re-exports |
| `ui/widgets/scenery_system.rs` | Simplified renderer, removed `coalesce_entries()` |
| `ui/dashboard/render.rs` | Updated type references |

## Test plan

- [x] 23 tile_progress tests pass (rewritten for region-level semantics)
- [x] All 2,235 tests pass
- [x] No clippy warnings
- [ ] CI passes
- [ ] Visual verification during flight test

🤖 Generated with [Claude Code](https://claude.com/claude-code)