### PR TITLE
feat(update): version update check with TUI notification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
     - `dds_tile_exists(row, col, zoom)` - Checks if DDS tile exists on disk (used by prefetch)
     - `resolve_lazy_filtered(path, predicate)` - Source-filtered lazy resolution (used by FUSE with GeoIndex)
 
-14. **GeoIndex** (`xearthlayer/src/geo_index/`)
+15. **Version Update Checker** (`xearthlayer/src/update/`)
+    - `VersionManifest` - Serde model for remote `version.json`
+    - `UpdateInfo` - Update notification data (current version, latest version, homepage)
+    - `UpdateChecker` trait - Abstraction for version checking (dependency injection)
+    - `RemoteUpdateChecker` - Production implementation with HTTP fetch and 24h disk cache
+    - Non-blocking: spawned on Tokio runtime, never delays startup
+    - Cache at `~/.xearthlayer/version_check.json` (mtime-based 24h expiry)
+    - TUI dashboard shows persistent footer when update available
+    - Configurable via `general.update_check` (default: true)
+
+16. **GeoIndex** (`xearthlayer/src/geo_index/`)
     - `GeoIndex` - Type-keyed, region-indexed geospatial reference database (thread-safe, ACID)
     - `DsfRegion` - 1°×1° DSF region coordinate type
     - `GeoLayer` trait - Marker trait for storable layer types (`Clone + Send + Sync + 'static`)
@@ -308,6 +318,8 @@ xearthlayer publish gaps --region <code> [--tile <lat,lon>] [--format <fmt>] [-o
 | `xearthlayer/src/ortho_union/` | Ortho union index module |
 | `xearthlayer/src/ortho_union/index.rs` | OrthoUnionIndex implementation |
 | `xearthlayer/src/ortho_union/builder.rs` | OrthoUnionIndexBuilder (with progress + caching) |
+| `xearthlayer/src/update/mod.rs` | Version update checking (VersionManifest, UpdateInfo) |
+| `xearthlayer/src/update/checker.rs` | UpdateChecker trait and RemoteUpdateChecker |
 | `xearthlayer/src/config/file.rs` | Configuration loading |
 | `xearthlayer/src/config/keys.rs` | ConfigKey enum with validation (Specification Pattern) |
 | `xearthlayer/src/publisher/` | Package publisher library |
@@ -332,6 +344,7 @@ xearthlayer publish gaps --region <code> [--tile <lat,lon>] [--format <fmt>] [-o
 Default config location: `~/.xearthlayer/config.ini`
 
 Key sections:
+- `[general]` - General settings (update_check)
 - `[provider]` - Imagery source (bing/google)
 - `[cache]` - Memory/disk sizes, directory, disk I/O profile (auto/hdd/ssd/nvme)
 - `[generation]` - Thread count, timeout

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,14 @@ For best results, set the cache directory to a fast NVMe or SSD that you can fil
 
 ## Sections
 
+### [general]
+
+General application settings.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `update_check` | boolean | `true` | Check for new versions on startup. Performs a single HTTP request once per day (cached locally). No telemetry is sent. |
+
 ### [provider]
 
 Controls which satellite imagery provider to use.

--- a/xearthlayer-cli/src/commands/run.rs
+++ b/xearthlayer-cli/src/commands/run.rs
@@ -327,7 +327,7 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
         run_tui(tui_config)?
     } else {
         // Fallback to simple text output for non-TTY
-        run_headless(&mut orchestrator, shutdown)?;
+        run_headless(&mut orchestrator, shutdown, config.general.update_check)?;
         orchestrator.cancellation()
     };
 

--- a/xearthlayer-cli/src/tui_app.rs
+++ b/xearthlayer-cli/src/tui_app.rs
@@ -25,6 +25,7 @@ use xearthlayer::config::ConfigFile;
 use xearthlayer::manager::{InstalledPackage, LocalPackageStore};
 use xearthlayer::prefetch::{PrewarmHandle, SharedPrefetchStatus};
 use xearthlayer::service::{PrewarmOrchestrator, ServiceOrchestrator, StartupProgress};
+use xearthlayer::update::{RemoteUpdateChecker, UpdateChecker, UpdateInfo};
 use xearthlayer::xplane::XPlaneEnvironment;
 
 use crate::error::CliError;
@@ -173,6 +174,27 @@ pub fn run_tui(config: TuiAppConfig) -> Result<CancellationToken, CliError> {
         .runtime_handle()
         .expect("Runtime handle should be available after initialization");
 
+    // Spawn background update check (non-blocking, once per day via disk cache)
+    let update_rx = if cfg.general.update_check {
+        let (tx, rx) = std::sync::mpsc::channel::<Option<UpdateInfo>>();
+        let current_version = xearthlayer::VERSION.to_string();
+        runtime_handle.spawn_blocking(move || {
+            let checker = RemoteUpdateChecker::new();
+            match checker.check(&current_version) {
+                Ok(info) => {
+                    let _ = tx.send(info);
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "Update check failed (non-fatal)");
+                    let _ = tx.send(None);
+                }
+            }
+        });
+        Some(rx)
+    } else {
+        None
+    };
+
     // Track prewarm handle (None when not active or complete)
     let mut prewarm_handle: Option<PrewarmHandle> = None;
 
@@ -286,6 +308,14 @@ pub fn run_tui(config: TuiAppConfig) -> Result<CancellationToken, CliError> {
             }
         }
 
