### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.2] - 2026-04-06
 
+### Added
+
+- **DDS disk cache tier** ([#132](https://github.com/samsoir/xearthlayer/issues/132)): Three-tier cache hierarchy (memory → DDS disk → chunk disk → network). Encoded DDS tiles persist to disk, avoiding re-encoding on memory eviction (~3.5ms NVMe read vs ~50-200ms re-encode). Configurable disk budget split via `cache.dds_disk_ratio` (default 60% DDS, 40% chunks).
+
+- **Speed-proportional prefetch box** ([#125](https://github.com/samsoir/xearthlayer/issues/125)): Prefetch box extent scales linearly with ground speed — 3.5° at 40kt to 6.5° at 450kt+. Reduces over-fetching during approach by ~45%, cutting burst sizes that contributed to swap-in storms on memory-constrained systems.
+
+- **Stale telemetry safe mode** ([#125](https://github.com/samsoir/xearthlayer/issues/125)): When X-Plane position telemetry goes stale (5s), prefetch pauses entirely. On resume, `on_ground` from SimState determines phase reset (Ground or Cruise) before normal cycling restarts.
+
+- **Version update check** ([#128](https://github.com/samsoir/xearthlayer/issues/128)): Non-blocking startup check against remote `version.json` with 24h disk cache. TUI dashboard shows persistent footer when an update is available. Configurable via `general.update_check` (default: true).
+
 ### Changed
 
-- **GPU encoding is now built-in** ([#139](https://github.com/samsoir/xearthlayer/pull/139)): The `gpu-encode` Cargo feature flag has been removed. GPU encoding via wgpu compute shaders is compiled unconditionally into every binary. Select it at runtime via `texture.compressor = gpu` in config — no special build flags required.
+- **GPU encoding is now built-in** ([#139](https://github.com/samsoir/xearthlayer/issues/139)): The `gpu-encode` Cargo feature flag has been removed. GPU encoding via wgpu compute shaders is compiled unconditionally into every binary. Select it at runtime via `texture.compressor = gpu` in config — no special build flags required. CI/CD pipeline simplified to a single binary variant.
+
+- **fuse3 updated to 0.9.0** ([#134](https://github.com/samsoir/xearthlayer/issues/134)): Upstream switched serialization from bincode to zerocopy. `ReplyInit` adapted to new `#[non_exhaustive]` constructor pattern. Contributed by [@mmaechtel](https://github.com/mmaechtel).
+
+- **Removed `prefetch.strategy` config setting** ([#136](https://github.com/samsoir/xearthlayer/issues/136)): Only the adaptive strategy exists; setting was redundant. Added to deprecated keys for automatic removal via `config upgrade`.
+
+### Fixed
+
+- **Debug map**: DDS disk cache hits now recorded in tile activity tracker — boundary tile loads were previously invisible to the debug map ([#125](https://github.com/samsoir/xearthlayer/issues/125))
+- **Debug map**: Prefetch box extent propagated in no-plan status updates — live speed-proportional box now renders correctly during steady cruise ([#125](https://github.com/samsoir/xearthlayer/issues/125))
+- **Download progress**: Completed download bars now clear so progress scrolls correctly for large packages ([#129](https://github.com/samsoir/xearthlayer/issues/129))
+- **CI**: Website sync now triggers on release branch merge instead of during release workflow ([#127](https://github.com/samsoir/xearthlayer/pull/127))
 
 ## [0.4.1] - 2026-03-29
 
@@ -934,7 +955,8 @@ Run `xearthlayer config upgrade` to automatically add new settings with defaults
 - Linux support only (Windows and macOS planned for future releases)
 - Requires FUSE3 for filesystem mounting
 
-[Unreleased]: https://github.com/samsoir/xearthlayer/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/samsoir/xearthlayer/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/samsoir/xearthlayer/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/samsoir/xearthlayer/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/samsoir/xearthlayer/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/samsoir/xearthlayer/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,7 +4755,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xearthlayer"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "axum",
  "bincode",
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "xearthlayer-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["XEarthLayer Contributors"]
 license = "MIT"

--- a/version.json
+++ b/version.json
@@ -1,33 +1,25 @@
 {
-  "version": "0.4.1",
-  "tag": "v0.4.1",
-  "release_date": "2026-03-29",
+  "version": "0.4.2",
+  "tag": "v0.4.2",
+  "release_date": "2026-04-06",
   "homepage": "https://xearthlayer.app",
   "assets": {
     "deb": {
-      "filename": "xearthlayer_0.4.1-1_amd64.deb",
+      "filename": "xearthlayer_0.4.2-1_amd64.deb",
       "description": "Debian/Ubuntu package"
     },
     "rpm": {
-      "filename": "xearthlayer-0.4.1-1.fc43.x86_64.rpm",
+      "filename": "xearthlayer-0.4.2-1.fc43.x86_64.rpm",
       "description": "Fedora/RHEL package"
     },
     "tarball": {
-      "filename": "xearthlayer-v0.4.1-x86_64-linux.tar.gz",
+      "filename": "xearthlayer-v0.4.2-x86_64-linux.tar.gz",
       "description": "Linux binary tarball"
     },
     "aur": {
       "filename": "aur-package.zip",
       "description": "Arch Linux AUR package"
-    },
-    "tarball-gpu": {
-      "filename": "xearthlayer-gpu-v0.4.1-x86_64-linux.tar.gz",
-      "description": "Linux binary tarball (GPU encoding)"
-    },
-    "deb-gpu": {
-      "filename": "xearthlayer_0.4.1-1_amd64-gpu.deb",
-      "description": "Debian/Ubuntu package (GPU encoding)"
     }
   },
-  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.1"
+  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.2"
 }


### PR DESCRIPTION
## Release v0.4.2

### Highlights

- **DDS disk cache tier** — three-tier cache eliminates re-encoding on memory eviction
- **Speed-proportional prefetch** — box shrinks during approach, reducing swap-in storms
- **Stale telemetry safe mode** — prefetch pauses when X-Plane telemetry drops
- **GPU encoding built-in** — no more `--features gpu-encode`, single binary for all users
- **fuse3 0.9.0** — upstream zerocopy serialization

### Full Changelog

See [CHANGELOG.md](CHANGELOG.md) for complete details.

### Release Checklist (from runbook)

- [x] Working tree clean, on `main`, up to date
- [x] `make pre-commit` passes (2365 tests)
- [x] Version bumped in `Cargo.toml` (0.4.1 → 0.4.2)
- [x] `CHANGELOG.md` updated with all changes
- [x] `version.json` updated (version, date, filenames, GPU assets removed)
- [x] Release branch created and PR opened
- [x] CI passes on PR
- [x] Tag created and pushed (BEFORE merging PR)
- [x] Release workflow completes successfully
- [x] PR merged (AFTER workflow completes)
- [x] Website shows new version