### PR TITLE
fix(tui): separate DDS disk and chunk disk cache metrics (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Three-tier cache metrics in TUI** ([#166](https://github.com/samsoir/xearthlayer/issues/166)): Split the combined "Disk" cache display into separate DDS Disk and Chunks tiers with independent hit rates. The TUI now shows a 3-column layout (Memory, DDS Disk, Chunks) with per-tier progress bars and hit/miss counters. DDS disk hit rate (93%+ in flight tests) is no longer hidden by chunk-level event volume.
+
 ## [0.4.3] - 2026-04-07
 
 ### Changed

--- a/xearthlayer-cli/src/tui_app.rs
+++ b/xearthlayer-cli/src/tui_app.rs
@@ -78,9 +78,12 @@ pub fn run_tui(config: TuiAppConfig) -> Result<CancellationToken, CliError> {
         xplane_env,
     } = config;
 
+    let dds_disk_max = (cfg.cache.disk_size as f64 * cfg.cache.dds_disk_ratio) as usize;
+    let chunk_disk_max = cfg.cache.disk_size.saturating_sub(dds_disk_max);
     let dashboard_config = DashboardConfig {
         memory_cache_max: cfg.cache.memory_size,
-        disk_cache_max: cfg.cache.disk_size,
+        dds_disk_cache_max: dds_disk_max,
+        chunk_disk_cache_max: chunk_disk_max,
         provider_name: cfg.provider.provider_type.clone(),
     };
 

--- a/xearthlayer-cli/src/ui/dashboard/mod.rs
+++ b/xearthlayer-cli/src/ui/dashboard/mod.rs
@@ -191,15 +191,16 @@ impl Dashboard {
 
         // Update disk history (both reads and writes for I/O tracking)
         self.disk_history.update(
-            snapshot.disk_bytes_written,
-            snapshot.disk_bytes_read,
+            snapshot.chunk_disk_bytes_written,
+            snapshot.chunk_disk_bytes_read + snapshot.dds_disk_bytes_read,
             sample_interval,
         );
 
         let uptime = self.start_time.elapsed();
         let cache_config = CacheConfig {
             memory_max_bytes: self.config.memory_cache_max,
-            disk_max_bytes: self.config.disk_cache_max,
+            dds_disk_max_bytes: self.config.dds_disk_cache_max,
+            chunk_disk_max_bytes: self.config.chunk_disk_cache_max,
         };
 
         // Get prefetch status if available

--- a/xearthlayer-cli/src/ui/dashboard/state.rs
+++ b/xearthlayer-cli/src/ui/dashboard/state.rs
@@ -229,8 +229,10 @@ impl PrewarmProgress {
 pub struct DashboardConfig {
     /// Memory cache max size.
     pub memory_cache_max: usize,
-    /// Disk cache max size.
-    pub disk_cache_max: usize,
+    /// DDS disk cache max size.
+    pub dds_disk_cache_max: usize,
+    /// Chunk disk cache max size.
+    pub chunk_disk_cache_max: usize,
     /// Provider name for display (e.g., "Bing", "Google", "Go2").
     pub provider_name: String,
 }
@@ -239,7 +241,8 @@ impl Default for DashboardConfig {
     fn default() -> Self {
         Self {
             memory_cache_max: 2 * 1024 * 1024 * 1024,
-            disk_cache_max: 20 * 1024 * 1024 * 1024,
+            dds_disk_cache_max: 12 * 1024 * 1024 * 1024,
+            chunk_disk_cache_max: 8 * 1024 * 1024 * 1024,
             provider_name: "Unknown".to_string(),
         }
     }

--- a/xearthlayer-cli/src/ui/dashboard/utils.rs
+++ b/xearthlayer-cli/src/ui/dashboard/utils.rs
@@ -24,13 +24,14 @@ pub fn format_duration(d: Duration) -> String {
 /// Simple non-TUI fallback for non-interactive terminals.
 pub fn print_simple_status(snapshot: &TelemetrySnapshot) {
     println!(
-        "[{}] Tiles: {} completed, {} active | Throughput: {} | Cache: {:.0}% mem, {:.0}% disk",
+        "[{}] Tiles: {} completed, {} active | Throughput: {} | Cache: {:.0}% mem, {:.0}% dds, {:.0}% chunks",
         snapshot.uptime_human(),
         snapshot.jobs_completed,
         snapshot.jobs_active,
         snapshot.throughput_human(),
         snapshot.memory_cache_hit_rate * 100.0,
-        snapshot.disk_cache_hit_rate * 100.0,
+        snapshot.dds_disk_cache_hit_rate * 100.0,
+        snapshot.chunk_disk_cache_hit_rate * 100.0,
     );
 }
 
@@ -55,9 +56,14 @@ pub fn print_session_summary(snapshot: &TelemetrySnapshot) {
         snapshot.memory_cache_hits
     );
     println!(
-        "  Disk cache: {:.1}% hit rate ({} hits)",
-        snapshot.disk_cache_hit_rate * 100.0,
-        snapshot.disk_cache_hits
+        "  DDS disk cache: {:.1}% hit rate ({} hits)",
+        snapshot.dds_disk_cache_hit_rate * 100.0,
+        snapshot.dds_disk_cache_hits
+    );
+    println!(
+        "  Chunk disk cache: {:.1}% hit rate ({} hits)",
+        snapshot.chunk_disk_cache_hit_rate * 100.0,
+        snapshot.chunk_disk_cache_hits
     );
     println!("  Avg throughput: {}", snapshot.throughput_human());
     println!("  Uptime: {}", snapshot.uptime_human());

--- a/xearthlayer-cli/src/ui/widgets/cache.rs
+++ b/xearthlayer-cli/src/ui/widgets/cache.rs
@@ -49,21 +49,31 @@ fn hit_rate_color(rate: f64) -> Color {
     }
 }
 
-/// Render a single cache tier in its column (2 lines).
-///
-/// Line 1: `Label [████░░░░] size/max`
-/// Line 2: `hit% │ Nhits │ Nmiss`
-fn render_cache_tier(
-    buf: &mut Buffer,
-    area: Rect,
-    label: &str,
+/// Data for rendering a single cache tier column.
+struct CacheTierData<'a> {
+    label: &'a str,
     color: Color,
     current_bytes: u64,
     max_bytes: u64,
     hit_rate: f64,
     hits: u64,
     misses: u64,
-) {
+}
+
+/// Render a single cache tier in its column (2 lines).
+///
+/// Line 1: `Label [████░░░░] size/max`
+/// Line 2: `hit% │ Nhits │ Nmiss`
+fn render_cache_tier(buf: &mut Buffer, area: Rect, data: &CacheTierData<'_>) {
+    let CacheTierData {
+        label,
+        color,
+        current_bytes,
+        max_bytes,
+        hit_rate,
+        hits,
+        misses,
+    } = *data;
     if area.height < 2 || area.width < 10 {
         return;
     }
@@ -78,7 +88,11 @@ fn render_cache_tier(
         Span::styled(format!("[{}]", progress_bar), Style::default().fg(color)),
         Span::raw(" "),
         Span::styled(
-            format!("{}/{}", format_bytes(current_bytes), format_bytes(max_bytes)),
+            format!(
+                "{}/{}",
+                format_bytes(current_bytes),
+                format_bytes(max_bytes)
+            ),
             Style::default().fg(color),
         ),
     ]);
@@ -146,39 +160,45 @@ impl Widget for CacheWidgetCompact<'_> {
         render_cache_tier(
             buf,
             columns[0],
-            "Memory",
-            Color::Magenta,
-            self.snapshot.memory_cache_size_bytes,
-            self.config.memory_max_bytes as u64,
-            self.snapshot.memory_cache_hit_rate * 100.0,
-            self.snapshot.memory_cache_hits,
-            self.snapshot.memory_cache_misses,
+            &CacheTierData {
+                label: "Memory",
+                color: Color::Magenta,
+                current_bytes: self.snapshot.memory_cache_size_bytes,
+                max_bytes: self.config.memory_max_bytes as u64,
+                hit_rate: self.snapshot.memory_cache_hit_rate * 100.0,
+                hits: self.snapshot.memory_cache_hits,
+                misses: self.snapshot.memory_cache_misses,
+            },
         );
 
         // DDS Disk tier
         render_cache_tier(
             buf,
             columns[1],
-            "DDS Disk",
-            Color::Blue,
-            self.snapshot.dds_disk_cache_size_bytes,
-            self.config.dds_disk_max_bytes as u64,
-            self.snapshot.dds_disk_cache_hit_rate * 100.0,
-            self.snapshot.dds_disk_cache_hits,
-            self.snapshot.dds_disk_cache_misses,
+            &CacheTierData {
+                label: "DDS Disk",
+                color: Color::Blue,
+                current_bytes: self.snapshot.dds_disk_cache_size_bytes,
+                max_bytes: self.config.dds_disk_max_bytes as u64,
+                hit_rate: self.snapshot.dds_disk_cache_hit_rate * 100.0,
+                hits: self.snapshot.dds_disk_cache_hits,
+                misses: self.snapshot.dds_disk_cache_misses,
+            },
         );
 
         // Chunks tier
         render_cache_tier(
             buf,
             columns[2],
-            "Chunks",
-            Color::Cyan,
-            self.snapshot.chunk_disk_cache_size_bytes,
-            self.config.chunk_disk_max_bytes as u64,
-            self.snapshot.chunk_disk_cache_hit_rate * 100.0,
-            self.snapshot.chunk_disk_cache_hits,
-            self.snapshot.chunk_disk_cache_misses,
+            &CacheTierData {
+                label: "Chunks",
+                color: Color::Cyan,
+                current_bytes: self.snapshot.chunk_disk_cache_size_bytes,
+                max_bytes: self.config.chunk_disk_max_bytes as u64,
+                hit_rate: self.snapshot.chunk_disk_cache_hit_rate * 100.0,
+                hits: self.snapshot.chunk_disk_cache_hits,
+                misses: self.snapshot.chunk_disk_cache_misses,
+            },
         );
     }
 }

--- a/xearthlayer-cli/src/ui/widgets/cache.rs
+++ b/xearthlayer-cli/src/ui/widgets/cache.rs
@@ -1,165 +1,111 @@
 //! Cache status widgets showing memory and disk cache utilization.
 //!
-//! Displays cache statistics in a compact format:
+//! Displays cache statistics in a compact 3-column 2-line format:
 //! ```text
-//! Memory: [████████░░] 1.2/2.0 GB (65%) | Hit: 89.2%
-//! Disk:   [██████░░░░] 6.5/20.0 GB (32%) | Hit: 72.5%
+//! Memory [████░░░░] 1.2/2.0 GB | DDS Disk [████░░░░] 6.5/12.0 GB | Chunks [██░░░░░░] 2.1/8.0 GB
+//! 89.2%  │ 1.5M hits │ 42K miss  │ 93.6%   │ 17.3K hits │ 1.2K miss │ 21.7% │ 5.0K hits │ 18K miss
 //! ```
-//!
-//! Note: CacheWidget is deprecated - use CacheWidgetCompact instead.
-
-#![allow(dead_code)] // Legacy CacheWidget kept for compatibility
 
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Widget},
+    widgets::{Paragraph, Widget},
 };
 use xearthlayer::metrics::TelemetrySnapshot;
 
-use super::primitives::{
-    format_bytes, format_bytes_usize, format_count, ProgressBar, ProgressBarStyle,
-};
+use super::primitives::{format_bytes, format_count, ProgressBar, ProgressBarStyle};
 
 /// Configuration for cache display.
 #[derive(Clone)]
 pub struct CacheConfig {
     /// Maximum memory cache size in bytes.
     pub memory_max_bytes: usize,
-    /// Maximum disk cache size in bytes.
-    pub disk_max_bytes: usize,
+    /// Maximum DDS disk cache size in bytes.
+    pub dds_disk_max_bytes: usize,
+    /// Maximum chunk disk cache size in bytes.
+    pub chunk_disk_max_bytes: usize,
 }
 
 impl Default for CacheConfig {
     fn default() -> Self {
         Self {
-            memory_max_bytes: 2 * 1024 * 1024 * 1024, // 2 GB
-            disk_max_bytes: 20 * 1024 * 1024 * 1024,  // 20 GB
+            memory_max_bytes: 2 * 1024 * 1024 * 1024,
+            dds_disk_max_bytes: 12 * 1024 * 1024 * 1024,
+            chunk_disk_max_bytes: 8 * 1024 * 1024 * 1024,
         }
     }
 }
 
-/// Widget displaying cache statistics in compact format.
+/// Get color for hit rate based on threshold.
+fn hit_rate_color(rate: f64) -> Color {
+    if rate > 80.0 {
+        Color::Green
+    } else if rate > 50.0 {
+        Color::Yellow
+    } else {
+        Color::Red
+    }
+}
+
+/// Render a single cache tier in its column (2 lines).
 ///
-/// Shows memory and disk cache on separate lines with:
-/// - Progress bar with fractional block precision
-/// - Current/max size
-/// - Utilization percentage
-/// - Hit rate
-pub struct CacheWidget<'a> {
-    snapshot: &'a TelemetrySnapshot,
-    config: CacheConfig,
+/// Line 1: `Label [████░░░░] size/max`
+/// Line 2: `hit% │ Nhits │ Nmiss`
+fn render_cache_tier(
+    buf: &mut Buffer,
+    area: Rect,
+    label: &str,
+    color: Color,
+    current_bytes: u64,
+    max_bytes: u64,
+    hit_rate: f64,
+    hits: u64,
+    misses: u64,
+) {
+    if area.height < 2 || area.width < 10 {
+        return;
+    }
+
+    let bar_width = 8;
+    let progress_bar = ProgressBar::from_u64(current_bytes, max_bytes, bar_width)
+        .bar_style(ProgressBarStyle::Fractional)
+        .to_string();
+
+    let line1 = Line::from(vec![
+        Span::styled(format!(" {} ", label), Style::default().fg(Color::White)),
+        Span::styled(format!("[{}]", progress_bar), Style::default().fg(color)),
+        Span::raw(" "),
+        Span::styled(
+            format!("{}/{}", format_bytes(current_bytes), format_bytes(max_bytes)),
+            Style::default().fg(color),
+        ),
+    ]);
+
+    let hit_color = hit_rate_color(hit_rate);
+    let line2 = Line::from(vec![
+        Span::raw(" "),
+        Span::styled(format!("{:.1}%", hit_rate), Style::default().fg(hit_color)),
+        Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("{} hits", format_count(hits)),
+            Style::default().fg(Color::Green),
+        ),
+        Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("{} miss", format_count(misses)),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+
+    let paragraph = Paragraph::new(vec![line1, line2]);
+    paragraph.render(area, buf);
 }
 
-impl<'a> CacheWidget<'a> {
-    pub fn new(snapshot: &'a TelemetrySnapshot) -> Self {
-        Self {
-            snapshot,
-            config: CacheConfig::default(),
-        }
-    }
-
-    pub fn with_config(mut self, config: CacheConfig) -> Self {
-        self.config = config;
-        self
-    }
-
-    /// Get color for hit rate based on threshold.
-    fn hit_rate_color(rate: f64) -> Color {
-        if rate > 80.0 {
-            Color::Green
-        } else if rate > 50.0 {
-            Color::Yellow
-        } else {
-            Color::Red
-        }
-    }
-
-    /// Build a compact cache line with all metrics.
-    fn build_cache_line(
-        label: &str,
-        current_bytes: u64,
-        max_bytes: u64,
-        hit_rate: f64,
-        bar_color: Color,
-    ) -> Line<'static> {
-        let utilization = if max_bytes > 0 {
-            (current_bytes as f64 / max_bytes as f64) * 100.0
-        } else {
-            0.0
-        };
-
-        let progress_bar = ProgressBar::from_u64(current_bytes, max_bytes, 10)
-            .bar_style(ProgressBarStyle::Fractional)
-            .to_string();
-
-        Line::from(vec![
-            Span::styled(format!("  {}: ", label), Style::default().fg(Color::White)),
-            Span::styled(
-                format!("[{}]", progress_bar),
-                Style::default().fg(bar_color),
-            ),
-            Span::raw(" "),
-            Span::styled(
-                format!(
-                    "{}/{}",
-                    format_bytes(current_bytes),
-                    format_bytes(max_bytes)
-                ),
-                Style::default().fg(bar_color),
-            ),
-            Span::styled(
-                format!(" ({:.0}%)", utilization),
-                Style::default().fg(Color::DarkGray),
-            ),
-            Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Hit: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format!("{:.1}%", hit_rate),
-                Style::default().fg(Self::hit_rate_color(hit_rate)),
-            ),
-        ])
-    }
-}
-
-impl Widget for CacheWidget<'_> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        let block = Block::default().borders(Borders::NONE);
-
-        // Memory cache metrics
-        let memory_current = self.snapshot.memory_cache_size_bytes;
-        let memory_max = self.config.memory_max_bytes as u64;
-        let memory_hit_rate = self.snapshot.memory_cache_hit_rate * 100.0;
-
-        // Disk cache metrics
-        let disk_current = self.snapshot.disk_cache_size_bytes;
-        let disk_max = self.config.disk_max_bytes as u64;
-        let disk_hit_rate = self.snapshot.disk_cache_hit_rate * 100.0;
-
-        let memory_line = Self::build_cache_line(
-            "Memory",
-            memory_current,
-            memory_max,
-            memory_hit_rate,
-            Color::Cyan,
-        );
-
-        let disk_line =
-            Self::build_cache_line("Disk  ", disk_current, disk_max, disk_hit_rate, Color::Blue);
-
-        let text = vec![memory_line, disk_line];
-
-        let paragraph = Paragraph::new(text).block(block);
-        paragraph.render(area, buf);
-    }
-}
-
-/// Compact cache widget for the new dashboard layout.
+/// Compact cache widget for the dashboard layout.
 ///
