### PR TITLE
fix(tui): cache hit rates reflect X-Plane requests, not prefetch traffic (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **TUI cache hit rates reflect X-Plane experience, not prefetch traffic** ([#171](https://github.com/samsoir/xearthlayer/issues/171)): The Memory and DDS Disk tiers in the cache widget now render FUSE-only hit rates and counts, so the percentages reflect how well the cache is serving X-Plane's actual requests. Previously, aggregate counters included prefetch and prewarm traffic — a long-haul flight with a 100%-full memory cache would show ~47% hit rate because prefetch misses dominated the denominator. Added `is_fuse` discriminator to `DdsDiskCacheHit`/`DdsDiskCacheMiss` events, paired FUSE-only counters in state and snapshot, and wired the executor daemon to tag events based on `RequestOrigin`. The Chunks tier continues to use aggregate (there's only one chunk-read path, so aggregate equals FUSE there). Also fixed a latent bug in `manager/mounts.rs` where `fuse_memory_cache_hit_rate` was never recalculated during multi-service aggregation.
+
 ### Changed
 
 - **Three-tier cache metrics in TUI** ([#166](https://github.com/samsoir/xearthlayer/issues/166)): Split the combined "Disk" cache display into separate DDS Disk and Chunks tiers with independent hit rates. The TUI now shows a 3-column layout (Memory, DDS Disk, Chunks) with per-tier progress bars and hit/miss counters. DDS disk hit rate (93%+ in flight tests) is no longer hidden by chunk-level event volume.

--- a/xearthlayer-cli/src/ui/dashboard/utils.rs
+++ b/xearthlayer-cli/src/ui/dashboard/utils.rs
@@ -21,50 +21,152 @@ pub fn format_duration(d: Duration) -> String {
     }
 }
 
-/// Simple non-TUI fallback for non-interactive terminals.
-pub fn print_simple_status(snapshot: &TelemetrySnapshot) {
-    println!(
+/// Format the simple non-TUI status line.
+///
+/// Memory and DDS disk hit rates use the FUSE-only counters so the line
+/// reflects X-Plane's actual cache experience; chunks use the aggregate
+/// (only one path emits chunk events, so aggregate == FUSE there). See #171.
+pub fn format_simple_status(snapshot: &TelemetrySnapshot) -> String {
+    format!(
         "[{}] Tiles: {} completed, {} active | Throughput: {} | Cache: {:.0}% mem, {:.0}% dds, {:.0}% chunks",
         snapshot.uptime_human(),
         snapshot.jobs_completed,
         snapshot.jobs_active,
         snapshot.throughput_human(),
-        snapshot.memory_cache_hit_rate * 100.0,
-        snapshot.dds_disk_cache_hit_rate * 100.0,
+        snapshot.fuse_memory_cache_hit_rate * 100.0,
+        snapshot.fuse_dds_disk_cache_hit_rate * 100.0,
         snapshot.chunk_disk_cache_hit_rate * 100.0,
-    );
+    )
+}
+
+/// Simple non-TUI fallback for non-interactive terminals.
+pub fn print_simple_status(snapshot: &TelemetrySnapshot) {
+    println!("{}", format_simple_status(snapshot));
+}
+
+/// Format the final session summary as a multi-line string.
+///
+/// Memory and DDS disk rates use FUSE-only counters (see #171).
+pub fn format_session_summary(snapshot: &TelemetrySnapshot) -> String {
+    let mut out = String::new();
+    out.push('\n');
+    out.push_str("Session Summary\n");
+    out.push_str("───────────────\n");
+    out.push_str(&format!(
+        "  Tiles generated: {} ({} failed)\n",
+        snapshot.jobs_completed, snapshot.jobs_failed
+    ));
+    out.push_str(&format!(
+        "  Tiles coalesced: {} ({:.0}% savings)\n",
+        snapshot.jobs_coalesced,
+        snapshot.coalescing_rate() * 100.0
+    ));
+    out.push_str(&format!(
+        "  Data downloaded: {}\n",
+        snapshot.bytes_downloaded_human()
+    ));
+    out.push_str(&format!(
+        "  Memory cache: {:.1}% hit rate ({} hits) [FUSE]\n",
+        snapshot.fuse_memory_cache_hit_rate * 100.0,
+        snapshot.fuse_memory_cache_hits
+    ));
+    out.push_str(&format!(
+        "  DDS disk cache: {:.1}% hit rate ({} hits) [FUSE]\n",
+        snapshot.fuse_dds_disk_cache_hit_rate * 100.0,
+        snapshot.fuse_dds_disk_cache_hits
+    ));
+    out.push_str(&format!(
+        "  Chunk disk cache: {:.1}% hit rate ({} hits)\n",
+        snapshot.chunk_disk_cache_hit_rate * 100.0,
+        snapshot.chunk_disk_cache_hits
+    ));
+    out.push_str(&format!(
+        "  Avg throughput: {}\n",
+        snapshot.throughput_human()
+    ));
+    out.push_str(&format!("  Uptime: {}\n", snapshot.uptime_human()));
+    out
 }
 
 /// Print final session summary.
 pub fn print_session_summary(snapshot: &TelemetrySnapshot) {
-    println!();
-    println!("Session Summary");
-    println!("───────────────");
-    println!(
-        "  Tiles generated: {} ({} failed)",
-        snapshot.jobs_completed, snapshot.jobs_failed
-    );
-    println!(
-        "  Tiles coalesced: {} ({:.0}% savings)",
-        snapshot.jobs_coalesced,
-        snapshot.coalescing_rate() * 100.0
-    );
-    println!("  Data downloaded: {}", snapshot.bytes_downloaded_human());
-    println!(
-        "  Memory cache: {:.1}% hit rate ({} hits)",
-        snapshot.memory_cache_hit_rate * 100.0,
-        snapshot.memory_cache_hits
-    );
-    println!(
-        "  DDS disk cache: {:.1}% hit rate ({} hits)",
-        snapshot.dds_disk_cache_hit_rate * 100.0,
-        snapshot.dds_disk_cache_hits
-    );
-    println!(
-        "  Chunk disk cache: {:.1}% hit rate ({} hits)",
-        snapshot.chunk_disk_cache_hit_rate * 100.0,
-        snapshot.chunk_disk_cache_hits
-    );
-    println!("  Avg throughput: {}", snapshot.throughput_human());
-    println!("  Uptime: {}", snapshot.uptime_human());
+    print!("{}", format_session_summary(snapshot));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_simple_status_uses_fuse_rates_for_memory_and_dds() {
+        // Regression for #171: status line must show FUSE-only hit rates so
+        // it matches the TUI cache widget and reflects X-Plane's experience.
+        let snapshot = TelemetrySnapshot {
+            memory_cache_hit_rate: 0.40,        // aggregate (misleading)
+            fuse_memory_cache_hit_rate: 0.90,   // FUSE-only (correct)
+            dds_disk_cache_hit_rate: 0.20,      // aggregate
+            fuse_dds_disk_cache_hit_rate: 0.80, // FUSE-only
+            chunk_disk_cache_hit_rate: 0.05,    // unchanged
+            ..Default::default()
+        };
+        let out = format_simple_status(&snapshot);
+        assert!(
+            out.contains("90% mem"),
+            "expected FUSE memory rate '90% mem', got: {}",
+            out
+        );
+        assert!(
+            !out.contains("40% mem"),
+            "must not contain aggregate memory rate, got: {}",
+            out
+        );
+        assert!(
+            out.contains("80% dds"),
+            "expected FUSE DDS rate '80% dds', got: {}",
+            out
+        );
+        assert!(
+            !out.contains("20% dds"),
+            "must not contain aggregate DDS rate, got: {}",
+            out
+        );
+        assert!(
+            out.contains("5% chunks"),
+            "chunks should still use aggregate, got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_format_session_summary_uses_fuse_rates_for_memory_and_dds() {
+        let snapshot = TelemetrySnapshot {
+            memory_cache_hits: 1000,
+            memory_cache_hit_rate: 0.30,
+            fuse_memory_cache_hits: 500,
+            fuse_memory_cache_hit_rate: 0.85,
+            dds_disk_cache_hits: 800,
+            dds_disk_cache_hit_rate: 0.25,
+            fuse_dds_disk_cache_hits: 400,
+            fuse_dds_disk_cache_hit_rate: 0.75,
+            chunk_disk_cache_hits: 50,
+            chunk_disk_cache_hit_rate: 0.10,
+            ..Default::default()
+        };
+        let out = format_session_summary(&snapshot);
+        assert!(
+            out.contains("Memory cache: 85.0% hit rate (500 hits)"),
+            "expected FUSE memory line, got:\n{}",
+            out
+        );
+        assert!(
+            out.contains("DDS disk cache: 75.0% hit rate (400 hits)"),
+            "expected FUSE DDS line, got:\n{}",
+            out
+        );
+        assert!(
+            out.contains("Chunk disk cache: 10.0% hit rate (50 hits)"),
+            "chunks should use aggregate, got:\n{}",
+            out
+        );
+    }
 }

--- a/xearthlayer-cli/src/ui/widgets/cache.rs
+++ b/xearthlayer-cli/src/ui/widgets/cache.rs
@@ -156,7 +156,9 @@ impl Widget for CacheWidgetCompact<'_> {
             ])
             .split(area);
 
-        // Memory tier
+        // Memory tier — FUSE-only counts/rate so the widget reflects
+        // X-Plane's actual cache experience rather than aggregate totals
+        // diluted by prefetch/prewarm traffic (see #171).
         render_cache_tier(
             buf,
             columns[0],
@@ -165,13 +167,13 @@ impl Widget for CacheWidgetCompact<'_> {
                 color: Color::Magenta,
                 current_bytes: self.snapshot.memory_cache_size_bytes,
                 max_bytes: self.config.memory_max_bytes as u64,
-                hit_rate: self.snapshot.memory_cache_hit_rate * 100.0,
-                hits: self.snapshot.memory_cache_hits,
-                misses: self.snapshot.memory_cache_misses,
+                hit_rate: self.snapshot.fuse_memory_cache_hit_rate * 100.0,
+                hits: self.snapshot.fuse_memory_cache_hits,
+                misses: self.snapshot.fuse_memory_cache_misses,
             },
         );
 
-        // DDS Disk tier
+        // DDS Disk tier — FUSE-only counts/rate (see #171).
         render_cache_tier(
             buf,
             columns[1],
@@ -180,9 +182,9 @@ impl Widget for CacheWidgetCompact<'_> {
                 color: Color::Blue,
                 current_bytes: self.snapshot.dds_disk_cache_size_bytes,
                 max_bytes: self.config.dds_disk_max_bytes as u64,
-                hit_rate: self.snapshot.dds_disk_cache_hit_rate * 100.0,
-                hits: self.snapshot.dds_disk_cache_hits,
-                misses: self.snapshot.dds_disk_cache_misses,
+                hit_rate: self.snapshot.fuse_dds_disk_cache_hit_rate * 100.0,
+                hits: self.snapshot.fuse_dds_disk_cache_hits,
+                misses: self.snapshot.fuse_dds_disk_cache_misses,
             },
         );
 
@@ -238,7 +240,7 @@ mod tests {
     #[test]
     fn test_dds_disk_hits_formatted() {
         let snapshot = TelemetrySnapshot {
-            dds_disk_cache_hits: 17_300,
+            fuse_dds_disk_cache_hits: 17_300,
             ..Default::default()
         };
         let output = render_compact_to_string(&snapshot);
@@ -266,13 +268,103 @@ mod tests {
     #[test]
     fn test_memory_hits_formatted() {
         let snapshot = TelemetrySnapshot {
-            memory_cache_hits: 1_500_000,
+            fuse_memory_cache_hits: 1_500_000,
             ..Default::default()
         };
         let output = render_compact_to_string(&snapshot);
         assert!(
             output.contains("1.5M hits"),
             "Memory hits should be formatted, got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_memory_tier_uses_fuse_only_rate() {
+        // Regression for #171: widget must render the FUSE-only memory hit rate
+        // to show X-Plane's actual cache experience, not the aggregate polluted
+        // by prefetch traffic.
+        let snapshot = TelemetrySnapshot {
+            // Aggregate: looks like ~40% hit rate (dominated by prefetch misses)
+            memory_cache_hits: 40,
+            memory_cache_misses: 60,
+            memory_cache_hit_rate: 0.40,
+            // FUSE only: X-Plane actually sees 90% hit rate
+            fuse_memory_cache_hits: 90,
+            fuse_memory_cache_misses: 10,
+            fuse_memory_cache_hit_rate: 0.90,
+            ..Default::default()
+        };
+        let output = render_compact_to_string(&snapshot);
+        assert!(
+            output.contains("90.0%"),
+            "Memory tier should render FUSE rate 90.0%, got:\n{}",
+            output
+        );
+        assert!(
+            !output.contains("40.0%"),
+            "Memory tier must NOT render aggregate rate 40.0%, got:\n{}",
+            output
+        );
+        assert!(
+            output.contains("90 hits"),
+            "Memory tier should render FUSE hits (90), got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_dds_disk_tier_uses_fuse_only_rate() {
+        // Regression for #171: widget must render the FUSE-only DDS disk hit
+        // rate, not the aggregate polluted by prefetch traffic.
+        let snapshot = TelemetrySnapshot {
+            // Aggregate: dominated by prefetch misses
+            dds_disk_cache_hits: 200,
+            dds_disk_cache_misses: 800,
+            dds_disk_cache_hit_rate: 0.20,
+            // FUSE only: 80% hit rate
+            fuse_dds_disk_cache_hits: 80,
+            fuse_dds_disk_cache_misses: 20,
+            fuse_dds_disk_cache_hit_rate: 0.80,
+            ..Default::default()
+        };
+        let output = render_compact_to_string(&snapshot);
+        assert!(
+            output.contains("80.0%"),
+            "DDS disk tier should render FUSE rate 80.0%, got:\n{}",
+            output
+        );
+        assert!(
+            !output.contains("20.0%"),
+            "DDS disk tier must NOT render aggregate rate 20.0%, got:\n{}",
+            output
+        );
+        assert!(
+            output.contains("80 hits"),
+            "DDS disk tier should render FUSE hits (80), got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_chunk_tier_still_uses_aggregate() {
+        // Chunks are fine as aggregate (all chunk reads flow through one path,
+        // no origin discrimination needed). This pins that behavior.
+        let snapshot = TelemetrySnapshot {
+            chunk_disk_cache_hits: 5000,
+            chunk_disk_cache_misses: 1000,
+            chunk_disk_cache_hit_rate: 5000.0 / 6000.0, // ~83.3%
+            ..Default::default()
+        };
+        let output = render_compact_to_string(&snapshot);
+        assert!(
+            output.contains("83.3%"),
+            "Chunks tier should render aggregate rate 83.3%, got:\n{}",
+            output
+        );
+        assert!(
+            output.contains("5.0K hits"),
+            "Chunks tier should render aggregate hit count, got:\n{}",
             output
         );
     }

--- a/xearthlayer/src/executor/daemon.rs
+++ b/xearthlayer/src/executor/daemon.rs
@@ -634,9 +634,11 @@ where
             .instrument(tracing::trace_span!(target: "profiling", "dds_disk_cache_check"))
             .await;
         if dds_disk_result.is_none() {
-            // Track DDS disk cache miss in metrics
+            // Track DDS disk cache miss in metrics.
+            // Passes origin.is_fuse() so the daemon can maintain a FUSE-only
+            // counter separate from prefetch/prewarm traffic (see #171).
             if let Some(client) = metrics_client {
-                client.dds_disk_cache_miss();
+                client.dds_disk_cache_miss(origin.is_fuse());
             }
             debug!(
                 tile_row = tile.row,
@@ -661,9 +663,11 @@ where
                 "DDS disk cache hit — serving without re-encode"
             );
 
-            // Track DDS disk cache hit in metrics
+            // Track DDS disk cache hit in metrics.
+            // Passes origin.is_fuse() so the daemon can maintain a FUSE-only
+            // counter separate from prefetch/prewarm traffic (see #171).
             if let Some(client) = metrics_client {
-                client.dds_disk_cache_hit(data.len() as u64);
+                client.dds_disk_cache_hit(data.len() as u64, origin.is_fuse());
                 if origin.is_fuse() {
                     client.fuse_tile_served();
                 }

--- a/xearthlayer/src/manager/mounts.rs
+++ b/xearthlayer/src/manager/mounts.rs
@@ -714,11 +714,16 @@ impl MountManager {
             memory_cache_hits: 0,
             memory_cache_misses: 0,
             memory_cache_hit_rate: 0.0,
+            fuse_memory_cache_hits: 0,
+            fuse_memory_cache_misses: 0,
             fuse_memory_cache_hit_rate: 0.0,
             memory_cache_size_bytes: 0,
             dds_disk_cache_hits: 0,
             dds_disk_cache_misses: 0,
             dds_disk_cache_hit_rate: 0.0,
+            fuse_dds_disk_cache_hits: 0,
+            fuse_dds_disk_cache_misses: 0,
+            fuse_dds_disk_cache_hit_rate: 0.0,
             dds_disk_cache_size_bytes: 0,
             dds_disk_bytes_read: 0,
             chunk_disk_cache_hits: 0,
@@ -774,6 +779,8 @@ impl MountManager {
             total.downloads_active += snapshot.downloads_active;
             total.memory_cache_hits += snapshot.memory_cache_hits;
             total.memory_cache_misses += snapshot.memory_cache_misses;
+            total.fuse_memory_cache_hits += snapshot.fuse_memory_cache_hits;
+            total.fuse_memory_cache_misses += snapshot.fuse_memory_cache_misses;
             // Use max() for cache sizes since all services share the same cache
             // (summing would incorrectly report N times the actual size)
             total.memory_cache_size_bytes = total
@@ -781,6 +788,8 @@ impl MountManager {
                 .max(snapshot.memory_cache_size_bytes);
             total.dds_disk_cache_hits += snapshot.dds_disk_cache_hits;
             total.dds_disk_cache_misses += snapshot.dds_disk_cache_misses;
+            total.fuse_dds_disk_cache_hits += snapshot.fuse_dds_disk_cache_hits;
+            total.fuse_dds_disk_cache_misses += snapshot.fuse_dds_disk_cache_misses;
             total.chunk_disk_cache_hits += snapshot.chunk_disk_cache_hits;
             total.chunk_disk_cache_misses += snapshot.chunk_disk_cache_misses;
             // Disk caches are also shared across services, so use max()
@@ -821,6 +830,20 @@ impl MountManager {
         let memory_total = total.memory_cache_hits + total.memory_cache_misses;
         total.memory_cache_hit_rate = if memory_total > 0 {
             total.memory_cache_hits as f64 / memory_total as f64
+        } else {
+            0.0
+        };
+
+        let fuse_memory_total = total.fuse_memory_cache_hits + total.fuse_memory_cache_misses;
+        total.fuse_memory_cache_hit_rate = if fuse_memory_total > 0 {
+            total.fuse_memory_cache_hits as f64 / fuse_memory_total as f64
+        } else {
+            0.0
+        };
+
+        let fuse_dds_disk_total = total.fuse_dds_disk_cache_hits + total.fuse_dds_disk_cache_misses;
+        total.fuse_dds_disk_cache_hit_rate = if fuse_dds_disk_total > 0 {
+            total.fuse_dds_disk_cache_hits as f64 / fuse_dds_disk_total as f64
         } else {
             0.0
         };

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -116,15 +116,27 @@ impl MetricsClient {
     // =========================================================================
 
     /// Records a DDS disk cache hit (tile-level granularity).
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - Size of the cached DDS tile
+    /// * `is_fuse` - `true` if this was a FUSE (X-Plane) request, `false` for
+    ///   prefetch/prewarm. The daemon uses this to maintain a FUSE-only counter
+    ///   that powers the cache widget's X-Plane-experience hit rate (see #171).
     #[inline]
-    pub fn dds_disk_cache_hit(&self, bytes: u64) {
-        self.send(MetricEvent::DdsDiskCacheHit { bytes });
+    pub fn dds_disk_cache_hit(&self, bytes: u64, is_fuse: bool) {
+        self.send(MetricEvent::DdsDiskCacheHit { bytes, is_fuse });
     }
 
     /// Records a DDS disk cache miss.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_fuse` - `true` if this was a FUSE (X-Plane) request, `false` for
+    ///   prefetch/prewarm.
     #[inline]
-    pub fn dds_disk_cache_miss(&self) {
-        self.send(MetricEvent::DdsDiskCacheMiss);
+    pub fn dds_disk_cache_miss(&self, is_fuse: bool) {
+        self.send(MetricEvent::DdsDiskCacheMiss { is_fuse });
     }
 
     /// Records a disk write starting.
@@ -429,15 +441,18 @@ mod tests {
     #[tokio::test]
     async fn test_client_dds_disk_cache_events() {
         let (client, mut rx) = create_client();
-        client.dds_disk_cache_hit(11_000_000);
-        client.dds_disk_cache_miss();
+        client.dds_disk_cache_hit(11_000_000, true);
+        client.dds_disk_cache_miss(false);
         assert!(matches!(
             rx.recv().await,
-            Some(MetricEvent::DdsDiskCacheHit { bytes: 11_000_000 })
+            Some(MetricEvent::DdsDiskCacheHit {
+                bytes: 11_000_000,
+                is_fuse: true
+            })
         ));
         assert!(matches!(
             rx.recv().await,
-            Some(MetricEvent::DdsDiskCacheMiss)
+            Some(MetricEvent::DdsDiskCacheMiss { is_fuse: false })
         ));
     }
 

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -188,12 +188,18 @@ impl MetricsDaemon {
             MetricEvent::DdsDiskCacheSizeUpdate { bytes } => {
                 self.state.dds_disk_cache_size_bytes = bytes;
             }
-            MetricEvent::DdsDiskCacheHit { bytes } => {
+            MetricEvent::DdsDiskCacheHit { bytes, is_fuse } => {
                 self.state.dds_disk_cache_hits += 1;
                 self.state.dds_disk_bytes_read += bytes;
+                if is_fuse {
+                    self.state.fuse_dds_disk_cache_hits += 1;
+                }
             }
-            MetricEvent::DdsDiskCacheMiss => {
+            MetricEvent::DdsDiskCacheMiss { is_fuse } => {
                 self.state.dds_disk_cache_misses += 1;
+                if is_fuse {
+                    self.state.fuse_dds_disk_cache_misses += 1;
+                }
             }
 
             // Memory cache events
@@ -443,12 +449,58 @@ mod tests {
     #[test]
     fn test_process_dds_disk_cache_events() {
         let (mut daemon, _tx) = create_daemon();
-        daemon.process_event(MetricEvent::DdsDiskCacheHit { bytes: 11_000_000 });
-        daemon.process_event(MetricEvent::DdsDiskCacheHit { bytes: 11_000_000 });
-        daemon.process_event(MetricEvent::DdsDiskCacheMiss);
+        daemon.process_event(MetricEvent::DdsDiskCacheHit {
+            bytes: 11_000_000,
+            is_fuse: false,
+        });
+        daemon.process_event(MetricEvent::DdsDiskCacheHit {
+            bytes: 11_000_000,
+            is_fuse: false,
+        });
+        daemon.process_event(MetricEvent::DdsDiskCacheMiss { is_fuse: false });
         assert_eq!(daemon.state.dds_disk_cache_hits, 2);
         assert_eq!(daemon.state.dds_disk_cache_misses, 1);
         assert_eq!(daemon.state.dds_disk_bytes_read, 22_000_000);
+    }
+
+    #[test]
+    fn test_dds_disk_cache_events_segregate_fuse_from_aggregate() {
+        // Regression for #171: DDS disk cache events tagged with `is_fuse: true`
+        // must increment both aggregate and FUSE-only counters; events with
+        // `is_fuse: false` (prefetch, prewarm) must only hit the aggregate.
+        let (mut daemon, _tx) = create_daemon();
+
+        // FUSE hit → both counters
+        daemon.process_event(MetricEvent::DdsDiskCacheHit {
+            bytes: 1_000,
+            is_fuse: true,
+        });
+        assert_eq!(daemon.state.dds_disk_cache_hits, 1);
+        assert_eq!(daemon.state.fuse_dds_disk_cache_hits, 1);
+
+        // Prefetch hit → aggregate only
+        daemon.process_event(MetricEvent::DdsDiskCacheHit {
+            bytes: 2_000,
+            is_fuse: false,
+        });
+        assert_eq!(daemon.state.dds_disk_cache_hits, 2);
+        assert_eq!(
+            daemon.state.fuse_dds_disk_cache_hits, 1,
+            "prefetch hits must NOT touch the FUSE-only counter"
+        );
+
+        // FUSE miss → both counters
+        daemon.process_event(MetricEvent::DdsDiskCacheMiss { is_fuse: true });
+        assert_eq!(daemon.state.dds_disk_cache_misses, 1);
+        assert_eq!(daemon.state.fuse_dds_disk_cache_misses, 1);
+
+        // Prefetch miss → aggregate only
+        daemon.process_event(MetricEvent::DdsDiskCacheMiss { is_fuse: false });
+        assert_eq!(daemon.state.dds_disk_cache_misses, 2);
+        assert_eq!(
+            daemon.state.fuse_dds_disk_cache_misses, 1,
+            "prefetch misses must NOT touch the FUSE-only counter"
+        );
     }
 
     #[test]

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -59,10 +59,15 @@ pub enum MetricEvent {
     DdsDiskCacheHit {
         /// Size of the cached DDS tile in bytes.
         bytes: u64,
+        /// `true` if this was a FUSE (X-Plane) request, `false` for prefetch/prewarm.
+        is_fuse: bool,
     },
 
     /// A DDS tile was not found in the DDS disk cache.
-    DdsDiskCacheMiss,
+    DdsDiskCacheMiss {
+        /// `true` if this was a FUSE (X-Plane) request, `false` for prefetch/prewarm.
+        is_fuse: bool,
+    },
 
     /// A disk cache write operation started.
     DiskWriteStarted,
@@ -206,7 +211,7 @@ impl MetricEvent {
             Self::ChunkDiskCacheHit { .. } => "chunk_disk_cache_hit",
             Self::ChunkDiskCacheMiss => "chunk_disk_cache_miss",
             Self::DdsDiskCacheHit { .. } => "dds_disk_cache_hit",
-            Self::DdsDiskCacheMiss => "dds_disk_cache_miss",
+            Self::DdsDiskCacheMiss { .. } => "dds_disk_cache_miss",
             Self::DiskWriteStarted => "disk_write_started",
             Self::DiskWriteCompleted { .. } => "disk_write_completed",
             Self::DiskCacheInitialSize { .. } => "disk_cache_initial_size",
@@ -278,11 +283,15 @@ mod tests {
     #[test]
     fn test_dds_disk_cache_event_types() {
         assert_eq!(
-            MetricEvent::DdsDiskCacheHit { bytes: 1024 }.event_type(),
+            MetricEvent::DdsDiskCacheHit {
+                bytes: 1024,
+                is_fuse: false
+            }
+            .event_type(),
             "dds_disk_cache_hit"
         );
         assert_eq!(
-            MetricEvent::DdsDiskCacheMiss.event_type(),
+            MetricEvent::DdsDiskCacheMiss { is_fuse: false }.event_type(),
             "dds_disk_cache_miss"
         );
     }

--- a/xearthlayer/src/metrics/optional.rs
+++ b/xearthlayer/src/metrics/optional.rs
@@ -13,8 +13,8 @@ pub trait OptionalMetrics {
     fn download_retried(&self);
     fn chunk_disk_cache_hit(&self, bytes: u64);
     fn chunk_disk_cache_miss(&self);
-    fn dds_disk_cache_hit(&self, bytes: u64);
-    fn dds_disk_cache_miss(&self);
+    fn dds_disk_cache_hit(&self, bytes: u64, is_fuse: bool);
+    fn dds_disk_cache_miss(&self, is_fuse: bool);
     fn disk_write_started(&self);
     fn disk_write_completed(&self, bytes: u64, duration_us: u64);
     fn disk_cache_initial_size(&self, bytes: u64);
@@ -79,16 +79,16 @@ impl OptionalMetrics for Option<MetricsClient> {
     }
 
     #[inline]
-    fn dds_disk_cache_hit(&self, bytes: u64) {
+    fn dds_disk_cache_hit(&self, bytes: u64, is_fuse: bool) {
         if let Some(client) = self {
-            client.dds_disk_cache_hit(bytes);
+            client.dds_disk_cache_hit(bytes, is_fuse);
         }
     }
 
     #[inline]
-    fn dds_disk_cache_miss(&self) {
+    fn dds_disk_cache_miss(&self, is_fuse: bool) {
         if let Some(client) = self {
-            client.dds_disk_cache_miss();
+            client.dds_disk_cache_miss(is_fuse);
         }
     }
 

--- a/xearthlayer/src/metrics/reporter.rs
+++ b/xearthlayer/src/metrics/reporter.rs
@@ -98,6 +98,13 @@ impl MetricsReporter for TuiReporter {
             0.0
         };
 
+        let fuse_dds_disk_total = state.fuse_dds_disk_cache_hits + state.fuse_dds_disk_cache_misses;
+        let fuse_dds_disk_hit_rate = if fuse_dds_disk_total > 0 {
+            state.fuse_dds_disk_cache_hits as f64 / fuse_dds_disk_total as f64
+        } else {
+            0.0
+        };
+
         let chunk_disk_total = state.chunk_disk_cache_hits + state.chunk_disk_cache_misses;
         let chunk_disk_hit_rate = if chunk_disk_total > 0 {
             state.chunk_disk_cache_hits as f64 / chunk_disk_total as f64
@@ -156,11 +163,16 @@ impl MetricsReporter for TuiReporter {
             memory_cache_hits: state.memory_cache_hits,
             memory_cache_misses: state.memory_cache_misses,
             memory_cache_hit_rate: memory_hit_rate,
+            fuse_memory_cache_hits: state.fuse_memory_cache_hits,
+            fuse_memory_cache_misses: state.fuse_memory_cache_misses,
             fuse_memory_cache_hit_rate: fuse_memory_hit_rate,
             memory_cache_size_bytes: state.memory_cache_size_bytes,
             dds_disk_cache_hits: state.dds_disk_cache_hits,
             dds_disk_cache_misses: state.dds_disk_cache_misses,
             dds_disk_cache_hit_rate: dds_disk_hit_rate,
+            fuse_dds_disk_cache_hits: state.fuse_dds_disk_cache_hits,
+            fuse_dds_disk_cache_misses: state.fuse_dds_disk_cache_misses,
+            fuse_dds_disk_cache_hit_rate: fuse_dds_disk_hit_rate,
             dds_disk_cache_size_bytes: state.dds_disk_cache_size_bytes,
             dds_disk_bytes_read: state.dds_disk_bytes_read,
             chunk_disk_cache_hits: state.chunk_disk_cache_hits,
@@ -270,6 +282,72 @@ mod tests {
         assert_eq!(snapshot.memory_cache_hit_rate, 0.0);
         assert_eq!(snapshot.dds_disk_cache_hit_rate, 0.0);
         assert_eq!(snapshot.chunk_disk_cache_hit_rate, 0.0);
+    }
+
+    #[test]
+    fn test_fuse_dds_disk_cache_hit_rate_exposed_on_snapshot() {
+        // Regression for #171: snapshot must expose FUSE-only DDS disk hit rate
+        // and underlying hit/miss counts, computed from `fuse_dds_disk_cache_*`
+        // counters (not the aggregate ones that include prefetch traffic).
+        let mut state = AggregatedState::new();
+        state.dds_disk_cache_hits = 200; // aggregate
+        state.dds_disk_cache_misses = 800;
+        state.fuse_dds_disk_cache_hits = 80; // FUSE only
+        state.fuse_dds_disk_cache_misses = 20;
+
+        let history = TimeSeriesHistory::default();
+        let reporter = TuiReporter::new();
+        let snapshot = reporter.report(&state, &history);
+
+        assert_eq!(snapshot.fuse_dds_disk_cache_hits, 80);
+        assert_eq!(snapshot.fuse_dds_disk_cache_misses, 20);
+        assert!(
+            (snapshot.fuse_dds_disk_cache_hit_rate - 0.8).abs() < 0.001,
+            "expected fuse rate 0.8, got {}",
+            snapshot.fuse_dds_disk_cache_hit_rate
+        );
+        // Aggregate still reflects the combined counts
+        assert!(
+            (snapshot.dds_disk_cache_hit_rate - 0.2).abs() < 0.001,
+            "aggregate rate should remain unchanged"
+        );
+    }
+
+    #[test]
+    fn test_fuse_dds_disk_cache_hit_rate_zero_total() {
+        let state = AggregatedState::new();
+        let history = TimeSeriesHistory::default();
+        let reporter = TuiReporter::new();
+        let snapshot = reporter.report(&state, &history);
+        assert_eq!(snapshot.fuse_dds_disk_cache_hit_rate, 0.0);
+    }
+
+    #[test]
+    fn test_fuse_memory_cache_counts_exposed_on_snapshot() {
+        // Regression for #171: the snapshot must expose FUSE-only memory hit/miss
+        // counts so the cache widget can render X-Plane's actual experience
+        // rather than aggregate totals diluted by prefetch traffic.
+        let mut state = AggregatedState::new();
+        state.memory_cache_hits = 150; // aggregate (FUSE + prefetch)
+        state.memory_cache_misses = 50;
+        state.fuse_memory_cache_hits = 90; // FUSE only
+        state.fuse_memory_cache_misses = 10;
+
+        let history = TimeSeriesHistory::default();
+        let reporter = TuiReporter::new();
+        let snapshot = reporter.report(&state, &history);
+
+        assert_eq!(
+            snapshot.fuse_memory_cache_hits, 90,
+            "snapshot must carry FUSE-only memory hit count"
+        );
+        assert_eq!(
+            snapshot.fuse_memory_cache_misses, 10,
+            "snapshot must carry FUSE-only memory miss count"
+        );
+        // Aggregate fields should remain unchanged — still useful as diagnostics.
+        assert_eq!(snapshot.memory_cache_hits, 150);
+        assert_eq!(snapshot.memory_cache_misses, 50);
     }
 
     #[test]

--- a/xearthlayer/src/metrics/snapshot.rs
+++ b/xearthlayer/src/metrics/snapshot.rs
@@ -59,18 +59,34 @@ pub struct TelemetrySnapshot {
     pub memory_cache_misses: u64,
     /// Memory cache hit rate — all origins (0.0 - 1.0)
     pub memory_cache_hit_rate: f64,
+    /// Memory cache hits from FUSE (X-Plane) requests only.
+    ///
+    /// Used by the cache widget to show X-Plane's actual cache experience,
+    /// uncontaminated by prefetch/prewarm traffic (see #171).
+    pub fuse_memory_cache_hits: u64,
+    /// Memory cache misses from FUSE (X-Plane) requests only.
+    pub fuse_memory_cache_misses: u64,
     /// Memory cache hit rate — FUSE (X-Plane) requests only (0.0 - 1.0)
     pub fuse_memory_cache_hit_rate: f64,
     /// Memory cache current size in bytes
     pub memory_cache_size_bytes: u64,
 
     // === DDS Disk Cache metrics ===
-    /// DDS disk cache hits
+    /// DDS disk cache hits (all origins)
     pub dds_disk_cache_hits: u64,
-    /// DDS disk cache misses
+    /// DDS disk cache misses (all origins)
     pub dds_disk_cache_misses: u64,
-    /// DDS disk cache hit rate (0.0 - 1.0)
+    /// DDS disk cache hit rate — all origins (0.0 - 1.0)
     pub dds_disk_cache_hit_rate: f64,
+    /// DDS disk cache hits from FUSE (X-Plane) requests only.
+    ///
+    /// Used by the cache widget to show X-Plane's actual cache experience,
+    /// uncontaminated by prefetch/prewarm traffic (see #171).
+    pub fuse_dds_disk_cache_hits: u64,
+    /// DDS disk cache misses from FUSE (X-Plane) requests only.
+    pub fuse_dds_disk_cache_misses: u64,
+    /// DDS disk cache hit rate — FUSE (X-Plane) requests only (0.0 - 1.0)
+    pub fuse_dds_disk_cache_hit_rate: f64,
     /// DDS disk cache current size in bytes
     pub dds_disk_cache_size_bytes: u64,
     /// DDS disk bytes read this session (from cache hits)
@@ -142,11 +158,16 @@ impl Default for TelemetrySnapshot {
             memory_cache_hits: 0,
             memory_cache_misses: 0,
             memory_cache_hit_rate: 0.0,
+            fuse_memory_cache_hits: 0,
+            fuse_memory_cache_misses: 0,
             fuse_memory_cache_hit_rate: 0.0,
             memory_cache_size_bytes: 0,
             dds_disk_cache_hits: 0,
             dds_disk_cache_misses: 0,
             dds_disk_cache_hit_rate: 0.0,
+            fuse_dds_disk_cache_hits: 0,
+            fuse_dds_disk_cache_misses: 0,
+            fuse_dds_disk_cache_hit_rate: 0.0,
             dds_disk_cache_size_bytes: 0,
             dds_disk_bytes_read: 0,
             chunk_disk_cache_hits: 0,
@@ -387,11 +408,16 @@ mod tests {
             memory_cache_hits: 30,
             memory_cache_misses: 60,
             memory_cache_hit_rate: 0.333,
+            fuse_memory_cache_hits: 15,
+            fuse_memory_cache_misses: 10,
             fuse_memory_cache_hit_rate: 0.6,
             memory_cache_size_bytes: 500_000_000,
             dds_disk_cache_hits: 17300,
             dds_disk_cache_misses: 1200,
             dds_disk_cache_hit_rate: 17300.0 / 18500.0,
+            fuse_dds_disk_cache_hits: 8500,
+            fuse_dds_disk_cache_misses: 600,
+            fuse_dds_disk_cache_hit_rate: 8500.0 / 9100.0,
             dds_disk_cache_size_bytes: 289_000_000_000,
             dds_disk_bytes_read: 190_000_000_000,
             chunk_disk_cache_hits: 5000,

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -158,10 +158,17 @@ pub struct AggregatedState {
     // =========================================================================
     // DDS Disk Cache Metrics
     // =========================================================================
-    /// DDS disk cache hits.
+    /// DDS disk cache hits (all origins).
     pub dds_disk_cache_hits: u64,
-    /// DDS disk cache misses.
+    /// DDS disk cache misses (all origins).
     pub dds_disk_cache_misses: u64,
+    /// DDS disk cache hits from FUSE (X-Plane) requests only.
+    ///
+    /// Used by the cache widget to show X-Plane's actual cache experience,
+    /// uncontaminated by prefetch/prewarm traffic (see #171).
+    pub fuse_dds_disk_cache_hits: u64,
+    /// DDS disk cache misses from FUSE (X-Plane) requests only.
+    pub fuse_dds_disk_cache_misses: u64,
     /// Total bytes read from DDS disk cache (cache hits).
     pub dds_disk_bytes_read: u64,
     /// Current DDS disk cache size in bytes (absolute value from LRU index).
@@ -262,6 +269,8 @@ impl AggregatedState {
             chunk_disk_cache_size_bytes: 0,
             dds_disk_cache_hits: 0,
             dds_disk_cache_misses: 0,
+            fuse_dds_disk_cache_hits: 0,
+            fuse_dds_disk_cache_misses: 0,
             dds_disk_bytes_read: 0,
             dds_disk_cache_size_bytes: 0,
             memory_cache_hits: 0,
@@ -310,6 +319,8 @@ impl AggregatedState {
         self.disk_write_time_us = 0;
         self.dds_disk_cache_hits = 0;
         self.dds_disk_cache_misses = 0;
+        self.fuse_dds_disk_cache_hits = 0;
+        self.fuse_dds_disk_cache_misses = 0;
         self.dds_disk_bytes_read = 0;
         self.memory_cache_hits = 0;
         self.memory_cache_misses = 0;


### PR DESCRIPTION
## Summary

- TUI cache widget now renders **FUSE-only** hit rates and counts for Memory and DDS Disk tiers, so the percentages reflect X-Plane's actual cache experience instead of being diluted by background prefetch/prewarm traffic.
- Adds `is_fuse` discriminator to `DdsDiskCacheHit`/`DdsDiskCacheMiss` events (mirroring the existing memory tier pattern) and threads it from the executor daemon down to the metrics daemon.
- Chunks tier continues to use the aggregate — chunk reads only happen on memory+DDS-disk double miss, so aggregate equals FUSE there.
- Fixes a latent bug in `manager/mounts.rs` where `fuse_memory_cache_hit_rate` was never recalculated during multi-service snapshot aggregation (always reported 0%).

## Why

On a 9-hour AMS→MSP test flight, the widget showed Memory at **47.2%** despite the cache being 100% full (4.29/4.29 GB) and DDS Disk at **39.1%** despite holding 268 GB. The arithmetic was correct, but the counters being divided included every prefetch job — which by definition expects misses. Over a long cruise, prefetch traffic dominated the denominator and hid how well the cache was actually serving X-Plane.

Expected outcome after the fix: Memory and DDS Disk hit rates should reflect X-Plane's experience (likely 85-95% memory, 70-85% DDS disk during cruise) instead of the diluted 40% range shown today.

## Implementation

Seven TDD cycles, one cascade fix:

1. Expose `fuse_memory_cache_hits`/`misses` on `TelemetrySnapshot` (counters already existed in `AggregatedState`)
2. Add `is_fuse` to `DdsDiskCacheHit`/`DdsDiskCacheMiss` event variants; daemon segregates FUSE from aggregate
3. Reporter computes `fuse_dds_disk_cache_hit_rate`, populates snapshot
4. Client/OptionalMetrics signatures updated to take `is_fuse` (cascade from #2)
5. Widget Memory tier reads FUSE fields
6. Widget DDS Disk tier reads FUSE fields
7. `dashboard/utils.rs` print helpers refactored into format+print pairs; format functions use FUSE rates

Executor daemon emission sites pass `origin.is_fuse()` — the information was already locally available via `RequestOrigin`.

## Scope explicitly excluded

- **Chunks tier unchanged** — aggregate is the right number there, pinned by `test_chunk_tier_still_uses_aggregate`.
- **No dimensional metrics refactor** — the conversation leading up to this PR explored treating this as an SSOT violation and rebuilding counters around event dimensions, but that was over-engineering for this bug. The fix surfaces existing FUSE counters and mirrors their pattern to DDS disk. May revisit dimensional metrics in v0.5.0.
- **No changes to aggregate counters** — they're still tracked in ``AggregatedState`` and exposed on ``TelemetrySnapshot``. The widget simply renders the FUSE subset.

## Test plan

- [x] ``make pre-commit`` green (fmt + clippy + tests)
- [x] 2445 tests passing (+9 from 2436 baseline)
- [x] 9 new tests written TDD-first, each verified to fail for the right reason before implementation
- [x] Non-regression pin: ``test_chunk_tier_still_uses_aggregate`` guards the chunks tier from being accidentally switched
- [x] Observe the widget live: run ``xearthlayer run`` with prefetch enabled; memory and DDS disk rates should trend above 80% during cruise instead of hovering around 40%
- [x] Multi-mount verification: with patches + regional packages mounted, confirm the aggregated snapshot at ``manager/mounts.rs`` reports a non-zero ``fuse_memory_cache_hit_rate`` (previously always 0%)

## Files changed

12 files, +491/-75:

- ``xearthlayer/src/metrics/`` — event, state, daemon, client, optional, snapshot, reporter (7 files)
- ``xearthlayer/src/manager/mounts.rs`` — aggregator plumbing + latent bug fix
- ``xearthlayer/src/executor/daemon.rs`` — pass ``origin.is_fuse()`` at two emission sites
- ``xearthlayer-cli/src/ui/widgets/cache.rs`` — widget read sites
- ``xearthlayer-cli/src/ui/dashboard/utils.rs`` — format+print refactor
- ``CHANGELOG.md``

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)