### PR TITLE
fix(prefetch): resolve InProgress region dead state with DDS disk verification (#157)

### DIFF
--- a/xearthlayer/src/cache/adapters/dds_disk_bridge.rs
+++ b/xearthlayer/src/cache/adapters/dds_disk_bridge.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use crate::cache::clients::TileCacheClient;
 use crate::cache::traits::Cache;
 use crate::coord::TileCoord;
-use crate::executor::DdsDiskCache;
+use crate::executor::{DdsDiskCache, DdsDiskCacheChecker};
 
 /// Bridge adapter implementing `executor::DdsDiskCache` using the cache service.
 ///
@@ -58,6 +58,20 @@ impl DdsDiskCache for DdsDiskCacheBridge {
             let tile = TileCoord { row, col, zoom };
             self.client.contains(&tile).await
         }
+    }
+}
+
+impl DdsDiskCacheChecker for DdsDiskCacheBridge {
+    fn tile_exists(
+        &self,
+        row: u32,
+        col: u32,
+        zoom: u8,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+        Box::pin(async move {
+            let tile = TileCoord { row, col, zoom };
+            self.client.contains(&tile).await
+        })
     }
 }
 

--- a/xearthlayer/src/executor/mod.rs
+++ b/xearthlayer/src/executor/mod.rs
@@ -196,8 +196,8 @@ pub use cache_adapter::ExecutorCacheAdapter;
 // Core traits (decoupled from pipeline module)
 pub use traits::{
     BlockingExecutor, ChunkDownloadError, ChunkProvider, ConcurrentResults, ConcurrentRunner,
-    DdsDiskCache, DiskCache, ExecutorError, MemoryCache, TextureEncodeError, TextureEncoderAsync,
-    Timer, TokioExecutor,
+    DdsDiskCache, DdsDiskCacheChecker, DiskCache, ExecutorError, MemoryCache, TextureEncodeError,
+    TextureEncoderAsync, Timer, TokioExecutor,
 };
 
 // Chunk results (for download/assemble stages)

--- a/xearthlayer/src/executor/traits.rs
+++ b/xearthlayer/src/executor/traits.rs
@@ -261,6 +261,28 @@ pub trait DdsDiskCache: Send + Sync + 'static {
 }
 
 // ============================================================================
