### PR TITLE
feat(publisher): add EU2 region colour for coverage maps

### DIFF
--- a/xearthlayer/src/publisher/coverage.rs
+++ b/xearthlayer/src/publisher/coverage.rs
@@ -71,6 +71,8 @@ impl Default for CoverageConfig {
         region_colors.insert("na".to_string(), (51, 136, 255, 180));
         // Orange for EU (matches GeoJSON)
         region_colors.insert("eu".to_string(), (255, 136, 0, 180));
+        // Tangerine for EU2 (Eastern Europe / Western Russia) — brighter than EU
+        region_colors.insert("eu2".to_string(), (255, 170, 0, 180));
         // Green for SA
         region_colors.insert("sa".to_string(), (0, 200, 83, 180));
         // Purple for OC
@@ -105,6 +107,8 @@ impl CoverageConfig {
         // Brighter colors for dark background
         region_colors.insert("na".to_string(), (100, 180, 255, 200));
         region_colors.insert("eu".to_string(), (255, 180, 100, 200));
+        // Tangerine for EU2 (dark mode) — brighter than EU
+        region_colors.insert("eu2".to_string(), (255, 200, 80, 200));
         region_colors.insert("sa".to_string(), (100, 255, 150, 200));
         region_colors.insert("oc".to_string(), (200, 100, 255, 200));
         // Red for AS3 (Asia Part 3)


### PR DESCRIPTION
## Summary

EU2 (Eastern Europe / Western Russia) is currently rendered with the fallback colour on coverage maps. Add a distinct tangerine entry in both light and dark palettes — visually adjacent to EU's orange (so the geographic relationship reads at a glance) but bright enough to distinguish on a coverage diff map.

## Colour values

| Palette | EU | EU2 |
|---------|----|----|
| Default | rgba(255, 136, 0, 180) | **rgba(255, 170, 0, 180)** |
| Dark | rgba(255, 180, 100, 200) | **rgba(255, 200, 80, 200)** |

## Test plan
- [x] `make pre-commit` passes locally
- [ ] CI green
- [ ] Visual verification by maintainer (coverage map regenerated for EU2 region)

🤖 Generated with [Claude Code](https://claude.com/claude-code)