### PR TITLE
Release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **TUI cache hit rates reflect X-Plane experience, not prefetch traffic** ([#171](https://github.com/samsoir/xearthlayer/issues/171)): The Memory and DDS Disk tiers in the cache widget now render FUSE-only hit rates and counts, so the percentages reflect how well the cache is serving X-Plane's actual requests. Previously, aggregate counters included prefetch and prewarm traffic — a long-haul flight with a 100%-full memory cache would show ~47% hit rate because prefetch misses dominated the denominator. Added `is_fuse` discriminator to `DdsDiskCacheHit`/`DdsDiskCacheMiss` events, paired FUSE-only counters in state and snapshot, and wired the executor daemon to tag events based on `RequestOrigin`. The Chunks tier continues to use aggregate (there's only one chunk-read path, so aggregate equals FUSE there). Also fixed a latent bug in `manager/mounts.rs` where `fuse_memory_cache_hit_rate` was never recalculated during multi-service aggregation.
+## [0.4.4] - 2026-04-16
 
 ### Changed
 
+- **Unified ground/cruise prefetch under single PrefetchBox** ([#172](https://github.com/samsoir/xearthlayer/issues/172)): Replaced the ring-based `GroundStrategy` (746 lines) with symmetric `PrefetchBox` (bias 0.5). Ground and cruise phases now share the same code path — ground uses a fixed extent with symmetric bias, cruise uses speed-proportional extent with heading bias (0.8). Eliminated dead `scene_tracker.loaded_bounds()` wiring that was never called in production.
+
+- **Debug map renders actual prefetch box (SSOT)** ([#172](https://github.com/samsoir/xearthlayer/issues/172)): The coordinator now computes bounds once per cycle and publishes them as `BoxBoundsSnapshot` via `SharedPrefetchStatus`. The debug map reads these verbatim — no recomputation, no drift between display and reality. Region colours are now GeoIndex-authoritative: regions stay yellow (InProgress) until every tile is verified on disk, then flip green (Prefetched). New orange (Mixed) state shows when FUSE has served tiles from a prefetched region.
+
 - **Three-tier cache metrics in TUI** ([#166](https://github.com/samsoir/xearthlayer/issues/166)): Split the combined "Disk" cache display into separate DDS Disk and Chunks tiers with independent hit rates. The TUI now shows a 3-column layout (Memory, DDS Disk, Chunks) with per-tier progress bars and hit/miss counters. DDS disk hit rate (93%+ in flight tests) is no longer hidden by chunk-level event volume.
+
+- **Default `executor.max_concurrent_jobs` tuned to `num_cpus / 2`** ([#172](https://github.com/samsoir/xearthlayer/issues/172)): Reduced from `ceil(num_cpus × 0.75)` to halve CPU pressure on X-Plane during heavy prefetch. Flight-tested as the best compromise between prefetch throughput and simulator frame rate.
+
+### Fixed
+
+- **Prefetch coverage degrades on long-haul flights** ([#172](https://github.com/samsoir/xearthlayer/issues/172)): Multiple interacting defects caused prefetched regions to enter permanent dead states on flights over ~2 hours. Regions were marked `InProgress` before submission results were known, the `cached_tiles` shadow set tracked only ~6% of actually-cached tiles, and DDS disk cache lookups used chunk coordinates instead of tile coordinates (silently returning `false` every time). Fixed by deferring `mark_in_progress` until after successful submission, replacing the shadow set with authoritative DDS disk cache queries, and correcting the coordinate mismatch. Verified against a 9-hour LOWW flight log.
+
+- **TUI cache hit rates reflect X-Plane experience, not prefetch traffic** ([#171](https://github.com/samsoir/xearthlayer/issues/171)): The Memory and DDS Disk tiers in the cache widget now render FUSE-only hit rates and counts, so the percentages reflect how well the cache is serving X-Plane's actual requests. Previously, aggregate counters included prefetch and prewarm traffic — a long-haul flight with a 100%-full memory cache would show ~47% hit rate because prefetch misses dominated the denominator. Added `is_fuse` discriminator to `DdsDiskCacheHit`/`DdsDiskCacheMiss` events, paired FUSE-only counters in state and snapshot, and wired the executor daemon to tag events based on `RequestOrigin`. The Chunks tier continues to use aggregate (there's only one chunk-read path, so aggregate equals FUSE there). Also fixed a latent bug in `manager/mounts.rs` where `fuse_memory_cache_hit_rate` was never recalculated during multi-service aggregation.
+
+- **TUI queue display order reversed** ([#165](https://github.com/samsoir/xearthlayer/issues/165)): Queue column now shows oldest (completing) jobs at the top with new jobs appended at the bottom, matching the natural reading order for a processing pipeline.
 
 ## [0.4.3] - 2026-04-07
 
@@ -981,7 +993,8 @@ Run `xearthlayer config upgrade` to automatically add new settings with defaults
 - Linux support only (Windows and macOS planned for future releases)
 - Requires FUSE3 for filesystem mounting
 
-[Unreleased]: https://github.com/samsoir/xearthlayer/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/samsoir/xearthlayer/compare/v0.4.4...HEAD
+[0.4.4]: https://github.com/samsoir/xearthlayer/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/samsoir/xearthlayer/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/samsoir/xearthlayer/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/samsoir/xearthlayer/compare/v0.4.0...v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,7 +4755,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xearthlayer"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "axum",
  "bincode",
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "xearthlayer-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 authors = ["XEarthLayer Contributors"]
 license = "MIT"

--- a/version.json
+++ b/version.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.4.3",
-  "tag": "v0.4.3",
-  "release_date": "2026-04-07",
+  "version": "0.4.4",
+  "tag": "v0.4.4",
+  "release_date": "2026-04-16",
   "homepage": "https://xearthlayer.app",
   "assets": {
     "deb": {
-      "filename": "xearthlayer_0.4.3-1_amd64.deb",
+      "filename": "xearthlayer_0.4.4-1_amd64.deb",
       "description": "Debian/Ubuntu package"
     },
     "rpm": {
-      "filename": "xearthlayer-0.4.3-1.fc43.x86_64.rpm",
+      "filename": "xearthlayer-0.4.4-1.fc43.x86_64.rpm",
       "description": "Fedora/RHEL package"
     },
     "tarball": {
-      "filename": "xearthlayer-v0.4.3-x86_64-linux.tar.gz",
+      "filename": "xearthlayer-v0.4.4-x86_64-linux.tar.gz",
       "description": "Linux binary tarball"
     },
     "aur": {
@@ -21,5 +21,5 @@
       "description": "Arch Linux AUR package"
     }
   },
-  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.3"
+  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.4"
 }


### PR DESCRIPTION
## Release v0.4.4

### Changed
- Unified ground/cruise prefetch under single `PrefetchBox` (#172)
- Debug map renders actual prefetch box via SSOT (`BoxBoundsSnapshot`) (#172)
- Three-tier cache metrics in TUI — Memory, DDS Disk, Chunks (#166)
- Default `executor.max_concurrent_jobs` tuned to `num_cpus / 2` (#172)

### Fixed
- Prefetch coverage degrades on long-haul flights — dead `InProgress` regions, DDS cache key mismatch, shadow state drift (#172)
- TUI cache hit rates reflect X-Plane experience, not prefetch traffic (#171)
- TUI queue display order reversed — oldest jobs at top (#165)

See [CHANGELOG.md](CHANGELOG.md) for full details.