+// DDS Disk Cache Checker (object-safe)
+// ============================================================================
+
+/// Object-safe trait for checking DDS tile existence on disk.
+///
+/// This is a subset of [`DdsDiskCache`] using `Pin<Box<dyn Future>>` returns
+/// so it can be used as `Arc<dyn DdsDiskCacheChecker>`. Used by the prefetch
+/// coordinator to verify whether tiles were generated before demoting stale
+/// InProgress regions.
+pub trait DdsDiskCacheChecker: Send + Sync + 'static {
+    /// Checks if a tile exists in the disk cache index.
+    ///
+    /// O(1) in-memory check against the LRU index (no disk I/O).
+    fn tile_exists(
+        &self,
+        row: u32,
+        col: u32,
+        zoom: u8,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>>;
+}
+
+// ============================================================================
 // Blocking Executor Trait
 // ============================================================================
 

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -133,7 +133,7 @@ impl BoundaryStrategy {
     ///
     /// Queries the scenery index for actual installed tiles (at correct zoom
     /// levels), falling back to geometric 4x4 grid at zoom 14.
-    fn tiles_for_region(
+    pub fn tiles_for_region(
         strategy: &BoundaryStrategy,
         region: &DsfRegion,
         scenery_index: Option<&Arc<SceneryIndex>>,

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -10,8 +10,11 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::coord::TileCoord;
-use crate::executor::{DaemonMemoryCache, DdsClient};
-use crate::geo_index::{DsfRegion, GeoIndex};
+use crate::executor::{DaemonMemoryCache, DdsClient, DdsDiskCacheChecker};
+
+/// Maximum demotion attempts before marking a region as NoCoverage.
+const MAX_REGION_ATTEMPTS: u8 = 3;
+use crate::geo_index::{DsfRegion, GeoIndex, PrefetchedRegion};
 use crate::ortho_union::OrthoUnionIndex;
 use crate::prefetch::state::{AircraftState, SharedPrefetchStatus};
 use crate::prefetch::SceneryIndex;
@@ -171,6 +174,19 @@ pub struct AdaptivePrefetchCoordinator {
     /// bug where large boundary plans are partially submitted and the remainder
     /// is permanently lost.
     pub(super) pending_tiles: Vec<TileCoord>,
+
+    /// DDS disk cache checker for verifying tile existence during stale region evaluation.
+    ///
+    /// When an InProgress region becomes stale, we check if its tiles exist on DDS disk
+    /// before deciding to promote (tiles exist) or demote (tiles missing) the region.
+    dds_disk_checker: Option<Arc<dyn DdsDiskCacheChecker>>,
+
+    /// Tracks demotion attempts per region to prevent infinite retry loops.
+    ///
+    /// Incremented each time an InProgress region is demoted (tiles not on disk after
+    /// stale timeout). After [`MAX_REGION_ATTEMPTS`] demotions, the region is marked
+    /// NoCoverage and permanently excluded for this session.
+    region_attempts: std::collections::HashMap<DsfRegion, u8>,
 }
 
 impl std::fmt::Debug for AdaptivePrefetchCoordinator {
@@ -219,6 +235,8 @@ impl AdaptivePrefetchCoordinator {
             scene_tracker: None,
             scenery_index: None,
             pending_tiles: Vec::new(),
+            dds_disk_checker: None,
+            region_attempts: std::collections::HashMap::new(),
         }
     }
 
@@ -295,6 +313,15 @@ impl AdaptivePrefetchCoordinator {
     /// Set the geospatial reference index for patched region filtering.
     pub fn with_geo_index(mut self, geo_index: Arc<GeoIndex>) -> Self {
         self.geo_index = Some(geo_index);
+        self
+    }
+
+    /// Set the DDS disk cache checker for stale region evaluation.
+    ///
+    /// When set, stale InProgress regions are checked against the DDS disk cache.
+    /// Tiles found on disk trigger promotion; tiles not found trigger demotion.
+    pub fn with_dds_disk_checker(mut self, checker: Arc<dyn DdsDiskCacheChecker>) -> Self {
+        self.dds_disk_checker = Some(checker);
         self
     }
 
@@ -864,22 +891,111 @@ impl AdaptivePrefetchCoordinator {
     /// This must run every cycle regardless of whether a prefetch plan was generated,
     /// otherwise InProgress regions block future boundary cycles indefinitely.
     pub fn run_region_maintenance(&mut self) {
-        if let Some(ref geo_index) = self.geo_index {
-            BoundaryStrategy::sweep_stale_regions(geo_index, self.config.stale_region_timeout);
-            BoundaryStrategy::promote_completed_regions(
-                geo_index,
-                &self.cached_tiles,
-                self.scenery_index.as_ref(),
-            );
-            // Evict PrefetchedRegion entries for regions outside the retained window,
-            // making them eligible for re-prefetch when the aircraft returns.
-            BoundaryStrategy::evict_non_retained(geo_index);
-            // Evict cached_tiles entries for tiles outside the retained window,
-            // allowing re-query of the memory cache for those tiles.
-            BoundaryStrategy::evict_cached_tiles_outside_retained(
-                &mut self.cached_tiles,
-                geo_index,
-            );
+        let geo_index = match self.geo_index {
+            Some(ref gi) => Arc::clone(gi),
+            None => return,
+        };
+
+        // Evaluate stale InProgress regions: promote if tiles on disk, demote if not.
+        // This replaces the old sweep_stale_regions which blindly removed stale regions
+        // without checking whether tiles had actually been generated.
+        self.evaluate_stale_regions(&geo_index);
+
+        BoundaryStrategy::promote_completed_regions(
+            &geo_index,
+            &self.cached_tiles,
+            self.scenery_index.as_ref(),
+        );
+        // Evict PrefetchedRegion entries for regions outside the retained window,
+        // making them eligible for re-prefetch when the aircraft returns.
+        BoundaryStrategy::evict_non_retained(&geo_index);
+        // Evict cached_tiles entries for tiles outside the retained window,
+        // allowing re-query of the memory cache for those tiles.
+        BoundaryStrategy::evict_cached_tiles_outside_retained(&mut self.cached_tiles, &geo_index);
+    }
+
+    /// Evaluate stale InProgress regions and decide: promote, demote, or NoCoverage.
+    ///
+    /// For each InProgress region that has exceeded the stale timeout:
+    /// 1. Check if tiles exist on DDS disk cache → promote to Prefetched
+    /// 2. If tiles not on disk, check attempt counter:
+    ///    - Under limit → remove from GeoIndex (allows retry on next cycle)
+    ///    - At limit → mark NoCoverage (permanently excluded this session)
+    fn evaluate_stale_regions(&mut self, geo_index: &GeoIndex) {
+        let stale: Vec<DsfRegion> = geo_index
+            .iter::<PrefetchedRegion>()
+            .into_iter()
+            .filter(|(_, region)| region.is_stale(self.config.stale_region_timeout))
+            .map(|(dsf, _)| dsf)
+            .collect();
+
+        if stale.is_empty() {
+            return;
+        }
+
+        let strategy = BoundaryStrategy::new();
+
+        for region in stale {
+            let tiles =
+                BoundaryStrategy::tiles_for_region(&strategy, &region, self.scenery_index.as_ref());
+
+            // Check if tiles exist on DDS disk cache
+            let tiles_on_disk = if let Some(ref checker) = self.dds_disk_checker {
+                // Use a synchronous block_on since we're in an async context
+                // but evaluate_stale_regions is called from the sync maintenance path.
+                // The DdsDiskCacheChecker::tile_exists is backed by an O(1) in-memory
+                // DashMap lookup, so blocking is negligible.
+                let checker = Arc::clone(checker);
+                let tiles_clone = tiles.clone();
+                tokio::task::block_in_place(|| {
+                    let rt = tokio::runtime::Handle::current();
+                    rt.block_on(async {
+                        if tiles_clone.is_empty() {
+                            return false;
+                        }
+                        // Check a sample — if the first tile exists, assume the region is covered
+                        let t = &tiles_clone[0];
+                        checker.tile_exists(t.row, t.col, t.zoom).await
+                    })
+                })
+            } else {
+                false
+            };
+
+            if tiles_on_disk {
+                // Tiles generated successfully — promote despite lost cached_tiles tracking
+                geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
+                tracing::info!(
+                    lat = region.lat,
+                    lon = region.lon,
+                    "Stale InProgress region promoted — tiles found on DDS disk"
+                );
+            } else {
+                let attempts = self.region_attempts.entry(region).or_insert(0);
+                *attempts += 1;
+
+                if *attempts >= MAX_REGION_ATTEMPTS {
+                    // Exhausted retries — mark permanently excluded
+                    geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::no_coverage());
+                    tracing::warn!(
+                        lat = region.lat,
+                        lon = region.lon,
+                        attempts = *attempts,
+                        "Region marked NoCoverage after {} failed attempts",
+                        MAX_REGION_ATTEMPTS
+                    );
+                } else {
+                    // Remove from GeoIndex to allow retry on next cycle
+                    geo_index.remove::<PrefetchedRegion>(&region);
+                    tracing::info!(
+                        lat = region.lat,
+                        lon = region.lon,
+                        attempt = *attempts,
+                        max = MAX_REGION_ATTEMPTS,
+                        "Stale InProgress region demoted for retry"
+                    );
+                }
+            }
         }
     }
 

--- a/xearthlayer/src/service/facade.rs
+++ b/xearthlayer/src/service/facade.rs
@@ -357,6 +357,19 @@ impl XEarthLayerService {
         self.memory_cache_bridge.clone()
     }
 
+    /// Get the DDS disk cache checker for tile existence verification.
+    ///
+    /// Returns the `DdsDiskCacheBridge` as a `DdsDiskCacheChecker` trait object.
+    /// Used by the prefetch system to verify whether tiles were generated when
+    /// evaluating stale InProgress regions.
+    ///
+    /// Returns `None` if caching is disabled.
+    pub fn dds_disk_checker(&self) -> Option<Arc<dyn crate::executor::DdsDiskCacheChecker>> {
+        self.cache_layer.as_ref().map(|cl| {
+            Arc::clone(&cl.dds_disk_bridge()) as Arc<dyn crate::executor::DdsDiskCacheChecker>
+        })
+    }
+
     /// Shutdown the cache layer gracefully.
     ///
     /// This stops the GC daemon and flushes pending operations.

--- a/xearthlayer/src/service/orchestrator/prefetch.rs
+++ b/xearthlayer/src/service/orchestrator/prefetch.rs
@@ -38,8 +38,15 @@ impl ServiceOrchestrator {
 
         let runtime_handle = service.runtime_handle().clone();
 
+        let dds_disk_checker = service.dds_disk_checker();
+
         if let Some(memory_cache) = service.memory_cache_bridge() {
-            self.start_prefetch_with_cache(&runtime_handle, dds_client, memory_cache)?;
+            self.start_prefetch_with_cache(
+                &runtime_handle,
+                dds_client,
+                memory_cache,
+                dds_disk_checker,
+            )?;
         } else {
             tracing::warn!("Memory cache not available, prefetch disabled");
             return Ok(());
@@ -54,6 +61,7 @@ impl ServiceOrchestrator {
         runtime_handle: &Handle,
         dds_client: Arc<dyn DdsClient>,
         memory_cache: Arc<M>,
+        dds_disk_checker: Option<Arc<dyn crate::executor::DdsDiskCacheChecker>>,
     ) -> Result<(), ServiceError> {
         use crate::prefetch::AircraftState as PrefetchAircraftState;
 
@@ -120,6 +128,14 @@ impl ServiceOrchestrator {
 
         // Wire memory cache for tile existence checks (Bug 5 fix)
         coordinator = coordinator.with_memory_cache(memory_cache);
+
+        // Wire DDS disk cache checker for stale InProgress region evaluation (#157)
+        if let Some(checker) = dds_disk_checker {
+            coordinator = coordinator.with_dds_disk_checker(checker);
+            tracing::info!(
+                "DDS disk cache checker wired to prefetch (stale region evaluation enabled)"
+            );
+        }
 
         // Wire scenery index if available
         if self.scenery_index.tile_count() > 0 {


### PR DESCRIPTION
## Summary

Fixes a prefetch coverage gap where InProgress regions entered a permanent dead state, preventing tiles from being served from cache and causing sim freezes when X-Plane requested them on-demand.

## Root Cause

The two-phase region commit created a lifecycle bug:
1. Region enters sliding box → tiles submitted → marked InProgress → tiles added to `cached_tiles`
2. Sliding box advances → `evict_cached_tiles_outside_retained()` removes entries from `cached_tiles`
3. Promotion check fails (can't verify tiles without `cached_tiles` entries)
4. Region stuck InProgress forever → `should_prefetch()` blocks all retry attempts

## Fix

Replace blind `sweep_stale_regions()` (which just removed stale regions) with `evaluate_stale_regions()` that makes an informed decision:

1. **Check DDS disk cache** for tile existence before deciding
2. **Tiles found on disk** → promote to Prefetched (tiles were generated, tracking was lost)
3. **Tiles not found** → demote for retry with attempt counter
4. **After 3 failed attempts** → mark NoCoverage (prevents retry loops)

## New Components

- `DdsDiskCacheChecker` trait (object-safe) — enables prefetch to verify tile existence
- Implemented for `DdsDiskCacheBridge` — O(1) in-memory LRU index check
- `region_attempts` HashMap — tracks demotion count per region
- Wired through facade → orchestrator → coordinator

## Flight Test Results

MSP heading west, ~1 hour:
- **57 promotions** — stale regions verified against DDS disk, tiles found, correctly promoted
- **45 demotions** — tiles not yet on disk, regions cleared for retry at leading edge
- **17 NoCoverage** — regions exhausted 3 attempts (ocean/no-scenery areas)
- **142 FUSE jobs** — down from 687 in previous test (all at coverage edges, not dead-state regions)
- **Zero sim freezes** from prefetch coverage gaps

## Test plan

- [x] `make pre-commit` passes (fmt + clippy + 2,358 tests)
- [x] Flight test: stale regions correctly promoted when tiles on DDS disk
- [x] Flight test: regions without tiles demoted and retried
- [x] Flight test: NoCoverage applied after 3 failed attempts (ocean regions)
- [x] No regression in prefetch tile generation throughput

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)