+        // Check for update check result (non-blocking)
+        if let Some(ref rx) = update_rx {
+            if let Ok(Some(info)) = rx.try_recv() {
+                tracing::info!(%info, "Update available");
+                dashboard.set_update_info(info);
+            }
+        }
+
         // Update dashboard at tick rate
         if last_tick.elapsed() >= tick_rate {
             let snapshot = orchestrator.telemetry_snapshot();
@@ -392,7 +422,26 @@ fn update_loading_progress(dashboard: &mut Dashboard, progress: &StartupProgress
 pub fn run_headless(
     orchestrator: &mut ServiceOrchestrator,
     shutdown: Arc<AtomicBool>,
+    update_check: bool,
 ) -> Result<(), CliError> {
+    // Background update check for headless mode
+    if update_check {
+        let current_version = xearthlayer::VERSION.to_string();
+        std::thread::spawn(move || {
+            let checker = RemoteUpdateChecker::new();
+            match checker.check(&current_version) {
+                Ok(Some(info)) => {
+                    tracing::info!(%info, "Update available");
+                    eprintln!("{}", info);
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::debug!(error = %e, "Update check failed (non-fatal)");
+                }
+            }
+        });
+    }
+
     println!("Start X-Plane to use XEarthLayer scenery.");
     println!("Press Ctrl+C to stop.");
     println!();

--- a/xearthlayer-cli/src/ui/dashboard/mod.rs
+++ b/xearthlayer-cli/src/ui/dashboard/mod.rs
@@ -32,6 +32,7 @@ use xearthlayer::aircraft_position::{AircraftPositionProvider, SharedAircraftPos
 use xearthlayer::metrics::TelemetrySnapshot;
 use xearthlayer::prefetch::SharedPrefetchStatus;
 use xearthlayer::runtime::{SharedRuntimeHealth, SharedTileProgressTracker};
+use xearthlayer::update::UpdateInfo;
 
 use crate::ui::widgets::{CacheConfig, DiskHistory, NetworkHistory, SceneryHistory};
 
@@ -72,6 +73,8 @@ pub struct Dashboard {
     aircraft_position: Option<SharedAircraftPosition>,
     /// Tile progress tracker for active tile generation display.
     tile_progress_tracker: Option<SharedTileProgressTracker>,
+    /// Update information when a newer version is available.
+    update_info: Option<UpdateInfo>,
 }
 
 impl Dashboard {
@@ -105,6 +108,7 @@ impl Dashboard {
             prewarm_status: None,
             aircraft_position: None,
             tile_progress_tracker: None,
+            update_info: None,
         })
     }
 
@@ -130,6 +134,11 @@ impl Dashboard {
     pub fn with_tile_progress_tracker(mut self, tracker: SharedTileProgressTracker) -> Self {
         self.tile_progress_tracker = Some(tracker);
         self
+    }
+
+    /// Set update information for footer display.
+    pub fn set_update_info(&mut self, info: UpdateInfo) {
+        self.update_info = Some(info);
     }
 
     /// Transition to the Running state.
@@ -211,6 +220,9 @@ impl Dashboard {
         // Calculate confirmation remaining time for display
         let confirmation_remaining = self.confirmation_remaining();
 
+        // Clone update info for rendering
+        let update_info = self.update_info.as_ref();
+
         // Clone prewarm status for rendering and advance spinner if active
         let prewarm_status = self.prewarm_status.clone();
         let prewarm_spinner = if prewarm_status.is_some() {
@@ -251,6 +263,7 @@ impl Dashboard {
                 prewarm_status.as_ref(),
                 prewarm_spinner,
                 &tile_progress_entries,
+                update_info,
             );
         })?;
 

--- a/xearthlayer-cli/src/ui/dashboard/render.rs
+++ b/xearthlayer-cli/src/ui/dashboard/render.rs
@@ -34,6 +34,7 @@ use ratatui::{
 use xearthlayer::metrics::TelemetrySnapshot;
 use xearthlayer::prefetch::PrefetchStatusSnapshot;
 use xearthlayer::runtime::{HealthSnapshot, RegionProgressEntry};
+use xearthlayer::update::UpdateInfo;
 
 use super::render_sections::inner_rect;
 use super::state::PrewarmProgress;
@@ -67,22 +68,28 @@ pub fn render_ui(
     prewarm_status: Option<&PrewarmProgress>,
     prewarm_spinner: Option<char>,
     tile_progress_entries: &[RegionProgressEntry],
+    update_info: Option<&UpdateInfo>,
 ) {
     let size = frame.area();
 
-    // Layout v0.3.1: 6 sections (Active Tiles moved into Scenery System)
+    // Build constraints dynamically — add a 1-line footer when an update is available
+    let mut constraints = vec![
+        Constraint::Length(3), // Header
+        Constraint::Length(5), // Aircraft Position (3 content lines + border + padding)
+        Constraint::Length(4), // Prefetch System (2 content lines + border + padding)
+        Constraint::Length(8), // Scenery System (3-column: REQUESTS | QUEUE | PROCESSING)
+        Constraint::Length(8), // Input/Output (2-column)
+        Constraint::Length(6), // Caches
+    ];
+    if update_info.is_some() {
+        constraints.push(Constraint::Length(1)); // Update footer
+    }
+    constraints.push(Constraint::Min(0)); // Padding
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(0)
-        .constraints([
-            Constraint::Length(3), // Header
-            Constraint::Length(5), // Aircraft Position (3 content lines + border + padding)
-            Constraint::Length(4), // Prefetch System (2 content lines + border + padding)
-            Constraint::Length(8), // Scenery System (3-column: REQUESTS | QUEUE | PROCESSING)
-            Constraint::Length(8), // Input/Output (2-column)
-            Constraint::Length(6), // Caches
-            Constraint::Min(0),    // Padding
-        ])
+        .constraints(constraints)
         .split(size);
 
     // 1. Header
@@ -139,6 +146,11 @@ pub fn render_ui(
         CacheWidgetCompact::new(snapshot).with_config(cache_config.clone()),
         cache_inner,
     );
+
+    // 7. Update available footer (conditional)
+    if let Some(info) = update_info {
+        render_update_footer(frame, chunks[6], info);
+    }
 
     // Quit confirmation overlay (if active)
     if let Some(remaining) = confirmation_remaining {
@@ -266,6 +278,30 @@ pub fn render_quit_confirmation(frame: &mut Frame, area: Rect, remaining: Durati
         .alignment(ratatui::layout::Alignment::Center);
 
     frame.render_widget(paragraph, banner_area);
+}
+
+/// Render the update available footer line.
+fn render_update_footer(frame: &mut Frame, area: Rect, info: &UpdateInfo) {
+    let line = Line::from(vec![
+        Span::styled(" Update available: ", Style::default().fg(Color::Yellow)),
+        Span::styled(
+            format!("v{}", info.current),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(" \u{2192} ", Style::default().fg(Color::Yellow)),
+        Span::styled(
+            format!("v{}", info.latest),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(" \u{2014} see {}", info.homepage),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+
+    frame.render_widget(Paragraph::new(line), area);
 }
 
 /// Render the header bar with uptime and prewarm status.

--- a/xearthlayer/src/config/defaults.rs
+++ b/xearthlayer/src/config/defaults.rs
@@ -10,6 +10,13 @@ use super::DiskIoProfile;
 use crate::dds::DdsFormat;
 
 // =============================================================================
+// General settings
+// =============================================================================
+
+/// Default: check for updates on startup (once per day).
+pub const DEFAULT_UPDATE_CHECK: bool = true;
+
+// =============================================================================
 // CPU helpers
 // =============================================================================
 
@@ -305,6 +312,9 @@ impl Default for ConfigFile {
             .join("xearthlayer");
 
         Self {
+            general: GeneralSettings {
+                update_check: DEFAULT_UPDATE_CHECK,
+            },
             provider: ProviderSettings {
                 provider_type: "bing".to_string(),
                 google_api_key: None,

--- a/xearthlayer/src/config/keys.rs
+++ b/xearthlayer/src/config/keys.rs
@@ -29,6 +29,9 @@ pub enum ConfigKeyError {
 /// get and set its value with proper validation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigKey {
+    // General settings
+    GeneralUpdateCheck,
+
     // Provider settings
     ProviderType,
     ProviderGoogleApiKey,
@@ -138,6 +141,8 @@ impl FromStr for ConfigKey {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            "general.update_check" => Ok(ConfigKey::GeneralUpdateCheck),
+
             "provider.type" => Ok(ConfigKey::ProviderType),
             "provider.google_api_key" => Ok(ConfigKey::ProviderGoogleApiKey),
             "provider.mapbox_access_token" => Ok(ConfigKey::ProviderMapboxAccessToken),
@@ -243,6 +248,7 @@ impl ConfigKey {
     /// Get the canonical key name (e.g., "packages.library_url").
     pub fn name(&self) -> &'static str {
         match self {
+            ConfigKey::GeneralUpdateCheck => "general.update_check",
             ConfigKey::ProviderType => "provider.type",
             ConfigKey::ProviderGoogleApiKey => "provider.google_api_key",
             ConfigKey::ProviderMapboxAccessToken => "provider.mapbox_access_token",
@@ -340,6 +346,7 @@ impl ConfigKey {
     /// Get the value from a config file as a string.
     pub fn get(&self, config: &ConfigFile) -> String {
         match self {
+            ConfigKey::GeneralUpdateCheck => config.general.update_check.to_string(),
             ConfigKey::ProviderType => config.provider.provider_type.clone(),
             ConfigKey::ProviderGoogleApiKey => {
                 config.provider.google_api_key.clone().unwrap_or_default()
@@ -502,6 +509,10 @@ impl ConfigKey {
     /// Set the value without validation. Use `set()` for validated setting.
     fn set_unchecked(&self, config: &mut ConfigFile, value: &str) {
         match self {
+            ConfigKey::GeneralUpdateCheck => {
+                let v = value.to_lowercase();
+                config.general.update_check = v == "true" || v == "1" || v == "yes" || v == "on";
+            }
             ConfigKey::ProviderType => {
                 config.provider.provider_type = value.to_lowercase();
             }
@@ -736,6 +747,7 @@ impl ConfigKey {
     /// Get the validation specification for this key.
     fn specification(&self) -> Box<dyn ValueSpecification> {
         match self {
+            ConfigKey::GeneralUpdateCheck => Box::new(BooleanSpec),
             ConfigKey::ProviderType => Box::new(OneOfSpec::new(&[
                 "apple", "arcgis", "bing", "go2", "google", "mapbox", "usgs",
             ])),
@@ -830,6 +842,7 @@ impl ConfigKey {
     /// expected in new configs. See upgrade.rs DEPRECATED_KEYS for the list.
     pub fn all() -> &'static [ConfigKey] {
         &[
+            ConfigKey::GeneralUpdateCheck,
             ConfigKey::ProviderType,
             ConfigKey::ProviderGoogleApiKey,
             ConfigKey::ProviderMapboxAccessToken,

--- a/xearthlayer/src/config/parser.rs
+++ b/xearthlayer/src/config/parser.rs
@@ -18,6 +18,14 @@ use crate::dds::DdsFormat;
 pub(super) fn parse_ini(ini: &Ini) -> Result<ConfigFile, ConfigFileError> {
     let mut config = ConfigFile::default();
 
+    // [general] section
+    if let Some(section) = ini.section(Some("general")) {
+        if let Some(v) = section.get("update_check") {
+            let v = v.to_lowercase();
+            config.general.update_check = v == "true" || v == "1" || v == "yes" || v == "on";
+        }
+    }
+
     // [provider] section
     if let Some(section) = ini.section(Some("provider")) {
         if let Some(v) = section.get("type") {

--- a/xearthlayer/src/config/settings.rs
+++ b/xearthlayer/src/config/settings.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 /// Complete application configuration loaded from config.ini.
 #[derive(Debug, Clone)]
 pub struct ConfigFile {
+    /// General application settings
+    pub general: GeneralSettings,
     /// Provider settings
     pub provider: ProviderSettings,
     /// Cache settings
@@ -40,6 +42,14 @@ pub struct ConfigFile {
     pub executor: ExecutorSettings,
     /// FUSE filesystem settings
     pub fuse: FuseSettings,
+}
+
+/// General application settings.
+#[derive(Debug, Clone)]
+pub struct GeneralSettings {
+    /// Enable automatic version update checking on startup (default: true).
+    /// When enabled, checks for new versions once per day via a cached HTTP request.
+    pub update_check: bool,
 }
 
 /// Provider configuration.

--- a/xearthlayer/src/config/writer.rs
+++ b/xearthlayer/src/config/writer.rs
@@ -43,8 +43,19 @@ pub(super) fn to_config_string(config: &ConfigFile) -> String {
         .map(|p| path_to_string(p))
         .unwrap_or_default();
 
+    let update_check = if config.general.update_check {
+        "true"
+    } else {
+        "false"
+    };
+
     format!(
-        r#"[provider]
+        r#"[general]
+; Check for new versions on startup (default: true)
+; When enabled, performs a single HTTP request once per day (no telemetry)
+update_check = {}
+
+[provider]
 ; Imagery provider:
 ;   apple  - Apple Maps (free, tokens auto-acquired via DuckDuckGo)
 ;   arcgis - ArcGIS World Imagery (free, global coverage)
@@ -280,6 +291,7 @@ max_background = {}
 ; Kernel starts throttling when pending requests exceed this. Convention: 75% of max_background.
 congestion_threshold = {}
 "#,
+        update_check,
         config.provider.provider_type,
         google_api_key,
         mapbox_access_token,

--- a/xearthlayer/src/lib.rs
+++ b/xearthlayer/src/lib.rs
@@ -49,6 +49,7 @@ pub mod system;
 pub mod tasks;
 pub mod texture;
 pub mod time;
+pub mod update;
 pub mod xplane;
 
 /// Version of the XEarthLayer library and CLI.

--- a/xearthlayer/src/update/checker.rs
+++ b/xearthlayer/src/update/checker.rs
@@ -1,0 +1,311 @@
+//! Update checker trait and remote implementation.
+//!
+//! Provides [`UpdateChecker`] as the abstraction for version checking,
+//! and [`RemoteUpdateChecker`] as the production implementation that
+//! fetches `version.json` via HTTP with a 24-hour disk cache.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use super::{UpdateInfo, VersionManifest};
+
+/// Errors that can occur during update checking.
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    /// Failed to parse a version string.
+    #[error("Failed to parse version '{0}': {1}")]
+    VersionParse(String, #[source] semver::Error),
+
+    /// HTTP request failed.
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Failed to read or write cache file.
+    #[error("Cache I/O error: {0}")]
+    CacheIo(#[from] std::io::Error),
+
+    /// Failed to parse JSON (manifest or cache).
+    #[error("JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Abstraction for version update checking.
+///
+/// Implementations may fetch from a remote URL, read from cache,
+/// or return fixed values for testing.
+pub trait UpdateChecker: Send + Sync {
+    /// Check whether a newer version is available.
+    ///
+    /// Returns `Ok(Some(info))` if an update exists, `Ok(None)` if up-to-date,
+    /// or `Err` on failure.
+    fn check(&self, current_version: &str) -> Result<Option<UpdateInfo>, UpdateError>;
+}
+
+/// Production update checker that fetches `version.json` from a remote URL.
+///
+/// Implements a 24-hour disk cache at `~/.xearthlayer/version_check.json`
+/// to avoid unnecessary network requests on every startup.
+pub struct RemoteUpdateChecker {
+    url: String,
+    cache_path: PathBuf,
+}
+
+impl Default for RemoteUpdateChecker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RemoteUpdateChecker {
+    /// Default URL for the version manifest.
+    pub const DEFAULT_URL: &str = "https://github.com/samsoir/xearthlayer/raw/main/version.json";
+
+    /// Cache validity duration (24 hours).
+    const CACHE_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
+
+    /// Create a new checker with the default URL and cache path.
+    pub fn new() -> Self {
+        let cache_path = crate::config::config_directory().join("version_check.json");
+        Self {
+            url: Self::DEFAULT_URL.to_string(),
+            cache_path,
+        }
+    }
+
+    /// Create a checker with custom URL and cache path (for testing).
+    pub fn with_url_and_cache(url: String, cache_path: PathBuf) -> Self {
+        Self { url, cache_path }
+    }
+
+    /// Try to load a cached manifest that is still fresh (< 24h old).
+    fn load_cached(&self) -> Option<VersionManifest> {
+        let metadata = std::fs::metadata(&self.cache_path).ok()?;
+        let modified = metadata.modified().ok()?;
+        let age = modified.elapsed().ok()?;
+
+        if age > Self::CACHE_MAX_AGE {
+            return None;
+        }
+
+        let contents = std::fs::read_to_string(&self.cache_path).ok()?;
+        serde_json::from_str(&contents).ok()
+    }
+
+    /// Save a manifest to the disk cache.
+    fn save_cache(&self, manifest: &VersionManifest) {
+        if let Some(parent) = self.cache_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let json = match serde_json::to_string_pretty(manifest) {
+            Ok(j) => j,
+            Err(_) => return,
+        };
+        let _ = std::fs::write(&self.cache_path, json);
+    }
+
+    /// Fetch the version manifest from the remote URL.
+    fn fetch_remote(&self) -> Result<VersionManifest, UpdateError> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .user_agent(format!("XEarthLayer/{}", crate::VERSION))
+            .build()?;
+
+        let response = client.get(&self.url).send()?;
+        let body = response.text()?;
+        let manifest: VersionManifest = serde_json::from_str(&body)?;
+        Ok(manifest)
+    }
+}
+
+impl UpdateChecker for RemoteUpdateChecker {
+    fn check(&self, current_version: &str) -> Result<Option<UpdateInfo>, UpdateError> {
+        // Try cache first
+        if let Some(cached) = self.load_cached() {
+            return cached.check_update(current_version);
+        }
+
+        // Fetch from remote
+        let manifest = self.fetch_remote()?;
+        self.save_cache(&manifest);
+        manifest.check_update(current_version)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    // =========================================================================
+    // Mock UpdateChecker for trait verification
+    // =========================================================================
+
+    struct MockUpdateChecker {
+        result: Result<Option<UpdateInfo>, String>,
+    }
+
+    impl MockUpdateChecker {
+        fn update_available(info: UpdateInfo) -> Self {
+            Self {
+                result: Ok(Some(info)),
+            }
+        }
+
+        fn up_to_date() -> Self {
+            Self { result: Ok(None) }
+        }
+    }
+
+    impl UpdateChecker for MockUpdateChecker {
+        fn check(&self, _current_version: &str) -> Result<Option<UpdateInfo>, UpdateError> {
+            match &self.result {
+                Ok(info) => Ok(info.clone()),
+                Err(msg) => Err(UpdateError::VersionParse(
+                    msg.clone(),
+                    semver::Version::parse("bad").unwrap_err(),
+                )),
+            }
+        }
+    }
+
+    #[test]
+    fn test_mock_checker_returns_update() {
+        let info = UpdateInfo {
+            current: semver::Version::new(0, 4, 1),
+            latest: semver::Version::new(0, 5, 0),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+        let checker = MockUpdateChecker::update_available(info);
+        let result = checker.check("0.4.1").unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().latest, semver::Version::new(0, 5, 0));
+    }
+
+    #[test]
+    fn test_mock_checker_returns_up_to_date() {
+        let checker = MockUpdateChecker::up_to_date();
+        let result = checker.check("0.4.1").unwrap();
+        assert!(result.is_none());
+    }
+
+    // =========================================================================
+    // Cache behavior
+    // =========================================================================
+
+    fn create_cache_file(dir: &TempDir, manifest: &VersionManifest) -> PathBuf {
+        let cache_path = dir.path().join("version_check.json");
+        let json = serde_json::to_string_pretty(manifest).unwrap();
+        let mut file = std::fs::File::create(&cache_path).unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+        cache_path
+    }
+
+    #[test]
+    fn test_fresh_cache_is_used() {
+        let dir = TempDir::new().unwrap();
+        let manifest = VersionManifest {
+            version: "0.5.0".to_string(),
+            tag: "v0.5.0".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+        let cache_path = create_cache_file(&dir, &manifest);
+
+        let checker = RemoteUpdateChecker::with_url_and_cache(
+            "http://invalid.test/version.json".to_string(),
+            cache_path,
+        );
+
+        // Should use cache (not hit network) and find an update
+        let result = checker.check("0.4.1").unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().latest, semver::Version::new(0, 5, 0));
+    }
+
+    #[test]
+    fn test_stale_cache_triggers_fetch() {
+        let dir = TempDir::new().unwrap();
+        let manifest = VersionManifest {
+            version: "0.5.0".to_string(),
+            tag: "v0.5.0".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+        let cache_path = create_cache_file(&dir, &manifest);
+
+        // Make the cache file old by setting mtime to 25 hours ago
+        let old_time = filetime::FileTime::from_unix_time(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64
+                - 25 * 3600,
+            0,
+        );
+        filetime::set_file_mtime(&cache_path, old_time).unwrap();
+
+        let checker = RemoteUpdateChecker::with_url_and_cache(
+            "http://invalid.test/version.json".to_string(),
+            cache_path,
+        );
+
+        // Stale cache should attempt fetch — which will fail on invalid URL
+        let result = checker.check("0.4.1");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_cache_triggers_fetch() {
+        let dir = TempDir::new().unwrap();
+        let cache_path = dir.path().join("nonexistent.json");
+
+        let checker = RemoteUpdateChecker::with_url_and_cache(
+            "http://invalid.test/version.json".to_string(),
+            cache_path,
+        );
+
+        // No cache — should attempt fetch and fail
+        let result = checker.check("0.4.1");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_corrupt_cache_triggers_fetch() {
+        let dir = TempDir::new().unwrap();
+        let cache_path = dir.path().join("version_check.json");
+        std::fs::write(&cache_path, "not valid json").unwrap();
+
+        let checker = RemoteUpdateChecker::with_url_and_cache(
+            "http://invalid.test/version.json".to_string(),
+            cache_path,
+        );
+
+        // Corrupt cache should attempt fetch and fail
+        let result = checker.check("0.4.1");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_save_cache_creates_file() {
+        let dir = TempDir::new().unwrap();
+        let cache_path = dir.path().join("subdir").join("version_check.json");
+
+        let checker = RemoteUpdateChecker::with_url_and_cache(
+            "http://invalid.test/version.json".to_string(),
+            cache_path.clone(),
+        );
+
+        let manifest = VersionManifest {
+            version: "0.5.0".to_string(),
+            tag: "v0.5.0".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+
+        checker.save_cache(&manifest);
+        assert!(cache_path.exists());
+
+        let contents = std::fs::read_to_string(&cache_path).unwrap();
+        let loaded: VersionManifest = serde_json::from_str(&contents).unwrap();
+        assert_eq!(loaded.version, "0.5.0");
+    }
+}

--- a/xearthlayer/src/update/mod.rs
+++ b/xearthlayer/src/update/mod.rs
@@ -1,0 +1,243 @@
+//! Version update checking for XEarthLayer.
+//!
+//! This module provides non-blocking version checking against a remote
+//! `version.json` manifest. It compares the running version against the
+//! latest published version and produces an [`UpdateInfo`] when an update
+//! is available.
+//!
+//! # Components
+//!
+//! - [`VersionManifest`] — Serde model for the remote `version.json`
+//! - [`UpdateInfo`] — Result of a successful update check (only when newer version exists)
+//! - [`UpdateChecker`] — Trait for version checking (supports dependency injection)
+//! - [`RemoteUpdateChecker`] — Production implementation with HTTP fetch and 24h disk cache
+
+mod checker;
+
+pub use checker::{RemoteUpdateChecker, UpdateChecker, UpdateError};
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+/// Remote version manifest matching the published `version.json` schema.
+///
+/// Only the fields needed for update checking are deserialized;
+/// unknown fields are silently ignored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionManifest {
+    /// Latest published version string (e.g., "0.5.0").
+    pub version: String,
+    /// Git tag for the release (e.g., "v0.5.0").
+    pub tag: String,
+    /// Project homepage URL for the update notification.
+    pub homepage: String,
+}
+
+/// Information about an available update.
+///
+/// Only constructed when the latest version is strictly greater than
+/// the currently running version.
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    /// Currently running version.
+    pub current: Version,
+    /// Latest available version.
+    pub latest: Version,
+    /// Project homepage URL to display in the notification.
+    pub homepage: String,
+}
+
+impl VersionManifest {
+    /// Compare this manifest against the current version.
+    ///
+    /// Returns `Some(UpdateInfo)` if the manifest version is strictly newer,
+    /// or `None` if the current version is up-to-date (or newer, e.g. dev builds).
+    pub fn check_update(&self, current_version: &str) -> Result<Option<UpdateInfo>, UpdateError> {
+        let current = Version::parse(current_version)
+            .map_err(|e| UpdateError::VersionParse(current_version.to_string(), e))?;
+        let latest = Version::parse(&self.version)
+            .map_err(|e| UpdateError::VersionParse(self.version.clone(), e))?;
+
+        if latest > current {
+            Ok(Some(UpdateInfo {
+                current,
+                latest,
+                homepage: self.homepage.clone(),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl std::fmt::Display for UpdateInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Update available: v{} \u{2192} v{} \u{2014} see {}",
+            self.current, self.latest, self.homepage
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // VersionManifest deserialization
+    // =========================================================================
+
+    #[test]
+    fn test_deserialize_valid_manifest() {
+        let json = r#"{
+            "version": "0.5.0",
+            "tag": "v0.5.0",
+            "homepage": "https://xearthlayer.app",
+            "release_date": "2026-04-01",
+            "assets": {},
+            "download_base_url": "https://example.com"
+        }"#;
+
+        let manifest: VersionManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.version, "0.5.0");
+        assert_eq!(manifest.tag, "v0.5.0");
+        assert_eq!(manifest.homepage, "https://xearthlayer.app");
+    }
+
+    #[test]
+    fn test_deserialize_minimal_manifest() {
+        let json = r#"{
+            "version": "1.0.0",
+            "tag": "v1.0.0",
+            "homepage": "https://example.com"
+        }"#;
+
+        let manifest: VersionManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.version, "1.0.0");
+    }
+
+    #[test]
+    fn test_deserialize_missing_required_field() {
+        let json = r#"{ "version": "1.0.0", "tag": "v1.0.0" }"#;
+        let result = serde_json::from_str::<VersionManifest>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_invalid_json() {
+        let result = serde_json::from_str::<VersionManifest>("not json");
+        assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // Version comparison via check_update
+    // =========================================================================
+
+    #[test]
+    fn test_update_available_when_latest_is_newer() {
+        let manifest = VersionManifest {
+            version: "0.5.0".to_string(),
+            tag: "v0.5.0".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+
+        let result = manifest.check_update("0.4.1").unwrap();
+        assert!(result.is_some());
+        let info = result.unwrap();
+        assert_eq!(info.current, Version::new(0, 4, 1));
+        assert_eq!(info.latest, Version::new(0, 5, 0));
+        assert_eq!(info.homepage, "https://xearthlayer.app");
+    }
+
+    #[test]
+    fn test_no_update_when_versions_equal() {
+        let manifest = VersionManifest {
+            version: "0.4.1".to_string(),
+            tag: "v0.4.1".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+
+        let result = manifest.check_update("0.4.1").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_no_update_when_current_is_newer() {
+        let manifest = VersionManifest {
+            version: "0.4.0".to_string(),
+            tag: "v0.4.0".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+
+        let result = manifest.check_update("0.5.0").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_update_available_for_patch_bump() {
+        let manifest = VersionManifest {
+            version: "0.4.2".to_string(),
+            tag: "v0.4.2".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+
+        let result = manifest.check_update("0.4.1").unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_update_available_for_major_bump() {
+        let manifest = VersionManifest {
+            version: "1.0.0".to_string(),
+            tag: "v1.0.0".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+
+        let result = manifest.check_update("0.99.99").unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_invalid_current_version_returns_error() {
+        let manifest = VersionManifest {
+            version: "0.5.0".to_string(),
+            tag: "v0.5.0".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+
+        let result = manifest.check_update("not-a-version");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_manifest_version_returns_error() {
+        let manifest = VersionManifest {
+            version: "bad".to_string(),
+            tag: "vbad".to_string(),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+
+        let result = manifest.check_update("0.4.1");
+        assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // Display
+    // =========================================================================
+
+    #[test]
+    fn test_update_info_display() {
+        let info = UpdateInfo {
+            current: Version::new(0, 4, 1),
+            latest: Version::new(0, 5, 0),
+            homepage: "https://xearthlayer.app".to_string(),
+        };
+
+        let display = format!("{}", info);
+        assert!(display.contains("v0.4.1"));
+        assert!(display.contains("v0.5.0"));
+        assert!(display.contains("https://xearthlayer.app"));
+        assert!(display.contains("\u{2192}")); // arrow
+    }
+}


### PR DESCRIPTION
## Summary

- Add non-blocking version update checking on `xearthlayer run` startup
- Display a persistent TUI dashboard footer when a newer version is available
- New `UpdateChecker` trait with `RemoteUpdateChecker` implementation (24h disk cache)
- New `general.update_check` config key (default: `true`) to opt out
- Headless mode prints update info to stderr

## Details

Fetches `version.json` from the main branch, compares against the running version using semver, and caches the result at `~/.xearthlayer/version_check.json` for 24 hours. No telemetry is sent — just a single HTTP GET to a static JSON file.

Footer example:
```
 Update available: v0.4.1 → v0.5.0 — see https://xearthlayer.app
```

## Test plan

- [x] Unit tests: manifest deserialization (valid/invalid/minimal JSON)
- [x] Unit tests: version comparison (newer, equal, older, major/patch bumps, invalid)
- [x] Unit tests: cache behavior (fresh hit, stale triggers fetch, corrupt triggers fetch, missing triggers fetch)
- [x] Unit tests: mock `UpdateChecker` trait verification
- [x] Unit tests: config key parse/get/set/validate round-trip
- [x] `make pre-commit` passes (fmt + clippy + 2283 tests)
- [x] Manual test: wrote fake `version_check.json` with v99.0.0, confirmed footer renders in TUI

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)