-/// An even more compact version that fits in 4 lines with additional
-/// stats like hits/misses on a second row per cache type.
+/// Renders three cache tiers (Memory, DDS Disk, Chunks) in a 3-column 2-line layout.
 pub struct CacheWidgetCompact<'a> {
     snapshot: &'a TelemetrySnapshot,
     config: CacheConfig,
@@ -181,103 +127,59 @@ impl<'a> CacheWidgetCompact<'a> {
 
 impl Widget for CacheWidgetCompact<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let block = Block::default().borders(Borders::NONE);
+        use ratatui::layout::{Constraint, Direction, Layout};
 
-        // Memory cache
-        let memory_current = self.snapshot.memory_cache_size_bytes;
-        let memory_max = self.config.memory_max_bytes as u64;
-        let memory_hit_rate = self.snapshot.memory_cache_hit_rate * 100.0;
-        let memory_hits = self.snapshot.memory_cache_hits;
-        let memory_misses = self.snapshot.memory_cache_misses;
+        if area.height < 2 {
+            return;
+        }
 
-        let memory_bar = ProgressBar::from_u64(memory_current, memory_max, 10)
-            .bar_style(ProgressBarStyle::Fractional)
-            .to_string();
+        let columns = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Ratio(1, 3),
+                Constraint::Ratio(1, 3),
+                Constraint::Ratio(1, 3),
+            ])
+            .split(area);
 
