### PR TITLE
chore: update version.json to 0.4.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.3.1",
-  "tag": "v0.3.1",
-  "release_date": "2026-03-13",
+  "version": "0.4.0",
+  "tag": "v0.4.0",
+  "release_date": "2026-03-21",
   "homepage": "https://xearthlayer.app",
   "assets": {
     "deb": {
-      "filename": "xearthlayer_0.3.1-1_amd64.deb",
+      "filename": "xearthlayer_0.4.0-1_amd64.deb",
       "description": "Debian/Ubuntu package"
     },
     "rpm": {
-      "filename": "xearthlayer-0.3.1-1.fc43.x86_64.rpm",
+      "filename": "xearthlayer-0.4.0-1.fc43.x86_64.rpm",
       "description": "Fedora/RHEL package"
     },
     "tarball": {
-      "filename": "xearthlayer-v0.3.1-x86_64-linux.tar.gz",
+      "filename": "xearthlayer-v0.4.0-x86_64-linux.tar.gz",
       "description": "Linux binary tarball"
     },
     "aur": {
@@ -21,13 +21,13 @@
       "description": "Arch Linux AUR package"
     },
     "tarball-gpu": {
-      "filename": "xearthlayer-gpu-v0.3.1-x86_64-linux.tar.gz",
+      "filename": "xearthlayer-gpu-v0.4.0-x86_64-linux.tar.gz",
       "description": "Linux binary tarball (GPU encoding)"
     },
     "deb-gpu": {
-      "filename": "xearthlayer_0.3.1-1_amd64-gpu.deb",
+      "filename": "xearthlayer_0.4.0-1_amd64-gpu.deb",
       "description": "Debian/Ubuntu package (GPU encoding)"
     }
   },
-  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.3.1"
+  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.0"
 }


### PR DESCRIPTION
Manual version.json update — the release workflow's API update was blocked by branch protection rules.