### PR TITLE
Release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-05-05
+
 ### Fixed
 
 - **Tiles assembled from failed chunk downloads are no longer cached** ([#180](https://github.com/samsoir/xearthlayer/issues/180)): Network failures during tile generation produced magenta-filled DDS tiles that were structurally valid (correct size + DDS magic) and persisted indefinitely in the memory and DDS disk caches, surviving even X-Plane's "Reload Scenery". On reconnect, re-requests would short-circuit to the poisoned cache instead of re-fetching. Cache writes are now gated on `ChunkResults::is_complete()`: tiles with any failed chunks are still served to X-Plane (so the sim doesn't stall during outages) but never persisted to memory or DDS disk. The chunk-disk tier was already correct (only successful HTTP downloads were cached), so it now functions as a natural retry-resume buffer on re-request — only the chunks that previously failed get re-fetched. Users who saw magenta tiles persist across an outage on v0.4.4 or earlier should run `xearthlayer cache clear` to purge any poisoned tiles.
@@ -997,7 +999,8 @@ Run `xearthlayer config upgrade` to automatically add new settings with defaults
 - Linux support only (Windows and macOS planned for future releases)
 - Requires FUSE3 for filesystem mounting
 
-[Unreleased]: https://github.com/samsoir/xearthlayer/compare/v0.4.4...HEAD
+[Unreleased]: https://github.com/samsoir/xearthlayer/compare/v0.4.5...HEAD
+[0.4.5]: https://github.com/samsoir/xearthlayer/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/samsoir/xearthlayer/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/samsoir/xearthlayer/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/samsoir/xearthlayer/compare/v0.4.1...v0.4.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,7 +4755,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xearthlayer"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "axum",
  "bincode",
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "xearthlayer-cli"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["XEarthLayer Contributors"]
 license = "MIT"

--- a/version.json
+++ b/version.json
@@ -9,7 +9,7 @@
       "description": "Debian/Ubuntu package"
     },
     "rpm": {
-      "filename": "xearthlayer-0.4.5-1.fc43.x86_64.rpm",
+      "filename": "xearthlayer-0.4.5-1.fc44.x86_64.rpm",
       "description": "Fedora/RHEL package"
     },
     "tarball": {

--- a/version.json
+++ b/version.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.4.4",
-  "tag": "v0.4.4",
-  "release_date": "2026-04-16",
+  "version": "0.4.5",
+  "tag": "v0.4.5",
+  "release_date": "2026-05-05",
   "homepage": "https://xearthlayer.app",
   "assets": {
     "deb": {
-      "filename": "xearthlayer_0.4.4-1_amd64.deb",
+      "filename": "xearthlayer_0.4.5-1_amd64.deb",
       "description": "Debian/Ubuntu package"
     },
     "rpm": {
-      "filename": "xearthlayer-0.4.4-1.fc43.x86_64.rpm",
+      "filename": "xearthlayer-0.4.5-1.fc43.x86_64.rpm",
       "description": "Fedora/RHEL package"
     },
     "tarball": {
-      "filename": "xearthlayer-v0.4.4-x86_64-linux.tar.gz",
+      "filename": "xearthlayer-v0.4.5-x86_64-linux.tar.gz",
       "description": "Linux binary tarball"
     },
     "aur": {
@@ -21,5 +21,5 @@
       "description": "Arch Linux AUR package"
     }
   },
-  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.4"
+  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.5"
 }


### PR DESCRIPTION
## Summary

Patch release containing one fix:

- **#180** — Tiles assembled from failed chunk downloads are no longer cached. Network outages no longer leave magenta tiles persisted in memory or DDS disk caches across X-Plane sessions.

Other v0.4.5-tagged work (3 chores, 4 features) deferred to v0.4.6 to keep this release focused on the user-reported defect.

## User-facing repair

Users who saw magenta tiles persist across an outage on v0.4.4 or earlier should run `xearthlayer cache clear` after upgrading to purge poisoned tiles.

## Files changed
- `Cargo.toml` — version 0.4.4 → 0.4.5
- `Cargo.lock` — workspace version refresh
- `CHANGELOG.md` — promote [Unreleased] → [0.4.5]
- `version.json` — version, tag, release_date, asset filenames

## Test plan
- [x] `make pre-commit` passes locally
- [x] CI green
- [x] Tag pushed AFTER CI passes, BEFORE merge (per release runbook)
- [x] Release workflow publishes all 4 assets (deb, rpm, tarball, AUR)
- [x] Merge after release publishes; website-sync picks up new version.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)