-        let memory_line1 = Line::from(vec![
-            Span::styled("  Memory: ", Style::default().fg(Color::White)),
-            Span::styled(
-                format!("[{}]", memory_bar),
-                Style::default().fg(Color::Cyan),
-            ),
-            Span::raw(" "),
-            Span::styled(
-                format!(
-                    "{}/{}",
-                    format_bytes(memory_current),
-                    format_bytes_usize(self.config.memory_max_bytes)
-                ),
-                Style::default().fg(Color::Cyan),
-            ),
-        ]);
+        // Memory tier
+        render_cache_tier(
+            buf,
+            columns[0],
+            "Memory",
+            Color::Magenta,
+            self.snapshot.memory_cache_size_bytes,
+            self.config.memory_max_bytes as u64,
+            self.snapshot.memory_cache_hit_rate * 100.0,
+            self.snapshot.memory_cache_hits,
+            self.snapshot.memory_cache_misses,
+        );
 
-        let memory_line2 = Line::from(vec![
-            Span::raw("           "),
-            Span::styled("Hit: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format!("{:.1}%", memory_hit_rate),
-                Style::default().fg(CacheWidget::hit_rate_color(memory_hit_rate)),
-            ),
-            Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format!("{} hits", format_count(memory_hits)),
-                Style::default().fg(Color::Green),
-            ),
-            Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format!("{} miss", format_count(memory_misses)),
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]);
+        // DDS Disk tier
+        render_cache_tier(
+            buf,
+            columns[1],
+            "DDS Disk",
+            Color::Blue,
+            self.snapshot.dds_disk_cache_size_bytes,
+            self.config.dds_disk_max_bytes as u64,
+            self.snapshot.dds_disk_cache_hit_rate * 100.0,
+            self.snapshot.dds_disk_cache_hits,
+            self.snapshot.dds_disk_cache_misses,
+        );
 
-        // Disk cache
-        let disk_current = self.snapshot.disk_cache_size_bytes;
-        let disk_max = self.config.disk_max_bytes as u64;
-        let disk_hit_rate = self.snapshot.disk_cache_hit_rate * 100.0;
-        let disk_hits = self.snapshot.disk_cache_hits;
-        let disk_misses = self.snapshot.disk_cache_misses;
-
-        let disk_bar = ProgressBar::from_u64(disk_current, disk_max, 10)
-            .bar_style(ProgressBarStyle::Fractional)
-            .to_string();
-
-        let disk_line1 = Line::from(vec![
-            Span::styled("  Disk:   ", Style::default().fg(Color::White)),
-            Span::styled(format!("[{}]", disk_bar), Style::default().fg(Color::Blue)),
-            Span::raw(" "),
-            Span::styled(
-                format!(
-                    "{}/{}",
-                    format_bytes(disk_current),
-                    format_bytes_usize(self.config.disk_max_bytes)
-                ),
-                Style::default().fg(Color::Blue),
-            ),
-        ]);
-
-        let disk_line2 = Line::from(vec![
-            Span::raw("           "),
-            Span::styled("Hit: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format!("{:.1}%", disk_hit_rate),
-                Style::default().fg(CacheWidget::hit_rate_color(disk_hit_rate)),
-            ),
-            Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format!("{} hits", format_count(disk_hits)),
-                Style::default().fg(Color::Green),
-            ),
-            Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format!("{} miss", format_count(disk_misses)),
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]);
-
-        let text = vec![memory_line1, memory_line2, disk_line1, disk_line2];
-
-        let paragraph = Paragraph::new(text).block(block);
-        paragraph.render(area, buf);
+        // Chunks tier
+        render_cache_tier(
+            buf,
+            columns[2],
+            "Chunks",
+            Color::Cyan,
+            self.snapshot.chunk_disk_cache_size_bytes,
+            self.config.chunk_disk_max_bytes as u64,
+            self.snapshot.chunk_disk_cache_hit_rate * 100.0,
+            self.snapshot.chunk_disk_cache_hits,
+            self.snapshot.chunk_disk_cache_misses,
+        );
     }
 }
 
