### PR TITLE
debug(cache): add diagnostic telemetry to cache read/write/startup paths (#172)

### DIFF
--- a/xearthlayer/src/cache/providers/disk.rs
+++ b/xearthlayer/src/cache/providers/disk.rs
@@ -114,7 +114,9 @@ impl DiskCacheProvider {
             Ok(stats) => {
                 info!(
                     dir = %config.directory.display(),
+                    tier = if config.is_dds_tier { "dds" } else { "chunks" },
                     files = stats.files_indexed,
+                    skipped = stats.skipped_unparseable,
                     size_mb = stats.total_bytes / 1_000_000,
                     max_mb = config.max_size_bytes / 1_000_000,
                     "Disk cache provider started"
@@ -274,6 +276,14 @@ impl Cache for DiskCacheProvider {
         let key_owned = key.to_string();
 
         Box::pin(async move {
+            debug!(
+                key = %key_owned,
+                size,
+                path = %path.display(),
+                tier = if self.is_dds_tier { "dds" } else { "chunks" },
+                "Disk cache write starting"
+            );
+
             // Ensure parent directory exists (creates region dir on first write)
             if let Some(parent) = path.parent() {
                 tokio::fs::create_dir_all(parent)
@@ -315,33 +325,38 @@ impl Cache for DiskCacheProvider {
                 Ok(data) => {
                     // Update LRU index access time
                     self.lru_index.touch(&key_owned);
-                    debug!(key = %key_owned, size = data.len(), is_dds, "Cache hit");
+                    debug!(
+                        key = %key_owned,
+                        size = data.len(),
+                        path = %path.display(),
+                        tier = if is_dds { "dds" } else { "chunks" },
+                        "Disk cache hit"
+                    );
                     Ok(Some(data))
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     // File not on disk - ensure index is clean
-                    if self.lru_index.contains(&key_owned) {
+                    let was_in_index = self.lru_index.contains(&key_owned);
+                    if was_in_index {
                         self.lru_index.remove(&key_owned);
-                        debug!(key = %key_owned, "Removed stale index entry");
                     }
-                    if is_dds {
-                        debug!(
-                            key = %key_owned,
-                            path = %path.display(),
-                            "DDS disk cache miss — file not found at computed path"
-                        );
-                    }
+                    debug!(
+                        key = %key_owned,
+                        path = %path.display(),
+                        tier = if is_dds { "dds" } else { "chunks" },
+                        was_in_index,
+                        "Disk cache miss — file not found"
+                    );
                     Ok(None)
                 }
                 Err(e) => {
-                    if is_dds {
-                        warn!(
-                            key = %key_owned,
-                            path = %path.display(),
-                            error = %e,
-                            "DDS disk cache read error (not NotFound)"
-                        );
-                    }
+                    warn!(
+                        key = %key_owned,
+                        path = %path.display(),
+                        tier = if is_dds { "dds" } else { "chunks" },
+                        error = %e,
+                        "Disk cache read error"
+                    );
                     Err(ServiceCacheError::Io(e))
                 }
             }
@@ -373,7 +388,13 @@ impl Cache for DiskCacheProvider {
     fn contains(&self, key: &str) -> BoxFuture<'_, Result<bool, ServiceCacheError>> {
         // Check index first (faster than filesystem)
         let in_index = self.lru_index.contains(key);
+        let is_dds = self.is_dds_tier;
         if !in_index {
+            debug!(
+                key = %key,
+                tier = if is_dds { "dds" } else { "chunks" },
+                "Disk cache contains: not in LRU index"
+            );
             return Box::pin(async move { Ok(false) });
         }
 
@@ -383,10 +404,22 @@ impl Cache for DiskCacheProvider {
 
         Box::pin(async move {
             if tokio::fs::metadata(&path).await.is_ok() {
+                debug!(
+                    key = %key_owned,
+                    path = %path.display(),
+                    tier = if is_dds { "dds" } else { "chunks" },
+                    "Disk cache contains: found (index + file verified)"
+                );
                 Ok(true)
             } else {
                 // File doesn't exist - clean up stale index entry
                 self.lru_index.remove(&key_owned);
+                debug!(
+                    key = %key_owned,
+                    path = %path.display(),
+                    tier = if is_dds { "dds" } else { "chunks" },
+                    "Disk cache contains: stale index entry (file missing), cleaned up"
+                );
                 Ok(false)
             }
         })

--- a/xearthlayer/src/cache/providers/memory.rs
+++ b/xearthlayer/src/cache/providers/memory.rs
@@ -105,7 +105,22 @@ impl Cache for MemoryCacheProvider {
 
     fn get(&self, key: &str) -> BoxFuture<'_, Result<Option<Vec<u8>>, ServiceCacheError>> {
         let key = key.to_string();
-        Box::pin(async move { Ok(self.cache.get(&key).await) })
+        Box::pin(async move {
+            let result = self.cache.get(&key).await;
+            match &result {
+                Some(data) => {
+                    tracing::debug!(
+                        key = %key,
+                        size = data.len(),
+                        "Memory cache hit"
+                    );
+                }
+                None => {
+                    tracing::debug!(key = %key, "Memory cache miss");
+                }
+            }
+            Ok(result)
+        })
     }
 
     fn delete(&self, key: &str) -> BoxFuture<'_, Result<bool, ServiceCacheError>> {

--- a/xearthlayer/src/executor/daemon.rs
+++ b/xearthlayer/src/executor/daemon.rs
@@ -585,6 +585,15 @@ where
         }
 
         // Fast path: check memory cache first
+        let cache_key = format!("tile:{}:{}:{}", tile.zoom, tile.row, tile.col);
+        debug!(
+            cache_key = %cache_key,
+            tile_row = tile.row,
+            tile_col = tile.col,
+            tile_zoom = tile.zoom,
+            origin = %origin,
+            "Executor: checking cache tiers"
+        );
         let cache_result = memory_cache
             .get(tile.row, tile.col, tile.zoom)
             .instrument(tracing::trace_span!(target: "profiling", "cache_check"))


### PR DESCRIPTION
## Summary

- Adds `tracing::debug!` instrumentation to every cache tier boundary (memory, DDS disk, chunk disk) to diagnose why FUSE tile reads are not hitting cached files.
- Adds tier distinction (`dds`/`chunks`) and skipped-file count to the DiskCacheProvider startup INFO log.
- Adds the constructed cache key (`tile:{zoom}:{row}:{col}`) to the executor daemon's cache walk, so we can correlate read-path keys with write-path keys in the log.
- Zero behavior changes. All logging gated behind `tracing::debug!` (zero cost at INFO level).

## Why

Multiple test flights have shown that the FUSE lookup path is not hitting cached files for the majority of scenery loads. The issue is either false negatives from the cache system or a FUSE integration disconnect. Before implementing any fix, we need to see the actual cache decision tree at runtime to identify WHERE the misses are occurring.

## What gets logged (at `--debug` level)

| Point | Fields | Purpose |
|-------|--------|---------|
| Executor: cache tier walk start | `cache_key`, `tile_row/col/zoom`, `origin` | Shows the key being used for this request |
| Memory cache get | `key`, `size` (hit) or `key` (miss) | Memory tier result |
| DDS disk cache get | `key`, `path`, `tier=dds`, `was_in_index` (miss only) | Critical: shows the file path probed and whether the LRU index even knew about the key |
| Chunk disk cache get | `key`, `path`, `tier=chunks` | Same for chunk tier |
| Disk cache contains | `key`, `tier`, index/file result | Distinguishes "not in index" from "in index but file missing" |
| Disk cache write start | `key`, `path`, `tier`, `size` | Write path correlation |
| DiskCacheProvider startup | `tier`, `files`, `skipped`, `size_mb`, `max_mb` | Shows whether startup scan populated the LRU index correctly for each tier |

## Diagnostic scenarios this enables

1. **Key mismatch**: Write log shows `key=tile:14:6250:7824 path=/cache/dds/+43+006/tile_14_6250_7824.cache`, read log shows a different key or path → key construction bug.
2. **Empty LRU index**: Startup log shows `tier=dds files=0` despite cache directory having files → startup scan bug.
3. **Stale index**: `contains` log shows `was_in_index=true` but `get` returns NotFound → file deleted but index not updated.
4. **Tier never consulted**: No debug log for DDS disk tier at all → wiring bug in executor daemon or bridge adapter.

## Test plan

- [x] `make pre-commit` green (fmt + clippy + tests)
- [x] All 2371 lib tests + CLI tests pass (same counts as baseline)
- [x] No behavior changes — pure logging additions
- [ ] Run `xearthlayer run --debug` on next test flight
- [ ] Analyze log output to identify where cache lookups fail
- [ ] Use findings to implement targeted fix

3 files changed, +76/-19 lines.

Related to #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)