### PR TITLE
fix(cli): initialize and flush logging for every subcommand (#194)

### DIFF
--- a/xearthlayer-cli/src/commands/run.rs
+++ b/xearthlayer-cli/src/commands/run.rs
@@ -24,6 +24,10 @@ use crate::tui_app::{run_headless, run_tui, TuiAppConfig};
 use crate::ui;
 
 /// Arguments for the run command.
+///
+/// `--debug` and `--profile` are promoted to top-level CLI flags (see
+/// `main.rs`) so they apply to every subcommand and reach the logging
+/// initializer before dispatch. They are no longer carried per-command.
 #[derive(Default)]
 pub struct RunArgs {
     pub provider: Option<ProviderType>,
@@ -33,8 +37,6 @@ pub struct RunArgs {
     pub timeout: Option<u64>,
     pub parallel: Option<usize>,
     pub no_cache: bool,
-    pub debug: bool,
-    pub profile: bool,
     pub no_prefetch: bool,
     pub airport: Option<String>,
 }
@@ -59,7 +61,7 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
         }
     }
 
-    let runner = CliRunner::with_options(args.debug, args.profile)?;
+    let runner = CliRunner::new()?;
     runner.log_startup("run");
 
     // Raise file descriptor limit to the hard maximum. XEL's FUSE mount +

--- a/xearthlayer-cli/src/error.rs
+++ b/xearthlayer-cli/src/error.rs
@@ -5,7 +5,6 @@
 
 use std::fmt;
 use std::path::PathBuf;
-use std::process;
 use xearthlayer::config::ConfigFileError;
 use xearthlayer::service::ServiceError;
 