@@ -288,9 +190,8 @@ mod tests {
     use ratatui::layout::Rect;
     use ratatui::widgets::Widget;
 
-    /// Helper: render CacheWidgetCompact to a buffer and return all text as a single string.
     fn render_compact_to_string(snapshot: &TelemetrySnapshot) -> String {
-        let area = Rect::new(0, 0, 80, 4);
+        let area = Rect::new(0, 0, 120, 2);
         let mut buf = Buffer::empty(area);
         CacheWidgetCompact::new(snapshot).render(area, &mut buf);
 
@@ -306,7 +207,44 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_cache_hits_formatted_with_thousands_abbreviation() {
+    fn test_three_tier_labels_present() {
+        let snapshot = TelemetrySnapshot::default();
+        let output = render_compact_to_string(&snapshot);
+        assert!(output.contains("Memory"), "Should contain Memory label");
+        assert!(output.contains("DDS Disk"), "Should contain DDS Disk label");
+        assert!(output.contains("Chunks"), "Should contain Chunks label");
+    }
+
+    #[test]
+    fn test_dds_disk_hits_formatted() {
+        let snapshot = TelemetrySnapshot {
+            dds_disk_cache_hits: 17_300,
+            ..Default::default()
+        };
+        let output = render_compact_to_string(&snapshot);
+        assert!(
+            output.contains("17.3K hits"),
+            "DDS disk hits should be formatted, got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_chunk_disk_misses_formatted() {
+        let snapshot = TelemetrySnapshot {
+            chunk_disk_cache_misses: 226_000,
+            ..Default::default()
+        };
+        let output = render_compact_to_string(&snapshot);
+        assert!(
+            output.contains("226.0K miss"),
+            "Chunk disk misses should be formatted, got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_memory_hits_formatted() {
         let snapshot = TelemetrySnapshot {
             memory_cache_hits: 1_500_000,
             ..Default::default()
@@ -314,71 +252,7 @@ mod tests {
         let output = render_compact_to_string(&snapshot);
         assert!(
             output.contains("1.5M hits"),
-            "Memory hits should be formatted as '1.5M hits', got:\n{}",
-            output
-        );
-    }
-
-    #[test]
-    fn test_memory_cache_misses_formatted_with_thousands_abbreviation() {
-        let snapshot = TelemetrySnapshot {
-            memory_cache_misses: 42_300,
-            ..Default::default()
-        };
-        let output = render_compact_to_string(&snapshot);
-        assert!(
-            output.contains("42.3K miss"),
-            "Memory misses should be formatted as '42.3K miss', got:\n{}",
-            output
-        );
-    }
-
-    #[test]
-    fn test_disk_cache_hits_formatted_with_thousands_abbreviation() {
-        let snapshot = TelemetrySnapshot {
-            disk_cache_hits: 5_000,
-            ..Default::default()
-        };
-        let output = render_compact_to_string(&snapshot);
-        assert!(
-            output.contains("5.0K hits"),
-            "Disk hits should be formatted as '5.0K hits', got:\n{}",
-            output
-        );
-    }
-
-    #[test]
-    fn test_disk_cache_misses_formatted_with_thousands_abbreviation() {
-        let snapshot = TelemetrySnapshot {
-            disk_cache_misses: 18_040,
-            ..Default::default()
-        };
-        let output = render_compact_to_string(&snapshot);
-        assert!(
-            output.contains("18.0K miss"),
-            "Disk misses should be formatted as '18.0K miss', got:\n{}",
-            output
-        );
-    }
-
-    #[test]
-    fn test_small_counts_displayed_without_abbreviation() {
-        let snapshot = TelemetrySnapshot {
-            memory_cache_hits: 42,
-            memory_cache_misses: 7,
-            disk_cache_hits: 100,
-            disk_cache_misses: 3,
-            ..Default::default()
-        };
-        let output = render_compact_to_string(&snapshot);
-        assert!(
-            output.contains("42 hits"),
-            "Small memory hits should be unabbreviated, got:\n{}",
-            output
-        );
-        assert!(
-            output.contains("7 miss"),
-            "Small memory misses should be unabbreviated, got:\n{}",
+            "Memory hits should be formatted, got:\n{}",
             output
         );
     }

--- a/xearthlayer-cli/src/ui/widgets/input_output.rs
+++ b/xearthlayer-cli/src/ui/widgets/input_output.rs
@@ -233,8 +233,8 @@ impl Widget for InputOutputWidget<'_> {
 
         // Total disk I/O this session
         let total_disk_writes = self.snapshot.chunk_disk_bytes_written;
-        let total_disk_reads = self.snapshot.chunk_disk_bytes_read
-            + self.snapshot.dds_disk_bytes_read;
+        let total_disk_reads =
+            self.snapshot.chunk_disk_bytes_read + self.snapshot.dds_disk_bytes_read;
 
         // Split into 2 columns
         let columns =

--- a/xearthlayer-cli/src/ui/widgets/input_output.rs
+++ b/xearthlayer-cli/src/ui/widgets/input_output.rs
@@ -232,8 +232,9 @@ impl Widget for InputOutputWidget<'_> {
             };
 
         // Total disk I/O this session
-        let total_disk_writes = self.snapshot.disk_bytes_written;
-        let total_disk_reads = self.snapshot.disk_bytes_read;
+        let total_disk_writes = self.snapshot.chunk_disk_bytes_written;
+        let total_disk_reads = self.snapshot.chunk_disk_bytes_read
+            + self.snapshot.dds_disk_bytes_read;
 
         // Split into 2 columns
         let columns =

--- a/xearthlayer-cli/src/ui/widgets/primitives/mod.rs
+++ b/xearthlayer-cli/src/ui/widgets/primitives/mod.rs
@@ -15,6 +15,6 @@ mod progress_bar;
 mod sparkline;
 
 // Re-export commonly used formatters (others available via primitives::format::*)
-pub use format::{format_bytes, format_bytes_usize, format_count, format_throughput};
+pub use format::{format_bytes, format_count, format_throughput};
 pub use progress_bar::{ProgressBar, ProgressBarStyle};
 pub use sparkline::{Sparkline, SparklineHistory};

--- a/xearthlayer/src/cache/clients/chunk.rs
+++ b/xearthlayer/src/cache/clients/chunk.rs
@@ -81,20 +81,20 @@ impl ChunkCacheClient {
         match self.cache.get(&key).await {
             Ok(Some(data)) => {
                 if let Some(ref m) = self.metrics {
-                    m.disk_cache_hit(data.len() as u64);
+                    m.chunk_disk_cache_hit(data.len() as u64);
                 }
                 Some(data)
             }
             Ok(None) => {
                 if let Some(ref m) = self.metrics {
-                    m.disk_cache_miss();
+                    m.chunk_disk_cache_miss();
                 }
                 None
             }
             Err(e) => {
                 warn!(error = %e, key = %key, "Chunk cache get failed");
                 if let Some(ref m) = self.metrics {
-                    m.disk_cache_miss();
+                    m.chunk_disk_cache_miss();
                 }
                 None
             }

--- a/xearthlayer/src/executor/daemon.rs
+++ b/xearthlayer/src/executor/daemon.rs
@@ -634,6 +634,10 @@ where
             .instrument(tracing::trace_span!(target: "profiling", "dds_disk_cache_check"))
             .await;
         if dds_disk_result.is_none() {
+            // Track DDS disk cache miss in metrics
+            if let Some(client) = metrics_client {
+                client.dds_disk_cache_miss();
+            }
             debug!(
                 tile_row = tile.row,
                 tile_col = tile.col,

--- a/xearthlayer/src/executor/daemon.rs
+++ b/xearthlayer/src/executor/daemon.rs
@@ -659,7 +659,7 @@ where
 
             // Track DDS disk cache hit in metrics
             if let Some(client) = metrics_client {
-                client.disk_cache_hit(data.len() as u64);
+                client.dds_disk_cache_hit(data.len() as u64);
                 if origin.is_fuse() {
                     client.fuse_tile_served();
                 }

--- a/xearthlayer/src/manager/mounts.rs
+++ b/xearthlayer/src/manager/mounts.rs
@@ -793,9 +793,7 @@ impl MountManager {
             total.chunk_disk_bytes_written = total
                 .chunk_disk_bytes_written
                 .max(snapshot.chunk_disk_bytes_written);
-            total.dds_disk_bytes_read = total
-                .dds_disk_bytes_read
-                .max(snapshot.dds_disk_bytes_read);
+            total.dds_disk_bytes_read = total.dds_disk_bytes_read.max(snapshot.dds_disk_bytes_read);
             total.chunk_disk_bytes_read = total
                 .chunk_disk_bytes_read
                 .max(snapshot.chunk_disk_bytes_read);

--- a/xearthlayer/src/manager/mounts.rs
+++ b/xearthlayer/src/manager/mounts.rs
@@ -716,12 +716,17 @@ impl MountManager {
             memory_cache_hit_rate: 0.0,
             fuse_memory_cache_hit_rate: 0.0,
             memory_cache_size_bytes: 0,
-            disk_cache_hits: 0,
-            disk_cache_misses: 0,
-            disk_cache_hit_rate: 0.0,
-            disk_cache_size_bytes: 0,
-            disk_bytes_written: 0,
-            disk_bytes_read: 0,
+            dds_disk_cache_hits: 0,
+            dds_disk_cache_misses: 0,
+            dds_disk_cache_hit_rate: 0.0,
+            dds_disk_cache_size_bytes: 0,
+            dds_disk_bytes_read: 0,
+            chunk_disk_cache_hits: 0,
+            chunk_disk_cache_misses: 0,
+            chunk_disk_cache_hit_rate: 0.0,
+            chunk_disk_cache_size_bytes: 0,
+            chunk_disk_bytes_written: 0,
+            chunk_disk_bytes_read: 0,
             encodes_completed: 0,
             encodes_active: 0,
             bytes_encoded: 0,
@@ -774,14 +779,26 @@ impl MountManager {
             total.memory_cache_size_bytes = total
                 .memory_cache_size_bytes
                 .max(snapshot.memory_cache_size_bytes);
-            total.disk_cache_hits += snapshot.disk_cache_hits;
-            total.disk_cache_misses += snapshot.disk_cache_misses;
-            // Disk cache is also shared across services, so use max()
-            total.disk_cache_size_bytes = total
-                .disk_cache_size_bytes
-                .max(snapshot.disk_cache_size_bytes);
-            total.disk_bytes_written = total.disk_bytes_written.max(snapshot.disk_bytes_written);
-            total.disk_bytes_read = total.disk_bytes_read.max(snapshot.disk_bytes_read);
+            total.dds_disk_cache_hits += snapshot.dds_disk_cache_hits;
+            total.dds_disk_cache_misses += snapshot.dds_disk_cache_misses;
+            total.chunk_disk_cache_hits += snapshot.chunk_disk_cache_hits;
+            total.chunk_disk_cache_misses += snapshot.chunk_disk_cache_misses;
+            // Disk caches are also shared across services, so use max()
+            total.dds_disk_cache_size_bytes = total
+                .dds_disk_cache_size_bytes
+                .max(snapshot.dds_disk_cache_size_bytes);
+            total.chunk_disk_cache_size_bytes = total
+                .chunk_disk_cache_size_bytes
+                .max(snapshot.chunk_disk_cache_size_bytes);
+            total.chunk_disk_bytes_written = total
+                .chunk_disk_bytes_written
+                .max(snapshot.chunk_disk_bytes_written);
+            total.dds_disk_bytes_read = total
+                .dds_disk_bytes_read
+                .max(snapshot.dds_disk_bytes_read);
+            total.chunk_disk_bytes_read = total
+                .chunk_disk_bytes_read
+                .max(snapshot.chunk_disk_bytes_read);
             total.encodes_completed += snapshot.encodes_completed;
             total.encodes_active += snapshot.encodes_active;
             total.bytes_encoded += snapshot.bytes_encoded;
@@ -810,9 +827,16 @@ impl MountManager {
             0.0
         };
 
-        let disk_total = total.disk_cache_hits + total.disk_cache_misses;
-        total.disk_cache_hit_rate = if disk_total > 0 {
-            total.disk_cache_hits as f64 / disk_total as f64
+        let dds_disk_total = total.dds_disk_cache_hits + total.dds_disk_cache_misses;
+        total.dds_disk_cache_hit_rate = if dds_disk_total > 0 {
+            total.dds_disk_cache_hits as f64 / dds_disk_total as f64
+        } else {
+            0.0
+        };
+
+        let chunk_disk_total = total.chunk_disk_cache_hits + total.chunk_disk_cache_misses;
+        total.chunk_disk_cache_hit_rate = if chunk_disk_total > 0 {
+            total.chunk_disk_cache_hits as f64 / chunk_disk_total as f64
         } else {
             0.0
         };

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -435,7 +435,10 @@ mod tests {
             rx.recv().await,
             Some(MetricEvent::DdsDiskCacheHit { bytes: 11_000_000 })
         ));
-        assert!(matches!(rx.recv().await, Some(MetricEvent::DdsDiskCacheMiss)));
+        assert!(matches!(
+            rx.recv().await,
+            Some(MetricEvent::DdsDiskCacheMiss)
+        ));
     }
 
     #[tokio::test]

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -18,7 +18,7 @@
 //! client.download_completed(30_000, 5_000);
 //!
 //! // Record a cache hit
-//! client.disk_cache_hit(30_000);
+//! client.chunk_disk_cache_hit(30_000);
 //! ```
 
 use super::event::MetricEvent;
@@ -92,23 +92,39 @@ impl MetricsClient {
     }
 
     // =========================================================================
-    // Disk Cache Events
+    // Chunk Disk Cache Events
     // =========================================================================
 
-    /// Records a disk cache hit.
+    /// Records a chunk disk cache hit.
     ///
     /// # Arguments
     ///
     /// * `bytes` - Size of the cached chunk
     #[inline]
-    pub fn disk_cache_hit(&self, bytes: u64) {
-        self.send(MetricEvent::DiskCacheHit { bytes });
+    pub fn chunk_disk_cache_hit(&self, bytes: u64) {
+        self.send(MetricEvent::ChunkDiskCacheHit { bytes });
     }
 
-    /// Records a disk cache miss.
+    /// Records a chunk disk cache miss.
     #[inline]
-    pub fn disk_cache_miss(&self) {
-        self.send(MetricEvent::DiskCacheMiss);
+    pub fn chunk_disk_cache_miss(&self) {
+        self.send(MetricEvent::ChunkDiskCacheMiss);
+    }
+
+    // =========================================================================
+    // DDS Disk Cache Events
+    // =========================================================================
+
+    /// Records a DDS disk cache hit (tile-level granularity).
+    #[inline]
+    pub fn dds_disk_cache_hit(&self, bytes: u64) {
+        self.send(MetricEvent::DdsDiskCacheHit { bytes });
+    }
+
+    /// Records a DDS disk cache miss.
+    #[inline]
+    pub fn dds_disk_cache_miss(&self) {
+        self.send(MetricEvent::DdsDiskCacheMiss);
     }
 
     /// Records a disk write starting.
@@ -367,8 +383,8 @@ mod tests {
     async fn test_client_cache_events() {
         let (client, mut rx) = create_client();
 
-        client.disk_cache_hit(2048);
-        client.disk_cache_miss();
+        client.chunk_disk_cache_hit(2048);
+        client.chunk_disk_cache_miss();
         client.disk_write_completed(2048, 1000);
         client.disk_cache_size(9_000_000_000);
         client.memory_cache_hit(true);
@@ -377,9 +393,12 @@ mod tests {
 
         assert!(matches!(
             rx.recv().await,
-            Some(MetricEvent::DiskCacheHit { bytes: 2048 })
+            Some(MetricEvent::ChunkDiskCacheHit { bytes: 2048 })
         ));
-        assert!(matches!(rx.recv().await, Some(MetricEvent::DiskCacheMiss)));
+        assert!(matches!(
+            rx.recv().await,
+            Some(MetricEvent::ChunkDiskCacheMiss)
+        ));
         assert!(matches!(
             rx.recv().await,
             Some(MetricEvent::DiskWriteCompleted {
@@ -404,6 +423,33 @@ mod tests {
         assert!(matches!(
             rx.recv().await,
             Some(MetricEvent::MemoryCacheSizeUpdate { bytes: 1_000_000 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_client_dds_disk_cache_events() {
+        let (client, mut rx) = create_client();
+        client.dds_disk_cache_hit(11_000_000);
+        client.dds_disk_cache_miss();
+        assert!(matches!(
+            rx.recv().await,
+            Some(MetricEvent::DdsDiskCacheHit { bytes: 11_000_000 })
+        ));
+        assert!(matches!(rx.recv().await, Some(MetricEvent::DdsDiskCacheMiss)));
+    }
+
+    #[tokio::test]
+    async fn test_client_chunk_disk_cache_events() {
+        let (client, mut rx) = create_client();
+        client.chunk_disk_cache_hit(2048);
+        client.chunk_disk_cache_miss();
+        assert!(matches!(
+            rx.recv().await,
+            Some(MetricEvent::ChunkDiskCacheHit { bytes: 2048 })
+        ));
+        assert!(matches!(
+            rx.recv().await,
+            Some(MetricEvent::ChunkDiskCacheMiss)
         ));
     }
 

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -160,20 +160,20 @@ impl MetricsDaemon {
                 self.state.chunks_retried += 1;
             }
 
-            // Disk cache events
-            MetricEvent::DiskCacheHit { bytes } => {
-                self.state.disk_cache_hits += 1;
-                self.state.disk_bytes_read += bytes;
+            // Chunk disk cache events
+            MetricEvent::ChunkDiskCacheHit { bytes } => {
+                self.state.chunk_disk_cache_hits += 1;
+                self.state.chunk_disk_bytes_read += bytes;
             }
-            MetricEvent::DiskCacheMiss => {
-                self.state.disk_cache_misses += 1;
+            MetricEvent::ChunkDiskCacheMiss => {
+                self.state.chunk_disk_cache_misses += 1;
             }
             MetricEvent::DiskWriteStarted => {
                 self.state.disk_writes_active += 1;
             }
             MetricEvent::DiskWriteCompleted { bytes, duration_us } => {
                 self.state.disk_writes_active = self.state.disk_writes_active.saturating_sub(1);
-                self.state.disk_bytes_written += bytes;
+                self.state.chunk_disk_bytes_written += bytes;
                 self.state.disk_write_time_us += duration_us;
             }
             MetricEvent::DiskCacheInitialSize { bytes } => {
@@ -184,13 +184,16 @@ impl MetricsDaemon {
             }
             MetricEvent::DiskCacheSizeUpdate { bytes } => {
                 self.state.chunk_disk_cache_size_bytes = bytes;
-                self.state.disk_cache_size_bytes =
-                    self.state.chunk_disk_cache_size_bytes + self.state.dds_disk_cache_size_bytes;
             }
             MetricEvent::DdsDiskCacheSizeUpdate { bytes } => {
                 self.state.dds_disk_cache_size_bytes = bytes;
-                self.state.disk_cache_size_bytes =
-                    self.state.chunk_disk_cache_size_bytes + self.state.dds_disk_cache_size_bytes;
+            }
+            MetricEvent::DdsDiskCacheHit { bytes } => {
+                self.state.dds_disk_cache_hits += 1;
+                self.state.dds_disk_bytes_read += bytes;
+            }
+            MetricEvent::DdsDiskCacheMiss => {
+                self.state.dds_disk_cache_misses += 1;
             }
 
             // Memory cache events
@@ -299,12 +302,12 @@ impl MetricsDaemon {
             // Disk throughput (bytes/sec)
             let disk_delta = self
                 .state
-                .disk_bytes_written
+                .chunk_disk_bytes_written
                 .saturating_sub(self.last_disk_bytes_written);
             self.history
                 .disk_throughput
                 .push(disk_delta as f64 / elapsed);
-            self.last_disk_bytes_written = self.state.disk_bytes_written;
+            self.last_disk_bytes_written = self.state.chunk_disk_bytes_written;
 
             // Job rate (jobs/sec)
             let jobs_delta = self
@@ -396,12 +399,12 @@ mod tests {
     fn test_process_cache_events() {
         let (mut daemon, _tx) = create_daemon();
 
-        daemon.process_event(MetricEvent::DiskCacheHit { bytes: 1024 });
-        daemon.process_event(MetricEvent::DiskCacheMiss);
-        daemon.process_event(MetricEvent::DiskCacheMiss);
+        daemon.process_event(MetricEvent::ChunkDiskCacheHit { bytes: 1024 });
+        daemon.process_event(MetricEvent::ChunkDiskCacheMiss);
+        daemon.process_event(MetricEvent::ChunkDiskCacheMiss);
 
-        assert_eq!(daemon.state.disk_cache_hits, 1);
-        assert_eq!(daemon.state.disk_cache_misses, 2);
+        assert_eq!(daemon.state.chunk_disk_cache_hits, 1);
+        assert_eq!(daemon.state.chunk_disk_cache_misses, 2);
 
         daemon.process_event(MetricEvent::MemoryCacheHit { is_fuse: true });
         daemon.process_event(MetricEvent::MemoryCacheMiss { is_fuse: false });
@@ -416,25 +419,47 @@ mod tests {
     fn test_process_disk_cache_size_update() {
         let (mut daemon, _tx) = create_daemon();
 
-        assert_eq!(daemon.state.disk_cache_size_bytes, 0);
+        assert_eq!(daemon.state.chunk_disk_cache_size_bytes, 0);
 
         // Initial size report
         daemon.process_event(MetricEvent::DiskCacheSizeUpdate {
             bytes: 5_000_000_000,
         });
-        assert_eq!(daemon.state.disk_cache_size_bytes, 5_000_000_000);
+        assert_eq!(daemon.state.chunk_disk_cache_size_bytes, 5_000_000_000);
 
         // Size increases after write
         daemon.process_event(MetricEvent::DiskCacheSizeUpdate {
             bytes: 5_001_000_000,
         });
-        assert_eq!(daemon.state.disk_cache_size_bytes, 5_001_000_000);
+        assert_eq!(daemon.state.chunk_disk_cache_size_bytes, 5_001_000_000);
 
         // Size decreases after eviction
         daemon.process_event(MetricEvent::DiskCacheSizeUpdate {
             bytes: 4_000_000_000,
         });
-        assert_eq!(daemon.state.disk_cache_size_bytes, 4_000_000_000);
+        assert_eq!(daemon.state.chunk_disk_cache_size_bytes, 4_000_000_000);
+    }
+
+    #[test]
+    fn test_process_dds_disk_cache_events() {
+        let (mut daemon, _tx) = create_daemon();
+        daemon.process_event(MetricEvent::DdsDiskCacheHit { bytes: 11_000_000 });
+        daemon.process_event(MetricEvent::DdsDiskCacheHit { bytes: 11_000_000 });
+        daemon.process_event(MetricEvent::DdsDiskCacheMiss);
+        assert_eq!(daemon.state.dds_disk_cache_hits, 2);
+        assert_eq!(daemon.state.dds_disk_cache_misses, 1);
+        assert_eq!(daemon.state.dds_disk_bytes_read, 22_000_000);
+    }
+
+    #[test]
+    fn test_process_chunk_disk_cache_events() {
+        let (mut daemon, _tx) = create_daemon();
+        daemon.process_event(MetricEvent::ChunkDiskCacheHit { bytes: 1024 });
+        daemon.process_event(MetricEvent::ChunkDiskCacheMiss);
+        daemon.process_event(MetricEvent::ChunkDiskCacheMiss);
+        assert_eq!(daemon.state.chunk_disk_cache_hits, 1);
+        assert_eq!(daemon.state.chunk_disk_cache_misses, 2);
+        assert_eq!(daemon.state.chunk_disk_bytes_read, 1024);
     }
 
     #[test]
@@ -513,7 +538,7 @@ mod tests {
 
         // Simulate some activity
         daemon.state.bytes_downloaded = 10_000;
-        daemon.state.disk_bytes_written = 5_000;
+        daemon.state.chunk_disk_bytes_written = 5_000;
         daemon.state.jobs_completed = 2;
 
         // Wait a bit and sample

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -8,7 +8,8 @@
 //!
 //! Events are designed at the appropriate granularity for each component:
 //! - Download events: per-chunk (256 per tile)
-//! - Disk cache events: per-chunk
+//! - Chunk disk cache events: per-chunk (256 per tile)
+//! - DDS disk cache events: per-tile
 //! - Memory cache events: tile-level (checked in daemon)
 //! - Job events: per-job (one per tile request)
 //! - FUSE events: per-request

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -40,16 +40,28 @@ pub enum MetricEvent {
     DownloadRetried,
 
     // =========================================================================
-    // Disk Cache Events (per-chunk granularity)
+    // Chunk Disk Cache Events (per-chunk granularity)
     // =========================================================================
-    /// A chunk was found in the disk cache.
-    DiskCacheHit {
+    /// A chunk was found in the chunk disk cache.
+    ChunkDiskCacheHit {
         /// Size of the cached chunk in bytes.
         bytes: u64,
     },
 
-    /// A chunk was not found in the disk cache.
-    DiskCacheMiss,
+    /// A chunk was not found in the chunk disk cache.
+    ChunkDiskCacheMiss,
+
+    // =========================================================================
+    // DDS Disk Cache Events (per-tile granularity)
+    // =========================================================================
+    /// A DDS tile was found in the DDS disk cache.
+    DdsDiskCacheHit {
+        /// Size of the cached DDS tile in bytes.
+        bytes: u64,
+    },
+
+    /// A DDS tile was not found in the DDS disk cache.
+    DdsDiskCacheMiss,
 
     /// A disk cache write operation started.
     DiskWriteStarted,
@@ -190,8 +202,10 @@ impl MetricEvent {
             Self::DownloadCompleted { .. } => "download_completed",
             Self::DownloadFailed => "download_failed",
             Self::DownloadRetried => "download_retried",
-            Self::DiskCacheHit { .. } => "disk_cache_hit",
-            Self::DiskCacheMiss => "disk_cache_miss",
+            Self::ChunkDiskCacheHit { .. } => "chunk_disk_cache_hit",
+            Self::ChunkDiskCacheMiss => "chunk_disk_cache_miss",
+            Self::DdsDiskCacheHit { .. } => "dds_disk_cache_hit",
+            Self::DdsDiskCacheMiss => "dds_disk_cache_miss",
             Self::DiskWriteStarted => "disk_write_started",
             Self::DiskWriteCompleted { .. } => "disk_write_completed",
             Self::DiskCacheInitialSize { .. } => "disk_cache_initial_size",
@@ -258,5 +272,29 @@ mod tests {
         let event = MetricEvent::JobSubmitted { is_fuse: true };
         let cloned = event.clone();
         assert_eq!(event.event_type(), cloned.event_type());
+    }
+
+    #[test]
+    fn test_dds_disk_cache_event_types() {
+        assert_eq!(
+            MetricEvent::DdsDiskCacheHit { bytes: 1024 }.event_type(),
+            "dds_disk_cache_hit"
+        );
+        assert_eq!(
+            MetricEvent::DdsDiskCacheMiss.event_type(),
+            "dds_disk_cache_miss"
+        );
+    }
+
+    #[test]
+    fn test_chunk_disk_cache_event_types() {
+        assert_eq!(
+            MetricEvent::ChunkDiskCacheHit { bytes: 1024 }.event_type(),
+            "chunk_disk_cache_hit"
+        );
+        assert_eq!(
+            MetricEvent::ChunkDiskCacheMiss.event_type(),
+            "chunk_disk_cache_miss"
+        );
     }
 }

--- a/xearthlayer/src/metrics/optional.rs
+++ b/xearthlayer/src/metrics/optional.rs
@@ -11,8 +11,10 @@ pub trait OptionalMetrics {
     fn download_completed(&self, bytes: u64, duration_us: u64);
     fn download_failed(&self);
     fn download_retried(&self);
-    fn disk_cache_hit(&self, bytes: u64);
-    fn disk_cache_miss(&self);
+    fn chunk_disk_cache_hit(&self, bytes: u64);
+    fn chunk_disk_cache_miss(&self);
+    fn dds_disk_cache_hit(&self, bytes: u64);
+    fn dds_disk_cache_miss(&self);
     fn disk_write_started(&self);
     fn disk_write_completed(&self, bytes: u64, duration_us: u64);
     fn disk_cache_initial_size(&self, bytes: u64);
@@ -63,16 +65,30 @@ impl OptionalMetrics for Option<MetricsClient> {
     }
 
     #[inline]
-    fn disk_cache_hit(&self, bytes: u64) {
+    fn chunk_disk_cache_hit(&self, bytes: u64) {
         if let Some(client) = self {
-            client.disk_cache_hit(bytes);
+            client.chunk_disk_cache_hit(bytes);
         }
     }
 
     #[inline]
-    fn disk_cache_miss(&self) {
+    fn chunk_disk_cache_miss(&self) {
         if let Some(client) = self {
-            client.disk_cache_miss();
+            client.chunk_disk_cache_miss();
+        }
+    }
+
+    #[inline]
+    fn dds_disk_cache_hit(&self, bytes: u64) {
+        if let Some(client) = self {
+            client.dds_disk_cache_hit(bytes);
+        }
+    }
+
+    #[inline]
+    fn dds_disk_cache_miss(&self) {
+        if let Some(client) = self {
+            client.dds_disk_cache_miss();
         }
     }
 

--- a/xearthlayer/src/metrics/reporter.rs
+++ b/xearthlayer/src/metrics/reporter.rs
@@ -91,9 +91,16 @@ impl MetricsReporter for TuiReporter {
             0.0
         };
 
-        let disk_total = state.disk_cache_hits + state.disk_cache_misses;
-        let disk_hit_rate = if disk_total > 0 {
-            state.disk_cache_hits as f64 / disk_total as f64
+        let dds_disk_total = state.dds_disk_cache_hits + state.dds_disk_cache_misses;
+        let dds_disk_hit_rate = if dds_disk_total > 0 {
+            state.dds_disk_cache_hits as f64 / dds_disk_total as f64
+        } else {
+            0.0
+        };
+
+        let chunk_disk_total = state.chunk_disk_cache_hits + state.chunk_disk_cache_misses;
+        let chunk_disk_hit_rate = if chunk_disk_total > 0 {
+            state.chunk_disk_cache_hits as f64 / chunk_disk_total as f64
         } else {
             0.0
         };
@@ -151,12 +158,17 @@ impl MetricsReporter for TuiReporter {
             memory_cache_hit_rate: memory_hit_rate,
             fuse_memory_cache_hit_rate: fuse_memory_hit_rate,
             memory_cache_size_bytes: state.memory_cache_size_bytes,
-            disk_cache_hits: state.disk_cache_hits,
-            disk_cache_misses: state.disk_cache_misses,
-            disk_cache_hit_rate: disk_hit_rate,
-            disk_cache_size_bytes: state.disk_cache_size_bytes,
-            disk_bytes_written: state.disk_bytes_written,
-            disk_bytes_read: state.disk_bytes_read,
+            dds_disk_cache_hits: state.dds_disk_cache_hits,
+            dds_disk_cache_misses: state.dds_disk_cache_misses,
+            dds_disk_cache_hit_rate: dds_disk_hit_rate,
+            dds_disk_cache_size_bytes: state.dds_disk_cache_size_bytes,
+            dds_disk_bytes_read: state.dds_disk_bytes_read,
+            chunk_disk_cache_hits: state.chunk_disk_cache_hits,
+            chunk_disk_cache_misses: state.chunk_disk_cache_misses,
+            chunk_disk_cache_hit_rate: chunk_disk_hit_rate,
+            chunk_disk_cache_size_bytes: state.chunk_disk_cache_size_bytes,
+            chunk_disk_bytes_written: state.chunk_disk_bytes_written,
+            chunk_disk_bytes_read: state.chunk_disk_bytes_read,
 
             // Encode metrics
             encodes_completed: state.encodes_completed,
@@ -196,8 +208,8 @@ mod tests {
 
         state.memory_cache_hits = 30;
         state.memory_cache_misses = 70;
-        state.disk_cache_hits = 200;
-        state.disk_cache_misses = 800;
+        state.dds_disk_cache_hits = 200;
+        state.dds_disk_cache_misses = 800;
 
         state.jobs_submitted = 100;
         state.fuse_jobs_submitted = 80;
@@ -242,8 +254,8 @@ mod tests {
         // Memory: 30 / (30 + 70) = 0.3
         assert!((snapshot.memory_cache_hit_rate - 0.3).abs() < 0.001);
 
-        // Disk: 200 / (200 + 800) = 0.2
-        assert!((snapshot.disk_cache_hit_rate - 0.2).abs() < 0.001);
+        // DDS Disk: 200 / (200 + 800) = 0.2
+        assert!((snapshot.dds_disk_cache_hit_rate - 0.2).abs() < 0.001);
     }
 
     #[test]
@@ -256,7 +268,8 @@ mod tests {
 
         // Should be 0.0, not NaN
         assert_eq!(snapshot.memory_cache_hit_rate, 0.0);
-        assert_eq!(snapshot.disk_cache_hit_rate, 0.0);
+        assert_eq!(snapshot.dds_disk_cache_hit_rate, 0.0);
+        assert_eq!(snapshot.chunk_disk_cache_hit_rate, 0.0);
     }
 
     #[test]
@@ -315,25 +328,25 @@ mod tests {
     }
 
     #[test]
-    fn test_disk_cache_size_uses_absolute_value() {
+    fn test_chunk_disk_cache_size_uses_absolute_value() {
         let mut state = AggregatedState::new();
         let history = TimeSeriesHistory::default();
         let reporter = TuiReporter::new();
 
-        // Set the authoritative disk cache size (from LRU index)
-        state.disk_cache_size_bytes = 5_000_000_000;
+        // Set the authoritative chunk disk cache size (from LRU index)
+        state.chunk_disk_cache_size_bytes = 5_000_000_000;
 
         // These legacy fields should NOT affect the reported size
         state.initial_disk_cache_bytes = 1_000_000_000;
-        state.disk_bytes_written = 10_000_000_000;
+        state.chunk_disk_bytes_written = 10_000_000_000;
         state.disk_bytes_evicted = 500_000_000;
 
         let snapshot = reporter.report(&state, &history);
 
         // Should use the absolute value, not the formula
         assert_eq!(
-            snapshot.disk_cache_size_bytes, 5_000_000_000,
-            "Reporter should use disk_cache_size_bytes directly, not initial+written-evicted"
+            snapshot.chunk_disk_cache_size_bytes, 5_000_000_000,
+            "Reporter should use chunk_disk_cache_size_bytes directly, not initial+written-evicted"
         );
     }
 }

--- a/xearthlayer/src/metrics/snapshot.rs
+++ b/xearthlayer/src/metrics/snapshot.rs
@@ -498,7 +498,7 @@ mod tests {
         assert!(output.contains("Cache:"));
         // Verify thousand separators
         assert!(output.contains("23,040")); // chunks_downloaded
-        // Verify per-tier disk cache lines
+                                            // Verify per-tier disk cache lines
         assert!(output.contains("DDS Disk"));
         assert!(output.contains("Chunks"));
         assert!(output.contains("17,300 hits")); // dds_disk_cache_hits

--- a/xearthlayer/src/metrics/snapshot.rs
+++ b/xearthlayer/src/metrics/snapshot.rs
@@ -63,18 +63,32 @@ pub struct TelemetrySnapshot {
     pub fuse_memory_cache_hit_rate: f64,
     /// Memory cache current size in bytes
     pub memory_cache_size_bytes: u64,
-    /// Disk cache hits
-    pub disk_cache_hits: u64,
-    /// Disk cache misses
-    pub disk_cache_misses: u64,
-    /// Disk cache hit rate (0.0 - 1.0)
-    pub disk_cache_hit_rate: f64,
-    /// Disk cache current size in bytes (initial + session writes)
-    pub disk_cache_size_bytes: u64,
-    /// Disk bytes written this session only (for "Written" display)
-    pub disk_bytes_written: u64,
-    /// Disk bytes read this session (from cache hits)
-    pub disk_bytes_read: u64,
+
+    // === DDS Disk Cache metrics ===
+    /// DDS disk cache hits
+    pub dds_disk_cache_hits: u64,
+    /// DDS disk cache misses
+    pub dds_disk_cache_misses: u64,
+    /// DDS disk cache hit rate (0.0 - 1.0)
+    pub dds_disk_cache_hit_rate: f64,
+    /// DDS disk cache current size in bytes
+    pub dds_disk_cache_size_bytes: u64,
+    /// DDS disk bytes read this session (from cache hits)
+    pub dds_disk_bytes_read: u64,
+
+    // === Chunk Disk Cache metrics ===
+    /// Chunk disk cache hits
+    pub chunk_disk_cache_hits: u64,
+    /// Chunk disk cache misses
+    pub chunk_disk_cache_misses: u64,
+    /// Chunk disk cache hit rate (0.0 - 1.0)
+    pub chunk_disk_cache_hit_rate: f64,
+    /// Chunk disk cache current size in bytes
+    pub chunk_disk_cache_size_bytes: u64,
+    /// Chunk disk bytes written this session
+    pub chunk_disk_bytes_written: u64,
+    /// Chunk disk bytes read this session (from cache hits)
+    pub chunk_disk_bytes_read: u64,
 
     // === Encode metrics ===
     /// Encode operations completed
@@ -130,12 +144,17 @@ impl Default for TelemetrySnapshot {
             memory_cache_hit_rate: 0.0,
             fuse_memory_cache_hit_rate: 0.0,
             memory_cache_size_bytes: 0,
-            disk_cache_hits: 0,
-            disk_cache_misses: 0,
-            disk_cache_hit_rate: 0.0,
-            disk_cache_size_bytes: 0,
-            disk_bytes_written: 0,
-            disk_bytes_read: 0,
+            dds_disk_cache_hits: 0,
+            dds_disk_cache_misses: 0,
+            dds_disk_cache_hit_rate: 0.0,
+            dds_disk_cache_size_bytes: 0,
+            dds_disk_bytes_read: 0,
+            chunk_disk_cache_hits: 0,
+            chunk_disk_cache_misses: 0,
+            chunk_disk_cache_hit_rate: 0.0,
+            chunk_disk_cache_size_bytes: 0,
+            chunk_disk_bytes_written: 0,
+            chunk_disk_bytes_read: 0,
             encodes_completed: 0,
             encodes_active: 0,
             bytes_encoded: 0,
@@ -273,10 +292,17 @@ impl fmt::Display for TelemetrySnapshot {
         )?;
         writeln!(
             f,
-            "  Disk: {:.1}% hit rate ({} hits, {} misses)",
-            self.disk_cache_hit_rate * 100.0,
-            format_number(self.disk_cache_hits),
-            format_number(self.disk_cache_misses)
+            "  DDS Disk: {:.1}% hit rate ({} hits, {} misses)",
+            self.dds_disk_cache_hit_rate * 100.0,
+            format_number(self.dds_disk_cache_hits),
+            format_number(self.dds_disk_cache_misses)
+        )?;
+        writeln!(
+            f,
+            "  Chunks: {:.1}% hit rate ({} hits, {} misses)",
+            self.chunk_disk_cache_hit_rate * 100.0,
+            format_number(self.chunk_disk_cache_hits),
+            format_number(self.chunk_disk_cache_misses)
         )?;
 
         Ok(())
@@ -363,12 +389,17 @@ mod tests {
             memory_cache_hit_rate: 0.333,
             fuse_memory_cache_hit_rate: 0.6,
             memory_cache_size_bytes: 500_000_000,
-            disk_cache_hits: 5000,
-            disk_cache_misses: 18040,
-            disk_cache_hit_rate: 0.217,
-            disk_cache_size_bytes: 5_000_000_000,
-            disk_bytes_written: 500_000_000, // Session writes only
-            disk_bytes_read: 750_000_000,    // Session reads (from cache hits)
+            dds_disk_cache_hits: 17300,
+            dds_disk_cache_misses: 1200,
+            dds_disk_cache_hit_rate: 17300.0 / 18500.0,
+            dds_disk_cache_size_bytes: 289_000_000_000,
+            dds_disk_bytes_read: 190_000_000_000,
+            chunk_disk_cache_hits: 5000,
+            chunk_disk_cache_misses: 18040,
+            chunk_disk_cache_hit_rate: 5000.0 / 23040.0,
+            chunk_disk_cache_size_bytes: 5_000_000_000,
+            chunk_disk_bytes_written: 500_000_000,
+            chunk_disk_bytes_read: 750_000_000,
             encodes_completed: 90,
             encodes_active: 2,
             bytes_encoded: 1_000_000_000, // ~1 GB
@@ -467,8 +498,13 @@ mod tests {
         assert!(output.contains("Cache:"));
         // Verify thousand separators
         assert!(output.contains("23,040")); // chunks_downloaded
-        assert!(output.contains("5,000 hits")); // disk_cache_hits
-        assert!(output.contains("18,040 misses")); // disk_cache_misses
+        // Verify per-tier disk cache lines
+        assert!(output.contains("DDS Disk"));
+        assert!(output.contains("Chunks"));
+        assert!(output.contains("17,300 hits")); // dds_disk_cache_hits
+        assert!(output.contains("1,200 misses")); // dds_disk_cache_misses
+        assert!(output.contains("5,000 hits")); // chunk_disk_cache_hits
+        assert!(output.contains("18,040 misses")); // chunk_disk_cache_misses
     }
 
     #[test]
@@ -481,5 +517,27 @@ mod tests {
     fn test_throughput_human() {
         let snapshot = test_snapshot();
         assert_eq!(snapshot.throughput_human(), "19.1 KB/s");
+    }
+
+    #[test]
+    fn test_dds_disk_cache_hit_rate() {
+        let snapshot = TelemetrySnapshot {
+            dds_disk_cache_hits: 93,
+            dds_disk_cache_misses: 7,
+            dds_disk_cache_hit_rate: 0.93,
+            ..Default::default()
+        };
+        assert!((snapshot.dds_disk_cache_hit_rate - 0.93).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_chunk_disk_cache_hit_rate() {
+        let snapshot = TelemetrySnapshot {
+            chunk_disk_cache_hits: 5000,
+            chunk_disk_cache_misses: 18000,
+            chunk_disk_cache_hit_rate: 5000.0 / 23000.0,
+            ..Default::default()
+        };
+        assert!((snapshot.chunk_disk_cache_hit_rate - 0.2174).abs() < 0.001);
     }
 }

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -134,18 +134,18 @@ pub struct AggregatedState {
     pub download_time_us: u64,
 
     // =========================================================================
-    // Disk Cache Metrics
+    // Chunk Disk Cache Metrics
     // =========================================================================
-    /// Disk cache hits.
-    pub disk_cache_hits: u64,
-    /// Disk cache misses.
-    pub disk_cache_misses: u64,
-    /// Active disk writes.
+    /// Chunk disk cache hits.
+    pub chunk_disk_cache_hits: u64,
+    /// Chunk disk cache misses.
+    pub chunk_disk_cache_misses: u64,
+    /// Active disk writes (chunks only — DDS writes don't emit write events).
     pub disk_writes_active: u64,
-    /// Total bytes written to disk cache.
-    pub disk_bytes_written: u64,
-    /// Total bytes read from disk cache (cache hits).
-    pub disk_bytes_read: u64,
+    /// Total bytes written to chunk disk cache.
+    pub chunk_disk_bytes_written: u64,
+    /// Total bytes read from chunk disk cache (cache hits).
+    pub chunk_disk_bytes_read: u64,
     /// Total disk write time in microseconds.
     pub disk_write_time_us: u64,
     /// Initial disk cache size (scanned on startup, not reset).
@@ -153,19 +153,19 @@ pub struct AggregatedState {
     /// Total bytes evicted from disk cache by the GC daemon.
     pub disk_bytes_evicted: u64,
     /// Current chunk disk cache size in bytes (absolute value from LRU index).
-    ///
-    /// Updated directly via `DiskCacheSizeUpdate` events from the chunk
-    /// `DiskCacheProvider` after writes and evictions.
     pub chunk_disk_cache_size_bytes: u64,
+
+    // =========================================================================
+    // DDS Disk Cache Metrics
+    // =========================================================================
+    /// DDS disk cache hits.
+    pub dds_disk_cache_hits: u64,
+    /// DDS disk cache misses.
+    pub dds_disk_cache_misses: u64,
+    /// Total bytes read from DDS disk cache (cache hits).
+    pub dds_disk_bytes_read: u64,
     /// Current DDS disk cache size in bytes (absolute value from LRU index).
-    ///
-    /// Updated directly via `DdsDiskCacheSizeUpdate` events from the DDS
-    /// `DiskCacheProvider` after writes and evictions.
     pub dds_disk_cache_size_bytes: u64,
-    /// Combined disk cache size in bytes (chunk + DDS).
-    ///
-    /// Computed as `chunk_disk_cache_size_bytes + dds_disk_cache_size_bytes`.
-    pub disk_cache_size_bytes: u64,
 
     // =========================================================================
     // Memory Cache Metrics
@@ -251,17 +251,19 @@ impl AggregatedState {
             chunks_retried: 0,
             bytes_downloaded: 0,
             download_time_us: 0,
-            disk_cache_hits: 0,
-            disk_cache_misses: 0,
+            chunk_disk_cache_hits: 0,
+            chunk_disk_cache_misses: 0,
             disk_writes_active: 0,
-            disk_bytes_written: 0,
-            disk_bytes_read: 0,
+            chunk_disk_bytes_written: 0,
+            chunk_disk_bytes_read: 0,
             disk_write_time_us: 0,
             initial_disk_cache_bytes: 0,
             disk_bytes_evicted: 0,
             chunk_disk_cache_size_bytes: 0,
+            dds_disk_cache_hits: 0,
+            dds_disk_cache_misses: 0,
+            dds_disk_bytes_read: 0,
             dds_disk_cache_size_bytes: 0,
-            disk_cache_size_bytes: 0,
             memory_cache_hits: 0,
             memory_cache_misses: 0,
             fuse_memory_cache_hits: 0,
@@ -300,12 +302,15 @@ impl AggregatedState {
         self.chunks_retried = 0;
         self.bytes_downloaded = 0;
         self.download_time_us = 0;
-        self.disk_cache_hits = 0;
-        self.disk_cache_misses = 0;
+        self.chunk_disk_cache_hits = 0;
+        self.chunk_disk_cache_misses = 0;
         self.disk_writes_active = 0;
-        self.disk_bytes_written = 0;
-        self.disk_bytes_read = 0;
+        self.chunk_disk_bytes_written = 0;
+        self.chunk_disk_bytes_read = 0;
         self.disk_write_time_us = 0;
+        self.dds_disk_cache_hits = 0;
+        self.dds_disk_cache_misses = 0;
+        self.dds_disk_bytes_read = 0;
         self.memory_cache_hits = 0;
         self.memory_cache_misses = 0;
         self.fuse_memory_cache_hits = 0;

--- a/xearthlayer/src/panic.rs
+++ b/xearthlayer/src/panic.rs
@@ -158,8 +158,13 @@ fn handle_panic(info: &PanicHookInfo<'_>) {
                 );
                 let _ = writeln!(
                     stderr,
-                    "Disk cache:       {} bytes",
-                    snapshot.disk_cache_size_bytes
+                    "DDS disk cache:   {} bytes",
+                    snapshot.dds_disk_cache_size_bytes
+                );
+                let _ = writeln!(
+                    stderr,
+                    "Chunk disk cache: {} bytes",
+                    snapshot.chunk_disk_cache_size_bytes
                 );
                 let _ = writeln!(stderr);
             }

--- a/xearthlayer/src/tasks/download_chunks.rs
+++ b/xearthlayer/src/tasks/download_chunks.rs
@@ -304,8 +304,8 @@ where
             chunk_col = chunk_col,
             "Chunk cache hit"
         );
-        // Emit disk cache hit metric
-        metrics.disk_cache_hit(cached.len() as u64);
+        // Emit chunk disk cache hit metric
+        metrics.chunk_disk_cache_hit(cached.len() as u64);
         return Ok(ChunkData {
             row: chunk_row,
             col: chunk_col,
@@ -313,8 +313,8 @@ where
         });
     }
 
-    // Emit disk cache miss metric
-    metrics.disk_cache_miss();
+    // Emit chunk disk cache miss metric
+    metrics.chunk_disk_cache_miss();
 
     // Calculate global coordinates for the provider
     let global_row = tile.row * crate::coord::CHUNKS_PER_TILE_SIDE + chunk_row as u32;


### PR DESCRIPTION
## Summary

- Split the combined "Disk" cache display into three independent tiers: **Memory**, **DDS Disk**, and **Chunks**
- Added dedicated `DdsDiskCacheHit`/`DdsDiskCacheMiss` metric events (tile-level granularity) distinct from chunk-level disk cache events
- Renamed `DiskCacheHit`/`DiskCacheMiss` → `ChunkDiskCacheHit`/`ChunkDiskCacheMiss` across the full metrics pipeline (event → client → daemon → state → snapshot → reporter → TUI)
- Redesigned `CacheWidgetCompact` as a **2-line, 3-column layout** showing per-tier progress bars and hit/miss counters
- DDS disk cache hit rate (93%+ in flight tests) is now visible instead of being buried by chunk-level event volume (~1.7% combined)

Closes #166

## Test plan

- [x] All 2,515 tests pass (`make pre-commit` green)
- [x] New tests for DDS disk event types, client methods, daemon routing, snapshot hit rates, and 3-column widget rendering
- [x] Clippy clean, no warnings
- [x] Flight test to verify TUI displays three tiers correctly with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)