### PR TITLE
fix(config): default temp dir to ~/.xearthlayer/tmp

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -493,7 +493,7 @@ Controls package manager behavior.
 | `install_location` | path | `~/.xearthlayer/packages` | Directory for storing installed packages |
 | `custom_scenery_path` | path | (auto-detect) | X-Plane Custom Scenery directory for overlay symlinks |
 | `auto_install_overlays` | bool | `false` | Automatically install matching overlay when installing ortho |
-| `temp_dir` | path | system temp | Temporary directory for package downloads |
+| `temp_dir` | path | `~/.xearthlayer/tmp` | Temporary directory for package downloads |
 | `concurrent_downloads` | Integer | `5` | Number of concurrent part downloads (1-10) |
 
 **Example:**
@@ -508,7 +508,7 @@ temp_dir = ~/Downloads/xearthlayer-temp
 
 **Notes:**
 - The default `library_url` points to the official XEarthLayer package library; override only if using a custom package source
-- The `temp_dir` is used for downloading archives before extraction; files are cleaned up after installation
+- The `temp_dir` is used for downloading archives before extraction; files are cleaned up after installation. The default avoids the system temp directory which is often RAM-backed (tmpfs) on Linux
 - When `auto_install_overlays` is enabled, installing an ortho package will automatically install the matching overlay package for the same region (if available)
 - If `custom_scenery_path` is not set, it falls back to `[xplane] scenery_dir` or auto-detects from X-Plane installation
 

--- a/xearthlayer-cli/src/commands/packages/mod.rs
+++ b/xearthlayer-cli/src/commands/packages/mod.rs
@@ -28,7 +28,6 @@ pub use handlers::{
 pub use services::{ConsoleInteraction, ConsoleOutput, DefaultPackageManagerService};
 pub use traits::CommandHandler;
 
-use std::env;
 use std::path::PathBuf;
 
 use args::{CheckArgs, InfoArgs, InstallArgs, ListArgs, RemoveArgs, UpdateArgs};
@@ -77,13 +76,15 @@ fn default_custom_scenery_dir(config: &ConfigFile) -> Option<PathBuf> {
 /// Get the default temporary directory.
 ///
 /// Uses the config file's packages.temp_dir if available, otherwise falls back to
-/// system temp directory.
+/// `~/.xearthlayer/tmp`. This avoids using the system temp directory which on many
+/// Linux distributions is a tmpfs (RAM-backed), causing OOM when downloading large
+/// scenery packages.
 fn default_temp_dir(config: &ConfigFile) -> PathBuf {
     config
         .packages
         .temp_dir
         .clone()
-        .unwrap_or_else(|| env::temp_dir().join("xearthlayer"))
+        .unwrap_or_else(|| xearthlayer::config::config_directory().join("tmp"))
 }
 
 /// Get the default library URL from config.

--- a/xearthlayer/src/config/settings.rs
+++ b/xearthlayer/src/config/settings.rs
@@ -147,7 +147,7 @@ pub struct PackagesSettings {
     pub custom_scenery_path: Option<PathBuf>,
     /// Automatically install overlay packages when installing ortho for same region.
     pub auto_install_overlays: bool,
-    /// Temporary directory for downloads (default: system temp dir).
+    /// Temporary directory for downloads (default: ~/.xearthlayer/tmp).
     pub temp_dir: Option<PathBuf>,
     /// Number of concurrent part downloads (1-10, default: 5).
     pub concurrent_downloads: usize,

--- a/xearthlayer/src/config/writer.rs
+++ b/xearthlayer/src/config/writer.rs
@@ -147,7 +147,7 @@ install_location = {}
 custom_scenery_path = {}
 ; Automatically install overlay packages when installing ortho for same region
 auto_install_overlays = {}
-; Temporary directory for package downloads (default: system temp dir)
+; Temporary directory for package downloads (default: ~/.xearthlayer/tmp)
 ; Large packages are downloaded here before extraction
 temp_dir = {}
 ; Number of concurrent part downloads (1-10, default: 5)

--- a/xearthlayer/src/manager/config.rs
+++ b/xearthlayer/src/manager/config.rs
@@ -36,7 +36,7 @@ impl Default for ManagerConfig {
     fn default() -> Self {
         Self {
             install_dir: PathBuf::from("."),
-            staging_dir: std::env::temp_dir().join("xearthlayer-staging"),
+            staging_dir: crate::config::config_directory().join("tmp"),
             library_urls: Vec::new(),
             timeout: Duration::from_secs(30),
             max_concurrent_downloads: 4,


### PR DESCRIPTION
## Summary
- Default temp directory for package downloads changed from system temp (`/tmp`) to `~/.xearthlayer/tmp`
- On many Linux distros `/tmp` is a `tmpfs` (RAM-backed), causing OOM errors when downloading multi-GB scenery packages
- Updated both CLI `default_temp_dir()` and `ManagerConfig::default()` staging dir
- Updated docs and config comments to reflect the new default

Fixes #118

## Test plan
- [x] `make pre-commit` passes (fmt + clippy + all tests)
- [x] Install a package on a system with tmpfs `/tmp` — verify downloads go to `~/.xearthlayer/tmp`
- [x] Verify `packages.temp_dir` config override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)