@@ -37,8 +36,15 @@ pub enum CliError {
 }
 
 impl CliError {
-    /// Exit the process with an appropriate error message and code.
-    pub fn exit(&self) -> ! {
+    /// Print the user-facing error message and return the intended
+    /// process exit code.
+    ///
+    /// Caller (typically `main`) is responsible for actually exiting,
+    /// so local destructors — most importantly the [`tracing_appender`]
+    /// `LoggingGuard` — get a chance to run. Calling [`std::process::exit`]
+    /// from inside this function would skip them and silently truncate
+    /// the on-disk log; see issue #194.
+    pub fn report(&self) -> u8 {
         eprintln!("Error: {}", self);
 
         // Print additional help for specific errors
@@ -86,7 +92,7 @@ impl CliError {
                 eprintln!("Run 'xearthlayer scenery-index --help' for usage information.");
             }
             CliError::NeedsSetup => {
-                // NeedsSetup is informational, not an error - print welcome message
+                // NeedsSetup is informational, not an error — print welcome message
                 println!();
                 println!("Welcome to XEarthLayer!");
                 println!();
@@ -98,13 +104,13 @@ impl CliError {
                 println!("  2. xearthlayer packages list     # View available packages");
                 println!("  3. xearthlayer packages install <region>");
                 println!();
-                // Exit with code 0 since this is not an error
-                process::exit(0);
+                // Treated as success since this is informational, not an error.
+                return 0;
             }
             _ => {}
         }
 
-        process::exit(1)
+        1
     }
 }
 

--- a/xearthlayer-cli/src/logging_init.rs
+++ b/xearthlayer-cli/src/logging_init.rs
@@ -1,0 +1,110 @@
+//! CLI-level logging initialization.
+//!
+//! Centralizes the wiring between [`xearthlayer::config::ConfigFile`] and
+//! [`xearthlayer::logging::init_logging_full`] so that every subcommand —
+//! not just the ones that go through [`crate::runner::CliRunner`] — gets a
+//! populated `xearthlayer.log` for diagnostics. See issue #194.
+
+use std::path::Path;
+
+use crate::error::CliError;
+use xearthlayer::config::ConfigFile;
+use xearthlayer::logging::{init_logging_full, LoggingGuard};
+
+/// Default log filename used when the configured path has no file component.
+const DEFAULT_LOG_FILE: &str = "xearthlayer.log";
+
+/// Default parent directory used when the configured path has no parent.
+const DEFAULT_LOG_DIR: &str = ".";
+
+/// Split a configured log path into the (`directory`, `filename`) tuple
+/// expected by [`init_logging_full`].
+///
+/// Falls back to safe defaults rather than failing: a config that omits
+/// either component should still produce a working logger.
+pub(crate) fn derive_log_paths(log_path: &Path) -> (String, String) {
+    let dir = log_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| DEFAULT_LOG_DIR.to_string());
+
+    let file = log_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| DEFAULT_LOG_FILE.to_string());
+
+    (dir, file)
+}
+
+/// Initialize the global tracing subscriber for any CLI subcommand.
+///
+/// Reads the log file path from `config.logging.file`, suppresses stdout
+/// logging when stdout is a TTY (so the TUI dashboard isn't corrupted),
+/// and returns a guard that must be kept alive for the duration of the
+/// process.
+///
+/// # Errors
+///
+/// Returns [`CliError::LoggingInit`] if the log directory cannot be created
+/// or the log file cannot be cleared.
+pub fn init_cli_logging(
+    config: &ConfigFile,
+    debug_mode: bool,
+    profile_mode: bool,
+) -> Result<LoggingGuard, CliError> {
+    let (log_dir, log_file) = derive_log_paths(&config.logging.file);
+    let stdout_enabled = !atty::is(atty::Stream::Stdout);
+
+    init_logging_full(
+        &log_dir,
+        &log_file,
+        stdout_enabled,
+        debug_mode,
+        profile_mode,
+    )
+    .map_err(|e| CliError::LoggingInit(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn derive_log_paths_splits_normal_path() {
+        let path = PathBuf::from("/home/user/.xearthlayer/xearthlayer.log");
+        let (dir, file) = derive_log_paths(&path);
+        assert_eq!(dir, "/home/user/.xearthlayer");
+        assert_eq!(file, "xearthlayer.log");
+    }
+
+    #[test]
+    fn derive_log_paths_handles_bare_filename() {
+        // A relative filename with no directory component should land in
+        // the current working directory rather than failing.
+        let path = PathBuf::from("xearthlayer.log");
+        let (dir, file) = derive_log_paths(&path);
+        assert_eq!(dir, DEFAULT_LOG_DIR);
+        assert_eq!(file, "xearthlayer.log");
+    }
+
+    #[test]
+    fn derive_log_paths_handles_root_path() {
+        // PathBuf::from("/") has no file_name; we should fall back to the
+        // default log filename rather than producing nonsense.
+        let path = PathBuf::from("/");
+        let (dir, file) = derive_log_paths(&path);
+        assert_eq!(file, DEFAULT_LOG_FILE);
+        // Parent of "/" is None or empty; either way the default applies.
+        assert!(dir == DEFAULT_LOG_DIR || dir == "/");
+    }
+
+    #[test]
+    fn derive_log_paths_preserves_nested_directories() {
+        let path = PathBuf::from("/a/b/c/d/e.log");
+        let (dir, file) = derive_log_paths(&path);
+        assert_eq!(dir, "/a/b/c/d");
+        assert_eq!(file, "e.log");
+    }
+}

--- a/xearthlayer-cli/src/main.rs
+++ b/xearthlayer-cli/src/main.rs
@@ -22,6 +22,8 @@ mod runner;
 mod tui_app;
 mod ui;
 
+use std::process::ExitCode;
+
 use clap::{Parser, Subcommand};
 use commands::cache::CacheAction;
 use commands::common::{DdsCompression, ProviderType};
@@ -163,7 +165,7 @@ enum Commands {
 // Main Entry Point
 // ============================================================================
 
-fn main() {
+fn main() -> ExitCode {
     let cli = Cli::parse();
 
     // Initialize logging once for every subcommand. Falls back to default
@@ -218,7 +220,14 @@ fn main() {
         }),
     };
 
-    if let Err(e) = result {
-        e.exit();
-    }
+    // Returning ExitCode (rather than calling process::exit) lets the
+    // _logging_guard drop normally, which forces tracing-appender's
+    // background writer to flush. Calling process::exit here would
+    // truncate the log on every failed run — exactly the symptom #194
+    // was filed to prevent. See CliError::report.
+    let exit_code = match result {
+        Ok(()) => 0u8,
+        Err(e) => e.report(),
+    };
+    ExitCode::from(exit_code)
 }

--- a/xearthlayer-cli/src/main.rs
+++ b/xearthlayer-cli/src/main.rs
@@ -17,6 +17,7 @@
 
 mod commands;
 mod error;
+mod logging_init;
 mod runner;
 mod tui_app;
 mod ui;
@@ -25,6 +26,8 @@ use clap::{Parser, Subcommand};
 use commands::cache::CacheAction;
 use commands::common::{DdsCompression, ProviderType};
 use commands::scenery_index::SceneryIndexAction;
+use logging_init::init_cli_logging;
+use xearthlayer::config::ConfigFile;
 
 // ============================================================================
 // CLI Argument Definitions
@@ -35,6 +38,20 @@ use commands::scenery_index::SceneryIndexAction;
 #[command(version = xearthlayer::VERSION)]
 #[command(about = "Satellite imagery streaming for X-Plane", long_about = None)]
 struct Cli {
+    /// Enable debug-level logging for the xearthlayer crate.
+    ///
+    /// Applies to every subcommand. Equivalent to setting
+    /// `RUST_LOG=info,xearthlayer=debug`. Use this when filing bug reports
+    /// or debugging download / cache issues.
+    #[arg(long, global = true)]
+    debug: bool,
+
+    /// Enable Chrome Trace profiling output (writes trace to logs/).
+    ///
+    /// Applies to every subcommand. Requires the `profiling` feature.
+    #[arg(long, global = true)]
+    profile: bool,
+
     /// Subcommand to run. If omitted, defaults to 'run'.
     #[command(subcommand)]
     command: Option<Commands>,
@@ -129,14 +146,6 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
 
-        /// Enable debug-level logging for troubleshooting
-        #[arg(long)]
-        debug: bool,
-
-        /// Enable Chrome Trace profiling (writes trace to logs/)
-        #[arg(long)]
-        profile: bool,
-
         /// Disable predictive tile prefetching
         #[arg(long)]
         no_prefetch: bool,
@@ -156,6 +165,22 @@ enum Commands {
 
 fn main() {
     let cli = Cli::parse();
+
+    // Initialize logging once for every subcommand. Falls back to default
+    // config (and therefore the default log path) if the user's config
+    // file is missing or unparseable; that keeps first-run scenarios and
+    // misconfigured installs from running with no diagnostic output. (#194)
+    let config_for_logging = ConfigFile::load().unwrap_or_default();
+    let _logging_guard = match init_cli_logging(&config_for_logging, cli.debug, cli.profile) {
+        Ok(guard) => Some(guard),
+        Err(e) => {
+            eprintln!(
+                "warning: failed to initialize logging ({}); continuing without log file",
+                e
+            );
+            None
+        }
+    };
 
     let result = match cli.command {
         // Default to 'run' when no subcommand is provided
@@ -178,8 +203,6 @@ fn main() {
             timeout,
             parallel,
             no_cache,
-            debug,
-            profile,
             no_prefetch,
             airport,
         }) => commands::run::run(commands::run::RunArgs {
@@ -190,8 +213,6 @@ fn main() {
             timeout,
             parallel,
             no_cache,
-            debug,
-            profile,
             no_prefetch,
             airport,
         }),

--- a/xearthlayer-cli/src/runner.rs
+++ b/xearthlayer-cli/src/runner.rs
@@ -1,84 +1,27 @@
 //! CLI runner for common setup and operations.
 //!
-//! Encapsulates logging initialization and configuration loading
-//! to reduce duplication across command handlers.
+//! Encapsulates configuration loading and startup-banner logging
+//! for command handlers that need a loaded config.
+//!
+//! Logging initialization is intentionally NOT performed here; it is
+//! lifted into [`crate::main`] so every subcommand benefits, not just
+//! the ones that go through this runner. See issue #194.
 
 use crate::error::CliError;
 use tracing::info;
 use xearthlayer::config::ConfigFile;
-use xearthlayer::logging::{init_logging_full, LoggingGuard};
 
 /// Runner that manages CLI lifecycle and common operations.
 pub struct CliRunner {
-    /// Logging guard - keeps logging active while runner exists
-    #[allow(dead_code)]
-    logging_guard: LoggingGuard,
     /// Loaded configuration file
     config: ConfigFile,
 }
 
 impl CliRunner {
-    /// Create a new CLI runner, loading config and initializing logging.
-    ///
-    /// When stdout is a TTY, stdout logging is disabled to prevent
-    /// interference with the TUI dashboard.
+    /// Create a new CLI runner, loading config from the default path.
     pub fn new() -> Result<Self, CliError> {
-        Self::with_debug(false)
-    }
-
-    /// Create a new CLI runner with optional debug logging.
-    ///
-    /// When stdout is a TTY, stdout logging is disabled to prevent
-    /// interference with the TUI dashboard.
-    ///
-    /// # Arguments
-    ///
-    /// * `debug_mode` - When true, enables debug-level logging regardless of RUST_LOG
-    pub fn with_debug(debug_mode: bool) -> Result<Self, CliError> {
-        Self::with_options(debug_mode, false)
-    }
-
-    /// Create a new CLI runner with debug and profile options.
-    ///
-    /// When stdout is a TTY, stdout logging is disabled to prevent
-    /// interference with the TUI dashboard.
-    ///
-    /// # Arguments
-    ///
-    /// * `debug_mode` - When true, enables debug-level logging regardless of RUST_LOG
-    /// * `profile_mode` - When true, enables Chrome Trace profiling output
-    pub fn with_options(debug_mode: bool, profile_mode: bool) -> Result<Self, CliError> {
-        // Load config file (or use defaults if not present)
         let config = ConfigFile::load()?;
-
-        // Use log path from config
-        let log_path = &config.logging.file;
-        let log_dir = log_path
-            .parent()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|| ".".to_string());
-        let log_file = log_path
-            .file_name()
-            .map(|s| s.to_string_lossy().to_string())
-            .unwrap_or_else(|| "xearthlayer.log".to_string());
-
-        // Disable stdout logging when running in a TTY since TUI will take over
-        // This prevents log messages from corrupting the TUI display
-        let stdout_enabled = !atty::is(atty::Stream::Stdout);
-
-        let logging_guard = init_logging_full(
-            &log_dir,
-            &log_file,
-            stdout_enabled,
-            debug_mode,
-            profile_mode,
-        )
-        .map_err(|e| CliError::LoggingInit(e.to_string()))?;
-
-        Ok(Self {
-            logging_guard,
-            config,
-        })
+        Ok(Self { config })
     }
 
     /// Get the loaded configuration.

--- a/xearthlayer/src/manager/download/orchestrator.rs
+++ b/xearthlayer/src/manager/download/orchestrator.rs
@@ -26,6 +26,8 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use tracing::{debug, error, warn};
+
 use super::http::HttpDownloader;
 use super::progress::{DownloadProgressCallback, ProgressCounters, ProgressReporter};
 use super::semaphore::CountingSemaphore;
@@ -267,10 +269,18 @@ impl MultiPartDownloader {
         while let Ok((index, outcome)) = result_rx.recv() {
             match outcome {
                 WorkerOutcome::Success { bytes } => {
+                    debug!(part_index = index, bytes, "part download completed");
                     total_bytes += bytes;
                     completed += 1;
                 }
                 WorkerOutcome::Failed { error, filename } => {
+                    error!(
+                        part_index = index,
+                        filename = %filename,
+                        attempts = MAX_RETRIES,
+                        error = %error,
+                        "part download failed (retries exhausted)"
+                    );
                     failed_parts.push(index);
                     if first_failure.is_none() {
                         first_failure = Some((filename, error));
@@ -278,6 +288,10 @@ impl MultiPartDownloader {
                     }
                 }
                 WorkerOutcome::Aborted => {
+                    debug!(
+                        part_index = index,
+                        "part download aborted (sibling failed first)"
+                    );
                     failed_parts.push(index);
                 }
             }
@@ -378,10 +392,19 @@ fn run_part_worker(
     counters.set_part_state(i, 1); // Downloading
     counters.set_part_attempt(i, 1);
 
+    debug!(part_index = i, filename = %filename, url = %url, "part download started");
+
     let mut last_error = String::new();
 
     for attempt in 1..=MAX_RETRIES {
         if attempt > 1 {
+            warn!(
+                part_index = i,
+                filename = %filename,
+                attempt,
+                error = %last_error,
+                "part download retry"
+            );
             counters.set_part_state(i, 4); // Retrying
             counters.set_part_attempt(i, attempt);
             counters.update_part(i, 0); // Reset byte counter for retry

--- a/xearthlayer/src/manager/installer.rs
+++ b/xearthlayer/src/manager/installer.rs
@@ -11,6 +11,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Instant;
+
+use tracing::info;
 
 use crate::package::{PackageMetadata, PackageType};
 
@@ -205,6 +208,13 @@ impl<C: LibraryClient> PackageInstaller<C> {
             "Fetching package metadata...",
         );
         let metadata = self.client.fetch_metadata(metadata_url)?;
+        info!(
+            region = %metadata.title,
+            package_type = %metadata.package_type,
+            version = %metadata.package_version,
+            parts = metadata.parts.len(),
+            "package metadata fetched"
+        );
         report(InstallStage::FetchingMetadata, 1.0, "Metadata fetched");
 
         // Install using the fetched metadata
@@ -229,6 +239,14 @@ impl<C: LibraryClient> PackageInstaller<C> {
         let region = &metadata.title;
         let package_type = metadata.package_type;
         let version = metadata.package_version.clone();
+
+        info!(
+            region = %region,
+            package_type = %package_type,
+            version = %version,
+            parts = metadata.parts.len(),
+            "package install started"
+        );
 
         // Wrap callback in Arc for sharing with download progress
         let on_progress = on_progress.map(Arc::new);
@@ -295,6 +313,15 @@ impl<C: LibraryClient> PackageInstaller<C> {
         );
         downloader.query_sizes(&mut download_state);
 
+        info!(
+            region = %region,
+            parts = metadata.parts.len(),
+            parallel_downloads = self.parallel_downloads,
+            total_bytes = download_state.total_size,
+            "download phase started"
+        );
+        let download_started = Instant::now();
+
         // Pre-flight disk-space check (issue #188): fail fast with a
         // clear message if the temp directory's filesystem can't hold
         // the download plus the extracted contents. We check the temp
@@ -351,6 +378,12 @@ impl<C: LibraryClient> PackageInstaller<C> {
         downloader.download_all(&mut download_state, download_progress)?;
 
         let bytes_downloaded = download_state.bytes_downloaded;
+        info!(
+            region = %region,
+            bytes_downloaded,
+            elapsed_secs = download_started.elapsed().as_secs_f64(),
+            "download phase completed"
+        );
         report(
             InstallStage::Downloading,
             1.0,
@@ -365,16 +398,24 @@ impl<C: LibraryClient> PackageInstaller<C> {
         );
 
         // Stage 4: Reassemble archive
+        info!(
+            parts = destinations.len(),
+            archive = %metadata.filename,
+            "reassembly started"
+        );
         report(InstallStage::Reassembling, 0.0, "Reassembling archive...");
         let archive_path = install_temp.join(&metadata.filename);
         let extractor = ShellExtractor::new();
         extractor.reassemble(&destinations, &archive_path)?;
+        info!(archive = %metadata.filename, "reassembly completed");
         report(InstallStage::Reassembling, 1.0, "Archive reassembled");
 
         // Stage 5: Extract archive
+        info!(archive = %metadata.filename, "extraction started");
         report(InstallStage::Extracting, 0.0, "Extracting archive...");
         let extract_dir = install_temp.join("extracted");
         let files_extracted = extractor.extract(&archive_path, &extract_dir)?;
+        info!(files_extracted, "extraction completed");
         report(
             InstallStage::Extracting,
             1.0,
@@ -403,6 +444,16 @@ impl<C: LibraryClient> PackageInstaller<C> {
         report(InstallStage::Cleanup, 1.0, "Cleanup complete");
 
         report(InstallStage::Complete, 1.0, "Installation complete");
+
+        info!(
+            region = %region,
+            package_type = %package_type,
+            version = %version,
+            install_path = %install_path.display(),
+            bytes_downloaded,
+            files_extracted,
+            "package install completed"
+        );
 
         Ok(InstallResult {
             region: region.to_string(),


### PR DESCRIPTION
## Summary

Three coordinated changes that take the CLI's log file from "exists but empty for the commands that need it most" to "useful for diagnosing real package-install failures." Filed as #194 after dee-sea's diagnostic round-trip on #186 went sideways because \`RUST_LOG=trace xearthlayer packages install eu\` produced no log file.

### 1. Initialize logging for every subcommand (\`20b1e85\`)
Previously only \`run\` and \`patches\` initialized the tracing subscriber, because the call to \`init_logging_full\` lived inside \`CliRunner::with_options\` and only those two commands constructed a \`CliRunner\`. Every other CLI subcommand ran with \`tracing\` events going nowhere.

Lift logging initialization out of \`CliRunner\` and into \`main.rs\` so it runs once before subcommand dispatch. \`CliRunner\` is now config-only.

Promote \`--debug\` and \`--profile\` to top-level \`Cli\` flags with \`global = true\`. They now apply to every subcommand. \`xearthlayer run --debug\` keeps working unchanged thanks to clap's global-flag positioning, and \`xearthlayer --debug packages install eu\` is now possible.

### 2. Flush log on error exit (\`55b0e3b\`, first half)
Discovered while verifying #1: \`CliError::exit\` called \`std::process::exit\` directly, which skips local destructors. The \`LoggingGuard\` therefore never dropped on the error path, and \`tracing-appender\`'s background writer was killed mid-flight with its queue unflushed — every failed CLI invocation produced an empty log file even after #1.

Replace \`exit\` with \`report() -> u8\`; have \`main\` return \`ExitCode\` so the guard drops normally before process termination.

### 3. Structured tracing across the install pipeline (\`55b0e3b\`, second half)
Added INFO events at every stage transition in \`installer.rs\` — install started, metadata fetched, download phase started/completed (with bytes + elapsed_secs), reassembly started/completed, extraction started/completed, install completed. All emitted with structured fields (region, version, parts, bytes, etc.) for grep / awk analysis.

In \`download/orchestrator.rs\`: DEBUG event when a part download starts, DEBUG on success, DEBUG on abort. WARN on each retry. ERROR when retries exhaust.

## Test plan

- [x] \`make pre-commit\` passes (2,404 unit tests + clippy + fmt)
- [x] \`xearthlayer --debug packages install eu\` (errors AlreadyInstalled) writes "package install started" to the log instead of leaving it empty
- [x] \`xearthlayer --debug diagnostics\` (success path) still writes wgpu detection events
- [x] \`xearthlayer run --debug\` and \`xearthlayer --debug run\` both accept the flag (clap \`global = true\`)
- [x] \`xearthlayer --help\` and \`xearthlayer run --help\` both surface the global flags

## What dee-sea will see when he retries on \`main\`

When he runs \`RUST_LOG=trace xearthlayer packages install eu\` from a fresh build, his failed install will now produce a log file showing exactly which parts failed, how many retries each got, and what the underlying error message was — exactly the diagnostic we asked for in #186 but couldn't capture before.

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)