### PR TITLE
Feat/macos port clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
     - `StateAggregator` - Combines multiple position sources with accuracy-based selection
     - `PositionModel` - Persistent position model refined by best available data
     - `WebApiAdapter` - Connects to X-Plane Web API (REST + WebSocket) for position and sim state
-    - `InferenceAdapter` - Position inference from FUSE file access patterns
+    - `InferenceAdapter` - Position inference from FUSE file access patterns (macOS caveat: virtual DDS files use the kernel page cache there, so FUSE only sees cold first-reads — steady-state position tracking is effectively Web API-only; see `docs/dev/fuse-filesystem.md`)
     - `FlightPathHistory` - Position history for track derivation
     - Position sources: Web API (10m), ManualReference (100m), SceneInference (100km)
     - Higher accuracy wins; stale high-accuracy can be beaten by fresh lower-accuracy
@@ -439,7 +439,7 @@ matrix jobs are renamed.
 ## Platform Support
 
 - **Linux**: ✅ Fully working (native FUSE)
-- **macOS**: ✅ Working (requires [macFUSE](https://macfuse.io); Apple Silicon tested; fuse3 pinned to a fork rev carrying the reply-resilience patch, upstream PR [Sherlock-Holo/fuse3#137](https://github.com/Sherlock-Holo/fuse3/pull/137))
+- **macOS**: ✅ Working (requires [macFUSE](https://macfuse.io); Apple Silicon tested; fuse3 pinned to a fork rev carrying the reply-resilience patch (upstream PR [Sherlock-Holo/fuse3#137](https://github.com/Sherlock-Holo/fuse3/pull/137)), comma-joined mount options, and reply-drop log demotion; install/approval guide in `docs/macos.md`)
 - **Windows**: ⏳ Planned (requires Dokan/WinFSP)
 
 ## References

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,7 +439,7 @@ matrix jobs are renamed.
 ## Platform Support
 
 - **Linux**: ✅ Fully working (native FUSE)
-- **macOS**: ✅ Working (requires [macFUSE](https://macfuse.io); Apple Silicon tested; fuse3 pinned to a fork rev carrying the reply-resilience patch (upstream PR [Sherlock-Holo/fuse3#137](https://github.com/Sherlock-Holo/fuse3/pull/137)), comma-joined mount options, and reply-drop log demotion; install/approval guide in `docs/macos.md`)
+- **macOS**: ✅ Working (requires [macFUSE](https://macfuse.io); Apple Silicon tested; fuse3 pinned to `samsoir/fuse3` `master` (upstream + `configurable-background` plus the macOS reply-resilience patch — upstream PR [Sherlock-Holo/fuse3#137](https://github.com/Sherlock-Holo/fuse3/pull/137) — comma-joined mount options, and reply-drop log demotion); install/approval guide in `docs/macos.md`)
 - **Windows**: ⏳ Planned (requires Dokan/WinFSP)
 
 ## References

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,8 +439,8 @@ matrix jobs are renamed.
 ## Platform Support
 
 - **Linux**: ✅ Fully working (native FUSE)
+- **macOS**: ✅ Working (requires [macFUSE](https://macfuse.io); Apple Silicon tested; fuse3 pinned to a fork rev carrying the reply-resilience patch, upstream PR [Sherlock-Holo/fuse3#137](https://github.com/Sherlock-Holo/fuse3/pull/137))
 - **Windows**: ⏳ Planned (requires Dokan/WinFSP)
-- **macOS**: ⏳ Planned (requires macFUSE)
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [How It Works](docs/how-it-works.md) for detailed architecture.
 - **Multiple compression backends**: ISPC SIMD (default), pure-Rust software, or GPU-accelerated via wgpu compute shaders
 - Real-time dashboard showing cache, download, and prefetch status
 - Works with Ortho4XP-generated scenery
-- Linux support
+- Linux and macOS support
 
 ## Quick Start
 
@@ -178,7 +178,7 @@ Run `xearthlayer --help` for all options.
 ## Requirements
 
 - **X-Plane 12**
-- **Linux** with FUSE support
+- **Linux** with FUSE support, or **macOS** with [macFUSE](https://macfuse.io) installed
 - **Modern GPU** with 8GB VRAM or higher, 16GB+ recommended (for X-Plane rendering)
 - **Fast Internet connection** for streaming imagery, recommended 800Mbps downstream or better
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Run `xearthlayer --help` for all options.
 ## Requirements
 
 - **X-Plane 12**
-- **Linux** with FUSE support, or **macOS** with [macFUSE](https://macfuse.io) installed
+- **Linux** with FUSE support, or **macOS** with [macFUSE](https://macfuse.io) installed (see the [macOS guide](docs/macos.md))
 - **Modern GPU** with 8GB VRAM or higher, 16GB+ recommended (for X-Plane rendering)
 - **Fast Internet connection** for streaming imagery, recommended 800Mbps downstream or better
 

--- a/docs/dev/fuse-filesystem.md
+++ b/docs/dev/fuse-filesystem.md
@@ -247,18 +247,30 @@ The regex pattern for recognition:
 
 | Operation | Behavior |
 |-----------|----------|
-| `open` | Virtual DDS inodes: `FOPEN_DIRECT_IO`; Real passthrough files: default flags |
+| `open` | Virtual DDS inodes: `VIRTUAL_DDS_OPEN_FLAGS` (platform-dependent, see below); Real passthrough files: default flags |
 | `read` | For DDS: serve from cache/generated; For others: read from source |
 | `release` | Clean up handles |
 
-### Direct I/O for Virtual DDS Files
+### Open Flags for Virtual DDS Files
 
-`Fuse3OrthoUnionFS` implements `open()` to set `FOPEN_DIRECT_IO` on virtual DDS inodes. This bypasses the kernel page cache for generated textures:
+Both filesystems set `VIRTUAL_DDS_OPEN_FLAGS` (single source of truth in
+`fuse/fuse3/shared.rs`) on virtual DDS inodes in `open()`. The value is
+platform-dependent:
+
+**Linux: `FOPEN_DIRECT_IO`** -- bypasses the kernel page cache for generated textures:
 
 - **Full observability** -- every X-Plane DDS read goes through the FUSE handler, visible to `FuseLoadMonitor`, `SceneTracker`, and `DdsAccessEvent`
 - **No stale data** -- page cache cannot serve outdated DDS data after provider changes or cache clears
 - **Reduced kernel memory** -- no page cache duplication of data already in the moka memory cache
 - Real passthrough files use default kernel caching (unchanged)
+
+**macOS: `0` (page cache enabled)** -- direct I/O breaks X-Plane's `mmap`-based
+texture loading under macFUSE (`EXC_BAD_ACCESS` in the sim's texture loader),
+so generated textures use normal kernel caching. Consequences:
+
+- **Reduced observability** -- once the kernel caches a DDS file, repeat reads never reach FUSE. `SceneTracker`, `DdsAccessEvent`, and FUSE-load calibration only see the *cold first read* of each tile; `InferenceAdapter` position inference degrades to "tiles seen once since mount", so steady-state position tracking is effectively **Web API-only** on macOS
+- **Prefetch is unaffected** in practice: the adaptive prefetcher is driven by Web API telemetry, and cold reads (the ones that matter for generation) always reach FUSE
+- Stale-data risk is acceptable: generated DDS content for a given tile/provider is immutable within a run
 
 ### Synthesized DDS Attributes
 
@@ -512,7 +524,7 @@ The DDS generation system uses a job/task framework:
 ### Operating Systems
 
 - Linux: Native FUSE support (✅ fully working)
-- macOS: Requires macFUSE (⏳ planned)
+- macOS: Requires [macFUSE](https://macfuse.io) (✅ working, Apple Silicon tested — see [macOS guide](../macos.md))
 - Windows: Requires WinFSP (⏳ planned)
 
 ### Scenery Compatibility

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ See [How It Works](how-it-works.md) for a detailed architectural explanation.
 ## Prerequisites
 
 - **X-Plane 12** (X-Plane 11 may work but is untested)
-- **Linux** (Windows and macOS support planned)
+- **Linux** with FUSE support, or **macOS** with [macFUSE](https://macfuse.io) — see the [macOS guide](macos.md) (Windows support planned)
 - **Internet connection** for streaming imagery
 - Basic familiarity with the command line
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,96 @@
+# XEarthLayer on macOS
+
+XEarthLayer supports macOS (Apple Silicon tested) using [macFUSE](https://macfuse.io) to provide the FUSE virtual filesystem that streams textures to X-Plane.
+
+## Requirements
+
+- macOS 12 or later (tested on Apple Silicon; Intel Macs should work but are untested)
+- [macFUSE](https://macfuse.io) 5.x or later
+- X-Plane 12
+
+## Installing macFUSE
+
+macFUSE ships as a kernel extension (kext), so installation involves a one-time
+security approval that is stricter on Apple Silicon Macs.
+
+### 1. Install the package
+
+Download the installer from [macfuse.io](https://macfuse.io) and run it, or use Homebrew:
+
+```bash
+brew install --cask macfuse
+```
+
+### 2. Approve the kernel extension
+
+**Apple Silicon Macs** must first allow third-party kernel extensions:
+
+1. Shut down the Mac completely.
+2. Press and **hold** the power button until "Loading startup options" appears, then choose **Options** to boot into Recovery.
+3. Open **Utilities → Startup Security Utility**, select your startup disk, and choose **Reduced Security** with **"Allow user management of kernel extensions from identified developers"** checked.
+4. Restart back into macOS.
+
+**All Macs** then approve the extension:
+
+1. Open **System Settings → Privacy & Security**.
+2. Under Security you will see a message that system software from developer **"Benjamin Fleischer"** (the macFUSE developer) was blocked — click **Allow** (macOS may ask you to **Enable System Extensions** and restart).
+3. Restart when prompted.
+
+After the restart, verify macFUSE is active — the mount helper should exist:
+
+```bash
+ls /usr/local/lib/libfuse* /Library/Filesystems/macfuse.fs 2>/dev/null
+```
+
+If the approval prompt never appeared, re-run the macFUSE installer after completing the Recovery steps.
+
+### 3. Build and run XEarthLayer
+
+Building from source works exactly as on Linux:
+
+```bash
+make release
+make install   # installs to ~/.local/bin
+xearthlayer setup
+```
+
+The setup wizard auto-detects your X-Plane installation, total memory (via `sysctl`), and storage type (via `diskutil`) to suggest sensible cache settings.
+
+## Platform Behavior Notes
+
+### Texture caching uses the kernel page cache
+
+On Linux, XEarthLayer serves generated DDS textures with direct I/O so every
+read from X-Plane is visible to the streaming service. On macOS, direct I/O
+interacts badly with X-Plane's memory-mapped texture loading (it can crash the
+simulator), so generated textures are served through the normal kernel page
+cache instead.
+
+This is safe and transparent, with one side effect: once a texture is cached by
+the kernel, repeat reads never reach XEarthLayer. Position inference from file
+access patterns (`InferenceAdapter`) therefore only sees the *first* read of
+each tile, so in steady flight XEarthLayer relies on the X-Plane **Web API**
+for aircraft position. The Web API connection is automatic and requires no
+configuration — just make sure X-Plane's Web API is not disabled. Prefetching
+and adaptive scenery loading work normally through it.
+
+### Stale mount recovery
+
+If XEarthLayer is killed without unmounting (crash, force-quit), macFUSE leaves
+a stale mount behind and the next run would fail with *"Device not configured
+(os error 6)"*. XEarthLayer detects this at startup and force-unmounts the
+stale mountpoint automatically. If you ever need to do it manually:
+
+```bash
+umount "/path/to/X-Plane 12/Custom Scenery/zzXEL_ortho"
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `mount_macfuse: the file system is not available (255)` | macFUSE kext not approved — redo the approval steps above |
+| "System extension blocked" notification | System Settings → Privacy & Security → Allow, then restart |
+| No approval option appears (Apple Silicon) | Boot into Recovery and enable Reduced Security with kernel extension management first |
+| "Device not configured (os error 6)" on mount | Stale mount from a previous run — recovered automatically at startup; manual fix: `umount <mountpoint>` |
+| macFUSE stops working after a macOS upgrade | Re-run the macFUSE installer and re-approve the extension |

--- a/xearthlayer-cli/src/commands/run.rs
+++ b/xearthlayer-cli/src/commands/run.rs
@@ -90,19 +90,18 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
     }
 
     // Get Custom Scenery path (where mounts go)
-    let custom_scenery_path = config
-        .packages
-        .custom_scenery_path
-        .clone()
-        .or_else(|| config.xplane.scenery_dir.clone())
-        .or_else(|| xearthlayer::config::detect_custom_scenery().ok())
-        .ok_or_else(|| {
-            CliError::Config(
-                "No Custom Scenery path configured. \
-                 Run 'xearthlayer init' or set packages.custom_scenery_path in config.ini"
-                    .to_string(),
-            )
-        })?;
+    let custom_scenery_path = resolve_custom_scenery_path(
+        config.packages.custom_scenery_path.clone(),
+        config.xplane.scenery_dir.clone(),
+        || xearthlayer::config::detect_custom_scenery().ok(),
+    )
+    .ok_or_else(|| {
+        CliError::Config(
+            "No Custom Scenery path configured. \
+             Run 'xearthlayer init' or set packages.custom_scenery_path in config.ini"
+                .to_string(),
+        )
+    })?;
 
     if !custom_scenery_path.exists() {
         return Err(CliError::Config(format!(
@@ -401,6 +400,20 @@ fn raise_fd_limit() {
     }
 }
 
+/// Resolve the Custom Scenery path from configuration, falling back to
+/// auto-detection of the X-Plane installation.
+///
+/// Precedence: `packages.custom_scenery_path` > `xplane.scenery_dir` >
+/// auto-detect. Auto-detection is only attempted when both config values
+/// are unset.
+fn resolve_custom_scenery_path(
+    custom_scenery_path: Option<PathBuf>,
+    scenery_dir: Option<PathBuf>,
+    detect: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    custom_scenery_path.or(scenery_dir).or_else(detect)
+}
+
 /// Display warning if configuration file needs upgrade.
 ///
 /// Checks if the user's config.ini is missing settings from the current version
@@ -439,5 +452,41 @@ fn check_config_upgrade_warning() {
             // Log error but don't fail - config upgrade is informational
             tracing::warn!("Failed to analyze config for upgrade: {}", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_custom_scenery_path_wins() {
+        let resolved = resolve_custom_scenery_path(
+            Some(PathBuf::from("/configured")),
+            Some(PathBuf::from("/scenery-dir")),
+            || panic!("auto-detect must not run when config is set"),
+        );
+        assert_eq!(resolved, Some(PathBuf::from("/configured")));
+    }
+
+    #[test]
+    fn scenery_dir_used_when_custom_scenery_path_unset() {
+        let resolved =
+            resolve_custom_scenery_path(None, Some(PathBuf::from("/scenery-dir")), || {
+                panic!("auto-detect must not run when scenery_dir is set")
+            });
+        assert_eq!(resolved, Some(PathBuf::from("/scenery-dir")));
+    }
+
+    #[test]
+    fn auto_detect_used_when_both_config_values_unset() {
+        let resolved = resolve_custom_scenery_path(None, None, || Some(PathBuf::from("/detected")));
+        assert_eq!(resolved, Some(PathBuf::from("/detected")));
+    }
+
+    #[test]
+    fn none_when_nothing_configured_and_detection_fails() {
+        let resolved = resolve_custom_scenery_path(None, None, || None);
+        assert_eq!(resolved, None);
     }
 }

--- a/xearthlayer-cli/src/commands/run.rs
+++ b/xearthlayer-cli/src/commands/run.rs
@@ -95,6 +95,7 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
         .custom_scenery_path
         .clone()
         .or_else(|| config.xplane.scenery_dir.clone())
+        .or_else(|| xearthlayer::config::detect_custom_scenery().ok())
         .ok_or_else(|| {
             CliError::Config(
                 "No Custom Scenery path configured. \

--- a/xearthlayer-cli/src/error.rs
+++ b/xearthlayer-cli/src/error.rs
@@ -57,11 +57,23 @@ impl CliError {
             CliError::Serve(_) => {
                 eprintln!();
                 eprintln!("Common issues:");
-                eprintln!("  1. FUSE not installed: sudo apt install fuse (Linux)");
-                eprintln!("  2. Permissions: You may need to add your user to 'fuse' group");
-                eprintln!(
-                    "  3. Mountpoint in use: Try unmounting with: fusermount -u <mountpoint>"
-                );
+                #[cfg(target_os = "macos")]
+                {
+                    eprintln!("  1. macFUSE not installed: download from https://macfuse.io");
+                    eprintln!(
+                        "  2. macFUSE not approved: allow it under System Settings > \
+                         Privacy & Security, then restart"
+                    );
+                    eprintln!("  3. Stale mount from a previous run: umount \"<mountpoint>\"");
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    eprintln!("  1. FUSE not installed: sudo apt install fuse (Linux)");
+                    eprintln!("  2. Permissions: You may need to add your user to 'fuse' group");
+                    eprintln!(
+                        "  3. Mountpoint in use: Try unmounting with: fusermount -u <mountpoint>"
+                    );
+                }
             }
             CliError::Publish(_) => {
                 eprintln!();

--- a/xearthlayer/src/config/settings.rs
+++ b/xearthlayer/src/config/settings.rs
@@ -156,7 +156,8 @@ pub struct PackagesSettings {
     /// Local directory for installed packages (default: ~/.xearthlayer/packages).
     pub install_location: Option<PathBuf>,
     /// X-Plane Custom Scenery directory for overlay symlinks.
-    /// If None, auto-detects from xplane.scenery_dir or ~/.x-plane/x-plane_install_12.txt
+    /// If None, auto-detects from xplane.scenery_dir or the platform's
+    /// X-Plane install reference file (see [`crate::xplane::paths`]).
     pub custom_scenery_path: Option<PathBuf>,
     /// Automatically install overlay packages when installing ortho for same region.
     pub auto_install_overlays: bool,

--- a/xearthlayer/src/config/storage.rs
+++ b/xearthlayer/src/config/storage.rs
@@ -156,12 +156,21 @@ impl DiskIoProfile {
     ///
     /// On detection failure, falls back to `Ssd`.
     pub fn resolve_for_path(&self, path: &Path) -> Self {
+        self.try_resolve_for_path(path).unwrap_or_else(|| {
+            debug!("Storage detection failed, defaulting to SSD profile");
+            Self::Ssd
+        })
+    }
+
+    /// Detect the appropriate profile for the given path, surfacing failure.
+    ///
+    /// Like [`resolve_for_path`](Self::resolve_for_path) but returns `None`
+    /// when `self` is `Auto` and detection fails, so callers (e.g. the setup
+    /// wizard) can tell a detected profile from a fallback guess.
+    pub fn try_resolve_for_path(&self, path: &Path) -> Option<Self> {
         match self {
-            Self::Auto => detect_storage_type(path).unwrap_or_else(|| {
-                debug!("Storage detection failed, defaulting to SSD profile");
-                Self::Ssd
-            }),
-            other => *other,
+            Self::Auto => detect_storage_type(path),
+            other => Some(*other),
         }
     }
 }
@@ -516,6 +525,25 @@ mod tests {
         assert_eq!("nvme".parse(), Ok(DiskIoProfile::Nvme));
         assert_eq!("NVMe".parse(), Ok(DiskIoProfile::Nvme));
         assert_eq!("invalid".parse::<DiskIoProfile>(), Err(()));
+    }
+
+    #[test]
+    fn try_resolve_for_path_passes_explicit_profiles_through() {
+        let path = Path::new("/nonexistent-path-for-test");
+        assert_eq!(
+            DiskIoProfile::Nvme.try_resolve_for_path(path),
+            Some(DiskIoProfile::Nvme)
+        );
+        assert_eq!(
+            DiskIoProfile::Hdd.try_resolve_for_path(path),
+            Some(DiskIoProfile::Hdd)
+        );
+        // For Auto the two resolvers must agree: same profile when
+        // detection succeeds, silent SSD fallback when it fails.
+        let expected = DiskIoProfile::Auto
+            .try_resolve_for_path(path)
+            .unwrap_or(DiskIoProfile::Ssd);
+        assert_eq!(DiskIoProfile::Auto.resolve_for_path(path), expected);
     }
 
     #[test]

--- a/xearthlayer/src/config/storage.rs
+++ b/xearthlayer/src/config/storage.rs
@@ -24,7 +24,7 @@
 use std::path::Path;
 use tracing::debug;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 use tracing::warn;
 
 // =============================================================================
@@ -329,14 +329,176 @@ fn check_device_match(device_name: &str, major: u32, minor: u32) -> bool {
     false
 }
 
-/// Fallback for non-Linux platforms - always returns None.
-#[cfg(not(target_os = "linux"))]
+/// Detect the storage type for the given path on macOS.
+///
+/// macOS has no `/sys/block`. We resolve the cache path to its backing device
+/// node with `df`, then ask `diskutil info` whether that device is solid state
+/// and over what protocol, mapping the result to a [`DiskIoProfile`]. Returns
+/// `None` (caller falls back to SSD) if any step fails or the device can't be
+/// classified.
+#[cfg(target_os = "macos")]
+fn detect_storage_type(path: &Path) -> Option<DiskIoProfile> {
+    let existing = nearest_existing_ancestor(path)?;
+    let df_out = run_command("df", &[existing.to_str()?])?;
+    let device = parse_df_device(&df_out)?;
+    debug!("Path {:?} is backed by device {}", path, device);
+
+    let info = run_command("diskutil", &["info", &device])?;
+    let profile = classify_diskutil_info(&info);
+    debug!("diskutil classified {} as {:?}", device, profile);
+    profile
+}
+
+/// Walk up from `path` to the nearest ancestor that exists.
+///
+/// The cache directory may not exist yet during setup, but `df` needs a real
+/// path. The filesystem of the nearest existing ancestor is the same one the
+/// cache will live on, so it answers the storage-type question correctly.
+#[cfg(target_os = "macos")]
+fn nearest_existing_ancestor(path: &Path) -> Option<std::path::PathBuf> {
+    let mut probe: Option<&Path> = Some(path);
+    while let Some(p) = probe {
+        if p.exists() {
+            return Some(p.to_path_buf());
+        }
+        probe = p.parent();
+    }
+    None
+}
+
+/// Run a command and return its stdout as a string, or `None` on failure.
+#[cfg(target_os = "macos")]
+fn run_command(cmd: &str, args: &[&str]) -> Option<String> {
+    use std::process::Command;
+
+    let output = Command::new(cmd).args(args).output().ok()?;
+    if !output.status.success() {
+        debug!("`{} {}` failed", cmd, args.join(" "));
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Extract the `/dev/...` device node from `df <path>` output.
+///
+/// Pure function (no I/O) so the parsing is unit-testable. `df` prints a header
+/// line followed by one data line whose first column is the device node, e.g.
+/// `/dev/disk3s5`. Returns `None` if there is no data line or it isn't a device.
+#[cfg(target_os = "macos")]
+fn parse_df_device(df_output: &str) -> Option<String> {
+    df_output
+        .lines()
+        .nth(1)? // skip the header row
+        .split_whitespace()
+        .next()
+        .filter(|dev| dev.starts_with("/dev/"))
+        .map(|dev| dev.to_string())
+}
+
+/// Map `diskutil info <device>` output to a [`DiskIoProfile`].
+///
+/// Pure function (no I/O) so the classification is unit-testable. Keys on two
+/// fields:
+/// - `Solid State: No`  → [`DiskIoProfile::Hdd`]
+/// - `Solid State: Yes` over a PCI / Apple Fabric / NVMe protocol → [`DiskIoProfile::Nvme`]
+/// - `Solid State: Yes` over any other protocol (SATA, USB, …) → [`DiskIoProfile::Ssd`]
+///
+/// Returns `None` if the `Solid State` field is absent, so the caller falls
+/// back to the safe SSD default rather than guessing.
+#[cfg(target_os = "macos")]
+fn classify_diskutil_info(info: &str) -> Option<DiskIoProfile> {
+    let field = |name: &str| {
+        info.lines().find_map(|line| {
+            line.split_once(':')
+                .filter(|(key, _)| key.trim() == name)
+                .map(|(_, value)| value.trim())
+        })
+    };
+
+    if field("Solid State")?.eq_ignore_ascii_case("No") {
+        return Some(DiskIoProfile::Hdd);
+    }
+
+    // Solid state: distinguish NVMe-class from SATA by the bus protocol.
+    let protocol = field("Protocol").unwrap_or("").to_ascii_lowercase();
+    if protocol.contains("pci") || protocol.contains("apple fabric") || protocol.contains("nvme") {
+        Some(DiskIoProfile::Nvme)
+    } else {
+        Some(DiskIoProfile::Ssd)
+    }
+}
+
+/// Fallback for unsupported platforms - always returns None.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn detect_storage_type(path: &Path) -> Option<DiskIoProfile> {
     warn!(
         "Storage type detection not supported on this platform, using default profile for {:?}",
         path
     );
     None
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod macos_storage_tests {
+    use super::*;
+
+    #[test]
+    fn classify_apple_fabric_ssd_as_nvme() {
+        // Apple Silicon internal storage.
+        let info =
+            "   Protocol:                  Apple Fabric\n   Solid State:               Yes\n";
+        assert_eq!(classify_diskutil_info(info), Some(DiskIoProfile::Nvme));
+    }
+
+    #[test]
+    fn classify_pci_express_ssd_as_nvme() {
+        // Intel Mac internal NVMe.
+        let info = "   Protocol:                  PCI-Express\n   Solid State:               Yes\n";
+        assert_eq!(classify_diskutil_info(info), Some(DiskIoProfile::Nvme));
+    }
+
+    #[test]
+    fn classify_sata_ssd_as_ssd() {
+        let info = "   Protocol:                  SATA\n   Solid State:               Yes\n";
+        assert_eq!(classify_diskutil_info(info), Some(DiskIoProfile::Ssd));
+    }
+
+    #[test]
+    fn classify_spinning_disk_as_hdd() {
+        let info = "   Protocol:                  USB\n   Solid State:               No\n";
+        assert_eq!(classify_diskutil_info(info), Some(DiskIoProfile::Hdd));
+    }
+
+    #[test]
+    fn classify_missing_solid_state_field_is_none() {
+        let info = "   Protocol:                  USB\n   Device Node:   /dev/disk9\n";
+        assert_eq!(classify_diskutil_info(info), None);
+    }
+
+    #[test]
+    fn parse_df_device_extracts_dev_node() {
+        let df = "Filesystem    512-blocks      Used Available Capacity  Mounted on\n\
+                  /dev/disk3s5  3906971480 100000000 50000000    67%  /System/Volumes/Data\n";
+        assert_eq!(parse_df_device(df).as_deref(), Some("/dev/disk3s5"));
+    }
+
+    #[test]
+    fn parse_df_device_rejects_missing_or_nondevice() {
+        assert_eq!(parse_df_device(""), None);
+        assert_eq!(parse_df_device("only a header line\n"), None);
+        assert_eq!(
+            parse_df_device("header\nmap auto_home 0 0 ... /home\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn detect_storage_type_for_root_does_not_panic() {
+        // End-to-end exercise of df + diskutil on a path that always exists.
+        // We don't assert a specific profile (varies by host), only that the
+        // pipeline runs without panicking and yields a sane Option.
+        let _ = detect_storage_type(Path::new("/"));
+    }
 }
 
 #[cfg(test)]

--- a/xearthlayer/src/config/writer.rs
+++ b/xearthlayer/src/config/writer.rs
@@ -141,7 +141,8 @@ retry_base_delay_ms = {}
 
 [xplane]
 ; X-Plane Custom Scenery directory for mounting scenery packs
-; If empty, auto-detects from ~/.x-plane/x-plane_install_12.txt
+; If empty, auto-detects from the X-Plane install reference file
+; (Linux: ~/.x-plane/x-plane_install_12.txt, macOS: ~/Library/Preferences/x-plane_install_12.txt)
 ; This is also where packages are installed by 'xearthlayer packages install'
 scenery_dir = {}
 

--- a/xearthlayer/src/diagnostics/report.rs
+++ b/xearthlayer/src/diagnostics/report.rs
@@ -109,6 +109,33 @@ impl SystemReport {
     }
 }
 
+/// Run a command and return its trimmed stdout, or `None` on failure / empty.
+///
+/// Used by the macOS collectors, which read hardware/OS facts from `sysctl`,
+/// `sw_vers`, and `route` rather than the Linux `/proc` and `/etc` files.
+#[cfg(target_os = "macos")]
+fn command_output(cmd: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(cmd).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let trimmed = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+/// Extract the interface name from `route -n get default` output.
+///
+/// Pure function (no I/O) so the parsing is unit-testable. The relevant line
+/// looks like `  interface: en0`.
+#[cfg(target_os = "macos")]
+fn parse_default_interface(route_output: &str) -> Option<String> {
+    route_output.lines().find_map(|line| {
+        line.split_once(':')
+            .filter(|(key, _)| key.trim() == "interface")
+            .map(|(_, value)| value.trim().to_string())
+    })
+}
+
 impl OsInfo {
     fn collect() -> Self {
         let mut info = Self::default();
@@ -134,6 +161,17 @@ impl OsInfo {
             }
         }
 
+        // macOS has no /etc/os-release; assemble the name from sw_vers.
+        #[cfg(target_os = "macos")]
+        if info.os_name.is_none() {
+            if let (Some(name), Some(version)) = (
+                command_output("sw_vers", &["-productName"]),
+                command_output("sw_vers", &["-productVersion"]),
+            ) {
+                info.os_name = Some(format!("{} {}", name, version));
+            }
+        }
+
         // Desktop environment
         if let Ok(desktop) = std::env::var("XDG_CURRENT_DESKTOP") {
             info.desktop = Some(desktop);
@@ -153,6 +191,17 @@ impl OsInfo {
 impl HardwareInfo {
     fn collect() -> Self {
         let mut info = Self::default();
+
+        // macOS has no /proc; read CPU/memory facts from sysctl.
+        #[cfg(target_os = "macos")]
+        {
+            info.cpu_model = command_output("sysctl", &["-n", "machdep.cpu.brand_string"]);
+            info.cpu_cores =
+                command_output("sysctl", &["-n", "hw.logicalcpu"]).and_then(|s| s.parse().ok());
+            info.memory_gb = command_output("sysctl", &["-n", "hw.memsize"])
+                .and_then(|s| s.parse::<u64>().ok())
+                .map(|bytes| bytes as f64 / 1024.0 / 1024.0 / 1024.0);
+        }
 
         // CPU info
         if let Ok(content) = fs::read_to_string("/proc/cpuinfo") {
@@ -360,6 +409,14 @@ impl NetworkInfo {
                         }
                     }
                 }
+            }
+        }
+
+        // macOS has no `ip`; ask the BSD routing table for the default route.
+        #[cfg(target_os = "macos")]
+        if info.default_interface.is_none() {
+            if let Some(out) = command_output("route", &["-n", "get", "default"]) {
+                info.default_interface = parse_default_interface(&out);
             }
         }
 
@@ -613,6 +670,39 @@ impl fmt::Display for SystemReport {
         writeln!(f, "Copy the above output into your GitHub issue.")?;
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod macos_tests {
+    use super::*;
+
+    #[test]
+    fn parse_default_interface_extracts_iface() {
+        let out = "   route to: default\n  destination: default\n  interface: en0\n        flags: <UP,GATEWAY>\n";
+        assert_eq!(parse_default_interface(out).as_deref(), Some("en0"));
+    }
+
+    #[test]
+    fn parse_default_interface_handles_missing() {
+        assert_eq!(parse_default_interface(""), None);
+        assert_eq!(parse_default_interface("no interface here\n"), None);
+    }
+
+    #[test]
+    fn hardware_collect_populates_on_macos() {
+        // Exercises the sysctl path end to end; every Mac has a CPU model,
+        // logical cores, and RAM, so none of these should be None.
+        let info = HardwareInfo::collect();
+        assert!(info.cpu_model.is_some(), "cpu_model should be detected");
+        assert!(info.cpu_cores.is_some(), "cpu_cores should be detected");
+        assert!(info.memory_gb.is_some(), "memory_gb should be detected");
+    }
+
+    #[test]
+    fn os_collect_populates_name_on_macos() {
+        let info = OsInfo::collect();
+        assert!(info.os_name.is_some(), "os_name should be set via sw_vers");
     }
 }
 

--- a/xearthlayer/src/fuse/fuse3/filesystem.rs
+++ b/xearthlayer/src/fuse/fuse3/filesystem.rs
@@ -4,7 +4,7 @@
 //! All operations are async and run concurrently on the Tokio runtime.
 
 use super::inode::InodeManager;
-use super::shared::{DdsRequestor, FileAttrBuilder, VirtualDdsConfig, TTL};
+use super::shared::{DdsRequestor, FileAttrBuilder, VirtualDdsConfig, TTL, VIRTUAL_DDS_OPEN_FLAGS};
 use super::types::{Fuse3Error, Fuse3Result, MountHandle};
 use crate::executor::{DdsClient, StorageConcurrencyLimiter};
 use crate::fuse::parse_dds_filename;
@@ -25,10 +25,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::fs;
 use tracing::{debug, trace};
-
-/// `FOPEN_DIRECT_IO` from `linux/fuse.h`: `#define FOPEN_DIRECT_IO (1 << 0)`.
-/// Bypasses the kernel page cache so every `read()` reaches our handler.
-const FOPEN_DIRECT_IO: u32 = 1;
 
 /// Async multi-threaded FUSE filesystem using fuse3.
 ///
@@ -340,10 +336,12 @@ impl Filesystem for Fuse3PassthroughFS {
     /// internally when the server returns `ENOSYS`, but macFUSE does not —
     /// it propagates that `ENOSYS` to the `read()` syscall. So we implement a
     /// trivial stateless `open` (reads key off the inode, not a file handle).
-    /// Virtual DDS files request direct I/O so every read reaches our handler.
+    /// Virtual DDS files report [`VIRTUAL_DDS_OPEN_FLAGS`]: direct I/O on Linux so
+    /// every read reaches our handler, but page cache on macOS — X-Plane mmaps
+    /// textures and macFUSE faults when a `direct_io` file is mapped.
     async fn open(&self, _req: Request, ino: u64, _flags: u32) -> Fuse3InternalResult<ReplyOpen> {
         let flags = if InodeManager::is_virtual_inode(ino) {
-            FOPEN_DIRECT_IO
+            VIRTUAL_DDS_OPEN_FLAGS
         } else {
             0
         };

--- a/xearthlayer/src/fuse/fuse3/filesystem.rs
+++ b/xearthlayer/src/fuse/fuse3/filesystem.rs
@@ -26,6 +26,10 @@ use std::time::Duration;
 use tokio::fs;
 use tracing::{debug, trace};
 
+/// `FOPEN_DIRECT_IO` from `linux/fuse.h`: `#define FOPEN_DIRECT_IO (1 << 0)`.
+/// Bypasses the kernel page cache so every `read()` reaches our handler.
+const FOPEN_DIRECT_IO: u32 = 1;
+
 /// Async multi-threaded FUSE filesystem using fuse3.
 ///
 /// This filesystem overlays an existing scenery pack:
@@ -328,6 +332,35 @@ impl Filesystem for Fuse3PassthroughFS {
 
         let attr = self.metadata_to_attr(ino, &metadata);
         Ok(ReplyAttr { ttl: TTL, attr })
+    }
+
+    /// Open a file.
+    ///
+    /// Linux's kernel honours `FUSE_NO_OPEN_SUPPORT` and handles `open`
+    /// internally when the server returns `ENOSYS`, but macFUSE does not —
+    /// it propagates that `ENOSYS` to the `read()` syscall. So we implement a
+    /// trivial stateless `open` (reads key off the inode, not a file handle).
+    /// Virtual DDS files request direct I/O so every read reaches our handler.
+    async fn open(&self, _req: Request, ino: u64, _flags: u32) -> Fuse3InternalResult<ReplyOpen> {
+        let flags = if InodeManager::is_virtual_inode(ino) {
+            FOPEN_DIRECT_IO
+        } else {
+            0
+        };
+        Ok(ReplyOpen { fh: 0, flags })
+    }
+
+    /// Release an open file. Stateless passthrough holds no per-handle state.
+    async fn release(
+        &self,
+        _req: Request,
+        _ino: u64,
+        _fh: u64,
+        _flags: u32,
+        _lock_owner: u64,
+        _flush: bool,
+    ) -> Fuse3InternalResult<()> {
+        Ok(())
     }
 
     /// Read data from a file.

--- a/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
+++ b/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
@@ -37,7 +37,7 @@
 //! missing textures dynamically using its configured imagery provider.
 
 use super::inode::InodeManager;
-use super::shared::{DdsRequestor, FileAttrBuilder, VirtualDdsConfig, TTL};
+use super::shared::{DdsRequestor, FileAttrBuilder, VirtualDdsConfig, TTL, VIRTUAL_DDS_OPEN_FLAGS};
 use super::types::{Fuse3Error, Fuse3Result};
 use crate::executor::{DdsClient, StorageConcurrencyLimiter};
 use crate::fuse::coalesce::RequestCoalescer;
@@ -63,33 +63,6 @@ use std::time::Duration;
 use tokio::fs;
 use tokio::sync::mpsc;
 use tracing::{debug, trace, Instrument};
-
-/// FUSE open flag: bypass kernel page cache for this file.
-///
-/// From `linux/fuse.h`: `#define FOPEN_DIRECT_IO (1 << 0)`
-///
-/// When set in `ReplyOpen::flags`, the kernel sends every `read()` through
-/// the FUSE handler instead of serving from its page cache. Used for virtual
-/// DDS files so that `FuseLoadMonitor`, `SceneTracker`, and `DdsAccessEvent`
-/// see every X-Plane read.
-///
-/// Only referenced on Linux (macOS serves virtual DDS through the page cache —
-/// see [`VIRTUAL_DDS_OPEN_FLAGS`]), so it is dead code on macOS.
-#[cfg_attr(target_os = "macos", allow(dead_code))]
-const FOPEN_DIRECT_IO: u32 = 1;
-
-/// Open flags reported for virtual DDS files.
-///
-/// On Linux we set [`FOPEN_DIRECT_IO`] so every `read()` reaches our handler
-/// (feeding the load monitor / scene tracker). On **macOS we must not**:
-/// X-Plane memory-maps texture files, and macFUSE faults with `EXC_BAD_ACCESS`
-/// when a `direct_io` file is `mmap`ed — `mmap` needs the page cache that
-/// `direct_io` bypasses. So macOS serves DDS through the page cache (flags 0),
-/// trading per-read tracking for not crashing the sim's texture loader.
-#[cfg(not(target_os = "macos"))]
-const VIRTUAL_DDS_OPEN_FLAGS: u32 = FOPEN_DIRECT_IO;
-#[cfg(target_os = "macos")]
-const VIRTUAL_DDS_OPEN_FLAGS: u32 = 0;
 
 /// Consolidated ortho union FUSE filesystem.
 ///

--- a/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
+++ b/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
@@ -72,7 +72,24 @@ use tracing::{debug, trace, Instrument};
 /// the FUSE handler instead of serving from its page cache. Used for virtual
 /// DDS files so that `FuseLoadMonitor`, `SceneTracker`, and `DdsAccessEvent`
 /// see every X-Plane read.
+///
+/// Only referenced on Linux (macOS serves virtual DDS through the page cache —
+/// see [`VIRTUAL_DDS_OPEN_FLAGS`]), so it is dead code on macOS.
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 const FOPEN_DIRECT_IO: u32 = 1;
+
+/// Open flags reported for virtual DDS files.
+///
+/// On Linux we set [`FOPEN_DIRECT_IO`] so every `read()` reaches our handler
+/// (feeding the load monitor / scene tracker). On **macOS we must not**:
+/// X-Plane memory-maps texture files, and macFUSE faults with `EXC_BAD_ACCESS`
+/// when a `direct_io` file is `mmap`ed — `mmap` needs the page cache that
+/// `direct_io` bypasses. So macOS serves DDS through the page cache (flags 0),
+/// trading per-read tracking for not crashing the sim's texture loader.
+#[cfg(not(target_os = "macos"))]
+const VIRTUAL_DDS_OPEN_FLAGS: u32 = FOPEN_DIRECT_IO;
+#[cfg(target_os = "macos")]
+const VIRTUAL_DDS_OPEN_FLAGS: u32 = 0;
 
 /// Consolidated ortho union FUSE filesystem.
 ///
@@ -973,12 +990,13 @@ impl Filesystem for Fuse3OrthoUnionFS {
 
     async fn open(&self, _req: Request, inode: u64, _flags: u32) -> Fuse3InternalResult<ReplyOpen> {
         if InodeManager::is_virtual_inode(inode) {
-            // Virtual DDS files: bypass kernel page cache so every read()
-            // goes through our FUSE handler. This ensures FuseLoadMonitor,
-            // SceneTracker, and DdsAccessEvent see all X-Plane reads.
+            // Virtual DDS files. On Linux, direct I/O routes every read through
+            // our handler (load monitor / scene tracker). On macOS that breaks
+            // X-Plane's mmap-based texture loader, so we use the page cache
+            // there instead. See VIRTUAL_DDS_OPEN_FLAGS.
             Ok(ReplyOpen {
                 fh: 0,
-                flags: FOPEN_DIRECT_IO,
+                flags: VIRTUAL_DDS_OPEN_FLAGS,
             })
         } else {
             // Real passthrough files: use default kernel caching
@@ -1857,7 +1875,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_open_virtual_dds_returns_direct_io() {
-        use super::FOPEN_DIRECT_IO;
+        use super::VIRTUAL_DDS_OPEN_FLAGS;
         use fuse3::raw::Filesystem;
 
         let temp = TempDir::new().unwrap();
@@ -1887,8 +1905,9 @@ mod tests {
         let reply = result.expect("open on virtual DDS inode should succeed");
         assert_eq!(reply.fh, 0, "file handle should be stateless");
         assert_eq!(
-            reply.flags, FOPEN_DIRECT_IO,
-            "virtual DDS files should have FOPEN_DIRECT_IO flag"
+            reply.flags, VIRTUAL_DDS_OPEN_FLAGS,
+            "virtual DDS files should use the platform's virtual-DDS open flags \
+             (direct I/O on Linux, page cache on macOS for mmap compatibility)"
         );
     }
 

--- a/xearthlayer/src/fuse/fuse3/shared.rs
+++ b/xearthlayer/src/fuse/fuse3/shared.rs
@@ -140,6 +140,12 @@ pub trait FileAttrBuilder {
             gid: metadata.gid(),
             rdev: metadata.rdev() as u32,
             blksize: 4096,
+            // macFUSE's FileAttr carries the macOS-only creation time and
+            // BSD file flags. Mirror ctime for crtime; we expose no flags.
+            #[cfg(target_os = "macos")]
+            crtime: UNIX_EPOCH.into(),
+            #[cfg(target_os = "macos")]
+            flags: 0,
         }
     }
 
@@ -169,6 +175,10 @@ pub trait FileAttrBuilder {
             gid: unsafe { libc::getgid() },
             rdev: 0,
             blksize: config.blksize(),
+            #[cfg(target_os = "macos")]
+            crtime: now,
+            #[cfg(target_os = "macos")]
+            flags: 0,
         }
     }
 
@@ -190,6 +200,10 @@ pub trait FileAttrBuilder {
             gid: unsafe { libc::getgid() },
             rdev: 0,
             blksize: 4096,
+            #[cfg(target_os = "macos")]
+            crtime: now,
+            #[cfg(target_os = "macos")]
+            flags: 0,
         }
     }
 
@@ -215,6 +229,10 @@ pub trait FileAttrBuilder {
             gid: unsafe { libc::getgid() },
             rdev: 0,
             blksize: 4096,
+            #[cfg(target_os = "macos")]
+            crtime: now,
+            #[cfg(target_os = "macos")]
+            flags: 0,
         }
     }
 }

--- a/xearthlayer/src/fuse/fuse3/shared.rs
+++ b/xearthlayer/src/fuse/fuse3/shared.rs
@@ -32,6 +32,37 @@ use crate::fuse::{get_default_placeholder, validate_dds_or_placeholder, DdsFilen
 /// This value is shared across all filesystem implementations.
 pub const TTL: Duration = Duration::from_secs(1);
 
+/// FUSE open flag: bypass kernel page cache for this file.
+///
+/// From `linux/fuse.h`: `#define FOPEN_DIRECT_IO (1 << 0)`
+///
+/// When set in `ReplyOpen::flags`, the kernel sends every `read()` through
+/// the FUSE handler instead of serving from its page cache. Used for virtual
+/// DDS files so that `FuseLoadMonitor`, `SceneTracker`, and `DdsAccessEvent`
+/// see every X-Plane read.
+///
+/// Only referenced on Linux (macOS serves virtual DDS through the page cache —
+/// see [`VIRTUAL_DDS_OPEN_FLAGS`]), so it is dead code on macOS.
+#[cfg_attr(target_os = "macos", allow(dead_code))]
+pub const FOPEN_DIRECT_IO: u32 = 1;
+
+/// Open flags reported for virtual DDS files, shared by every fuse3 filesystem.
+///
+/// On Linux we set [`FOPEN_DIRECT_IO`] so every `read()` reaches our handler
+/// (feeding the load monitor / scene tracker). On **macOS we must not**:
+/// X-Plane memory-maps texture files, and macFUSE faults with `EXC_BAD_ACCESS`
+/// when a `direct_io` file is `mmap`ed — `mmap` needs the page cache that
+/// `direct_io` bypasses. So macOS serves DDS through the page cache (flags 0),
+/// trading per-read tracking for not crashing the sim's texture loader.
+///
+/// This is the single source of truth: both [`Fuse3PassthroughFS`](super::Fuse3PassthroughFS)
+/// and [`Fuse3OrthoUnionFS`](super::Fuse3OrthoUnionFS) report it from `open()`,
+/// so the macOS mmap-safety rule cannot drift between filesystems.
+#[cfg(not(target_os = "macos"))]
+pub const VIRTUAL_DDS_OPEN_FLAGS: u32 = FOPEN_DIRECT_IO;
+#[cfg(target_os = "macos")]
+pub const VIRTUAL_DDS_OPEN_FLAGS: u32 = 0;
+
 // =============================================================================
 // VirtualDdsConfig - Shared DDS file configuration
 // =============================================================================

--- a/xearthlayer/src/fuse/fuse3/types.rs
+++ b/xearthlayer/src/fuse/fuse3/types.rs
@@ -187,29 +187,37 @@ impl SpawnedMountHandle {
         if let Some(task) = self.task.take() {
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
 
+            let mut finished = false;
             while std::time::Instant::now() < deadline {
                 if task.is_finished() {
-                    debug!(mountpoint = %mountpoint_str, "Mount task completed cleanly");
-                    return;
+                    debug!(mountpoint = %mountpoint_str, "Mount task completed");
+                    finished = true;
+                    break;
                 }
                 std::thread::sleep(std::time::Duration::from_millis(50));
             }
 
-            // Task didn't finish in time — abort and fall back to fusermount
-            warn!(
-                mountpoint = %mountpoint_str,
-                "Mount task did not complete within 5s, aborting"
-            );
-            task.abort();
+            if !finished {
+                // Task didn't finish in time — abort and fall back to umount.
+                warn!(
+                    mountpoint = %mountpoint_str,
+                    "Mount task did not complete within 5s, aborting"
+                );
+                task.abort();
+            }
         }
 
-        // Fallback: check if still mounted and use fusermount
+        // Always verify the mount is actually gone. The fuse3 task completing
+        // does NOT prove the kernel released the mount — on macFUSE it routinely
+        // leaves the mount wedged — so we must check and force-unmount rather
+        // than trust task completion. `is_mounted` is platform-correct, so a
+        // false here genuinely means unmounted.
         if !Self::is_mounted(&self.mountpoint) {
-            debug!(mountpoint = %mountpoint_str, "Already unmounted after task abort");
+            debug!(mountpoint = %mountpoint_str, "Unmounted cleanly");
             return;
         }
 
-        debug!(mountpoint = %mountpoint_str, "Still mounted, attempting fusermount");
+        debug!(mountpoint = %mountpoint_str, "Still mounted, forcing unmount");
 
         let graceful_success = Self::try_unmount(&mountpoint_str, false);
 
@@ -255,18 +263,66 @@ impl SpawnedMountHandle {
     }
 
     /// Check if a path is currently mounted.
+    ///
+    /// Platform-specific because the mount table lives in different places:
+    /// Linux exposes it as `/proc/mounts`, while macOS has no such file and
+    /// requires querying the kernel via `mount(8)`. A wrong answer here is not
+    /// cosmetic: `unmount_sync` only escalates to a real `umount` when this
+    /// returns `true`, so a Linux-only implementation silently disabled the
+    /// macOS unmount fallback and left zombie macFUSE mounts behind.
     fn is_mounted(path: &Path) -> bool {
-        // Read /proc/mounts to check if the path is mounted
-        if let Ok(mounts) = std::fs::read_to_string("/proc/mounts") {
-            let path_str = path.to_string_lossy();
-            for line in mounts.lines() {
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() >= 2 && parts[1] == path_str {
-                    return true;
+        let path_str = path.to_string_lossy();
+
+        #[cfg(target_os = "macos")]
+        {
+            // macOS has no /proc/mounts; ask the kernel via mount(8). This also
+            // correctly reports a wedged macFUSE mount (the daemon dead but the
+            // entry still present), which is exactly the zombie we must clear.
+            match std::process::Command::new("/sbin/mount").output() {
+                Ok(output) => {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    Self::mount_output_contains(&stdout, &path_str)
                 }
+                Err(_) => false,
             }
         }
-        false
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            match std::fs::read_to_string("/proc/mounts") {
+                Ok(mounts) => Self::proc_mounts_contains(&mounts, &path_str),
+                Err(_) => false,
+            }
+        }
+    }
+
+    /// Whether `/proc/mounts` content lists `path` as a mountpoint.
+    ///
+    /// Pure function (no I/O) so the parsing is unit-testable. Each line is
+    /// `device mountpoint fstype opts ...`; we match field 2.
+    #[cfg(not(target_os = "macos"))]
+    fn proc_mounts_contains(mounts: &str, path: &str) -> bool {
+        mounts.lines().any(|line| {
+            let mut fields = line.split_whitespace();
+            fields.next(); // device
+            fields.next() == Some(path)
+        })
+    }
+
+    /// Whether BSD `mount(8)` output lists `path` as a mountpoint.
+    ///
+    /// Pure function (no I/O) so the parsing is unit-testable. Lines look like
+    /// `device on /mount/point (fstype, opts...)`; the mountpoint sits between
+    /// " on " and the trailing " (". Mountpoints with spaces (e.g.
+    /// `X-Plane 12`) are handled because we split on the last " (".
+    #[cfg(target_os = "macos")]
+    fn mount_output_contains(output: &str, path: &str) -> bool {
+        output.lines().any(|line| {
+            line.split_once(" on ")
+                .and_then(|(_, rest)| rest.rsplit_once(" (").map(|(mp, _)| mp))
+                .map(|mp| mp == path)
+                .unwrap_or(false)
+        })
     }
 }
 
@@ -407,6 +463,40 @@ mod tests {
         }
         // Prevent Drop from trying unmount_sync
         handle.unmount_tx.take();
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn proc_mounts_contains_detects_mountpoint() {
+        let mounts = "proc /proc proc rw,nosuid 0 0\n\
+                      fuse.xel /mnt/zzXEL_ortho fuse rw 0 0\n\
+                      /dev/sda1 / ext4 rw 0 0\n";
+        assert!(SpawnedMountHandle::proc_mounts_contains(
+            mounts,
+            "/mnt/zzXEL_ortho"
+        ));
+        assert!(SpawnedMountHandle::proc_mounts_contains(mounts, "/"));
+        assert!(!SpawnedMountHandle::proc_mounts_contains(
+            mounts,
+            "/mnt/not_mounted"
+        ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mount_output_contains_detects_macfuse_mountpoint() {
+        // Real macFUSE line shape, including a mountpoint that contains spaces.
+        let output = "/dev/disk1s1 on / (apfs, local, journaled)\n\
+                      xearthlayer@macfuse0 on /Users/me/X-Plane 12/Custom Scenery/zzXEL_ortho (macfuse, nodev, nosuid, synchronous, mounted by me)\n";
+        assert!(SpawnedMountHandle::mount_output_contains(
+            output,
+            "/Users/me/X-Plane 12/Custom Scenery/zzXEL_ortho"
+        ));
+        assert!(SpawnedMountHandle::mount_output_contains(output, "/"));
+        assert!(!SpawnedMountHandle::mount_output_contains(
+            output,
+            "/Users/me/elsewhere"
+        ));
     }
 
     #[tokio::test]

--- a/xearthlayer/src/fuse/fuse3/types.rs
+++ b/xearthlayer/src/fuse/fuse3/types.rs
@@ -5,7 +5,6 @@ use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::process::Command;
 use std::task::{Context, Poll};
 use thiserror::Error;
 use tokio::sync::oneshot;
@@ -239,55 +238,20 @@ impl SpawnedMountHandle {
         }
     }
 
-    /// Attempt to unmount using fusermount3 or fusermount.
+    /// Attempt to unmount the filesystem at `mountpoint`.
+    ///
+    /// Delegates to the platform-abstracted [`unmount_fuse`] helper
+    /// (fusermount on Linux, umount on macOS).
     ///
     /// # Arguments
     /// * `mountpoint` - Path to unmount
-    /// * `lazy` - If true, use lazy unmount (-uz) which detaches immediately
+    /// * `lazy` - If true, escalate to the platform's most aggressive unmount
+    ///   (Linux lazy `-uz`, macOS force `-f`)
     ///
     /// # Returns
     /// `true` if unmount command succeeded, `false` otherwise
     fn try_unmount(mountpoint: &str, lazy: bool) -> bool {
-        let args: &[&str] = if lazy {
-            &["-uz", mountpoint]
-        } else {
-            &["-u", mountpoint]
-        };
-
-        let result = Command::new("fusermount3")
-            .args(args)
-            .output()
-            .or_else(|_| Command::new("fusermount").args(args).output());
-
-        match result {
-            Ok(output) => {
-                if output.status.success() {
-                    true
-                } else {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    // "not found" or "not mounted" means already unmounted - that's success
-                    if stderr.contains("not found") || stderr.contains("not mounted") {
-                        true
-                    } else {
-                        debug!(
-                            mountpoint = %mountpoint,
-                            lazy = lazy,
-                            stderr = %stderr,
-                            "fusermount failed"
-                        );
-                        false
-                    }
-                }
-            }
-            Err(e) => {
-                warn!(
-                    mountpoint = %mountpoint,
-                    error = %e,
-                    "Failed to run fusermount"
-                );
-                false
-            }
-        }
+        crate::system::unmount_fuse(std::path::Path::new(mountpoint), lazy)
     }
 
     /// Check if a path is currently mounted.

--- a/xearthlayer/src/fuse/fuse3/types.rs
+++ b/xearthlayer/src/fuse/fuse3/types.rs
@@ -264,65 +264,12 @@ impl SpawnedMountHandle {
 
     /// Check if a path is currently mounted.
     ///
-    /// Platform-specific because the mount table lives in different places:
-    /// Linux exposes it as `/proc/mounts`, while macOS has no such file and
-    /// requires querying the kernel via `mount(8)`. A wrong answer here is not
+    /// Delegates to the shared, platform-aware [`crate::system::is_path_mounted`]
+    /// so mount detection lives in exactly one place. A wrong answer here is not
     /// cosmetic: `unmount_sync` only escalates to a real `umount` when this
-    /// returns `true`, so a Linux-only implementation silently disabled the
-    /// macOS unmount fallback and left zombie macFUSE mounts behind.
+    /// returns `true`.
     fn is_mounted(path: &Path) -> bool {
-        let path_str = path.to_string_lossy();
-
-        #[cfg(target_os = "macos")]
-        {
-            // macOS has no /proc/mounts; ask the kernel via mount(8). This also
-            // correctly reports a wedged macFUSE mount (the daemon dead but the
-            // entry still present), which is exactly the zombie we must clear.
-            match std::process::Command::new("/sbin/mount").output() {
-                Ok(output) => {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    Self::mount_output_contains(&stdout, &path_str)
-                }
-                Err(_) => false,
-            }
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        {
-            match std::fs::read_to_string("/proc/mounts") {
-                Ok(mounts) => Self::proc_mounts_contains(&mounts, &path_str),
-                Err(_) => false,
-            }
-        }
-    }
-
-    /// Whether `/proc/mounts` content lists `path` as a mountpoint.
-    ///
-    /// Pure function (no I/O) so the parsing is unit-testable. Each line is
-    /// `device mountpoint fstype opts ...`; we match field 2.
-    #[cfg(not(target_os = "macos"))]
-    fn proc_mounts_contains(mounts: &str, path: &str) -> bool {
-        mounts.lines().any(|line| {
-            let mut fields = line.split_whitespace();
-            fields.next(); // device
-            fields.next() == Some(path)
-        })
-    }
-
-    /// Whether BSD `mount(8)` output lists `path` as a mountpoint.
-    ///
-    /// Pure function (no I/O) so the parsing is unit-testable. Lines look like
-    /// `device on /mount/point (fstype, opts...)`; the mountpoint sits between
-    /// " on " and the trailing " (". Mountpoints with spaces (e.g.
-    /// `X-Plane 12`) are handled because we split on the last " (".
-    #[cfg(target_os = "macos")]
-    fn mount_output_contains(output: &str, path: &str) -> bool {
-        output.lines().any(|line| {
-            line.split_once(" on ")
-                .and_then(|(_, rest)| rest.rsplit_once(" (").map(|(mp, _)| mp))
-                .map(|mp| mp == path)
-                .unwrap_or(false)
-        })
+        crate::system::is_path_mounted(path)
     }
 }
 
@@ -463,40 +410,6 @@ mod tests {
         }
         // Prevent Drop from trying unmount_sync
         handle.unmount_tx.take();
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    #[test]
-    fn proc_mounts_contains_detects_mountpoint() {
-        let mounts = "proc /proc proc rw,nosuid 0 0\n\
-                      fuse.xel /mnt/zzXEL_ortho fuse rw 0 0\n\
-                      /dev/sda1 / ext4 rw 0 0\n";
-        assert!(SpawnedMountHandle::proc_mounts_contains(
-            mounts,
-            "/mnt/zzXEL_ortho"
-        ));
-        assert!(SpawnedMountHandle::proc_mounts_contains(mounts, "/"));
-        assert!(!SpawnedMountHandle::proc_mounts_contains(
-            mounts,
-            "/mnt/not_mounted"
-        ));
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn mount_output_contains_detects_macfuse_mountpoint() {
-        // Real macFUSE line shape, including a mountpoint that contains spaces.
-        let output = "/dev/disk1s1 on / (apfs, local, journaled)\n\
-                      xearthlayer@macfuse0 on /Users/me/X-Plane 12/Custom Scenery/zzXEL_ortho (macfuse, nodev, nosuid, synchronous, mounted by me)\n";
-        assert!(SpawnedMountHandle::mount_output_contains(
-            output,
-            "/Users/me/X-Plane 12/Custom Scenery/zzXEL_ortho"
-        ));
-        assert!(SpawnedMountHandle::mount_output_contains(output, "/"));
-        assert!(!SpawnedMountHandle::mount_output_contains(
-            output,
-            "/Users/me/elsewhere"
-        ));
     }
 
     #[tokio::test]

--- a/xearthlayer/src/logging.rs
+++ b/xearthlayer/src/logging.rs
@@ -127,17 +127,20 @@ pub fn init_logging_full(
     // Flags are combinable: --debug + --profile enables both debug logs and profiling spans.
     //
     // When debug_mode is enabled, we only enable DEBUG for xearthlayer crate.
-    // Third-party crates (especially fuse3) produce extremely verbose DEBUG output
-    // that can flood the log and cause performance issues.
+    // fuse3 is pinned to WARN in every arm: it instruments every FUSE handler with
+    // an INFO span, so at the default `info` level it emits a log line per syscall.
+    // On macOS this is catastrophic — Finder/Spotlight/save-panel constantly stat the
+    // mount, and combined with the debug build's FmtSpan::CLOSE + pretty() format it
+    // floods the log at ~10 MB/s. WARN keeps fuse3 quiet while preserving our logs.
     //
     // When profile_mode is enabled, we enable DEBUG for the "profiling" target —
     // our spans use `target: "profiling"` to isolate them from ambient events.
     let env_filter = match (profile_mode, debug_mode) {
         (true, true) => EnvFilter::new("info,fuse3=warn,profiling=debug,xearthlayer=debug"),
         (true, false) => EnvFilter::new("info,fuse3=warn,profiling=debug"),
-        (false, true) => EnvFilter::new("info,xearthlayer=debug"),
+        (false, true) => EnvFilter::new("info,fuse3=warn,xearthlayer=debug"),
         (false, false) => {
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,fuse3=warn"))
         }
     };
 

--- a/xearthlayer/src/manager/local.rs
+++ b/xearthlayer/src/manager/local.rs
@@ -256,34 +256,18 @@ fn calculate_dir_size(path: &Path) -> std::io::Result<u64> {
 /// Only ortho packages can be mounted (via FUSE). Overlay packages
 /// return `Unknown` since they don't use FUSE mounts.
 fn check_mount_status(path: &Path, package_type: PackageType) -> MountStatus {
-    // Only ortho packages can be mounted
+    // Only ortho packages can be mounted (via FUSE).
     if package_type != PackageType::Ortho {
         return MountStatus::Unknown;
     }
 
-    // On Linux, check /proc/mounts for the path
-    #[cfg(target_os = "linux")]
-    {
-        if let Ok(mounts) = fs::read_to_string("/proc/mounts") {
-            let path_str = path.to_string_lossy();
-            for line in mounts.lines() {
-                // /proc/mounts format: device mountpoint type options dump pass
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() >= 2 && parts[1] == path_str {
-                    return MountStatus::Mounted;
-                }
-            }
-            return MountStatus::NotMounted;
-        }
+    // Share the platform-aware mount-table query with the unmount path so macOS
+    // (which has no /proc/mounts) reports real status instead of Unknown.
+    if crate::system::is_path_mounted(path) {
+        MountStatus::Mounted
+    } else {
+        MountStatus::NotMounted
     }
-
-    // On other platforms, return Unknown
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = path; // Suppress unused warning
-    }
-
-    MountStatus::Unknown
 }
 
 #[cfg(test)]

--- a/xearthlayer/src/manager/mounts.rs
+++ b/xearthlayer/src/manager/mounts.rs
@@ -408,6 +408,13 @@ impl MountManager {
             "Built consolidated ortho union index"
         );
 
+        // A previous run that died hard (crash, SIGKILL, system sleep) can
+        // leave a stale FUSE mount on the mountpoint; mounting over it fails
+        // (macFUSE: ENXIO "Device not configured"). A stale mount also makes
+        // exists() report false, so recovery must happen before the directory
+        // check below.
+        crate::system::recover_stale_fuse_mount(&mountpoint);
+
         // Create mountpoint directory
         if !mountpoint.exists() {
             if let Err(e) = std::fs::create_dir_all(&mountpoint) {

--- a/xearthlayer/src/panic.rs
+++ b/xearthlayer/src/panic.rs
@@ -12,7 +12,6 @@
 use std::io::Write;
 use std::panic::{self, PanicHookInfo};
 use std::path::PathBuf;
-use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
 use crate::metrics::TelemetrySnapshot;
@@ -187,48 +186,15 @@ fn handle_panic(info: &PanicHookInfo<'_>) {
                 for mount_point in &guard.mount_points {
                     let _ = write!(stderr, "  Unmounting {}... ", mount_point.display());
 
-                    // Try fusermount -u first (graceful unmount)
-                    let result = Command::new("fusermount")
-                        .arg("-u")
-                        .arg(mount_point)
-                        .output();
-
-                    match result {
-                        Ok(output) if output.status.success() => {
-                            let _ = writeln!(stderr, "OK");
-                        }
-                        Ok(_) => {
-                            // Try fusermount3 -u as fallback
-                            let result3 = Command::new("fusermount3")
-                                .arg("-u")
-                                .arg(mount_point)
-                                .output();
-
-                            match result3 {
-                                Ok(output) if output.status.success() => {
-                                    let _ = writeln!(stderr, "OK (fusermount3)");
-                                }
-                                _ => {
-                                    // Last resort: lazy unmount
-                                    let lazy_result = Command::new("fusermount")
-                                        .arg("-uz")
-                                        .arg(mount_point)
-                                        .output();
-
-                                    match lazy_result {
-                                        Ok(output) if output.status.success() => {
-                                            let _ = writeln!(stderr, "OK (lazy)");
-                                        }
-                                        _ => {
-                                            let _ = writeln!(stderr, "FAILED");
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            let _ = writeln!(stderr, "ERROR: {}", e);
-                        }
+                    // Graceful first, then escalate to the platform's forced
+                    // unmount if the mount is still busy. unmount_fuse picks
+                    // fusermount (Linux) or umount (macOS).
+                    if crate::system::unmount_fuse(mount_point, false) {
+                        let _ = writeln!(stderr, "OK");
+                    } else if crate::system::unmount_fuse(mount_point, true) {
+                        let _ = writeln!(stderr, "OK (forced)");
+                    } else {
+                        let _ = writeln!(stderr, "FAILED");
                     }
                 }
             }

--- a/xearthlayer/src/prefetch/adaptive/transition_throttle.rs
+++ b/xearthlayer/src/prefetch/adaptive/transition_throttle.rs
@@ -26,6 +26,19 @@ const DEFAULT_RAMP_DURATION: Duration = Duration::from_secs(30);
 /// Default ramp start fraction.
 const DEFAULT_RAMP_START_FRACTION: f64 = 0.25;
 
+/// Computes the ramp fraction for a given elapsed time.
+///
+/// Returns `None` once the ramp has completed, signalling the caller to fall
+/// back to full throughput. Kept free of `Instant` so the interpolation can be
+/// tested deterministically without wall-clock sleeps.
+fn ramp_fraction(elapsed: Duration, ramp_duration: Duration, start_fraction: f64) -> Option<f64> {
+    if elapsed >= ramp_duration {
+        return None;
+    }
+    let t = elapsed.as_secs_f64() / ramp_duration.as_secs_f64();
+    Some(start_fraction + t * (1.0 - start_fraction))
+}
+
 /// Internal state of the transition throttle.
 #[derive(Debug, Clone)]
 enum ThrottleState {
@@ -123,14 +136,17 @@ impl TransitionThrottle {
             ThrottleState::Idle => 1.0,
             ThrottleState::Held => 0.0,
             ThrottleState::Ramping { started_at } => {
-                let elapsed = started_at.elapsed();
-                if elapsed >= self.ramp_duration {
-                    tracing::debug!("TransitionThrottle: ramp complete");
-                    self.state = ThrottleState::Idle;
-                    1.0
-                } else {
-                    let t = elapsed.as_secs_f64() / self.ramp_duration.as_secs_f64();
-                    self.ramp_start_fraction + t * (1.0 - self.ramp_start_fraction)
+                match ramp_fraction(
+                    started_at.elapsed(),
+                    self.ramp_duration,
+                    self.ramp_start_fraction,
+                ) {
+                    Some(fraction) => fraction,
+                    None => {
+                        tracing::debug!("TransitionThrottle: ramp complete");
+                        self.state = ThrottleState::Idle;
+                        1.0
+                    }
                 }
             }
         }
@@ -209,14 +225,15 @@ mod tests {
 
     #[test]
     fn test_ramp_resets_on_re_transition() {
-        let mut throttle = TransitionThrottle::with_config(Duration::from_millis(100), 0.25);
+        // Long ramp so no plausible scheduling delay advances it meaningfully;
+        // this test covers the state machine, not the interpolation.
+        let mut throttle = TransitionThrottle::with_config(Duration::from_secs(60), 0.25);
 
         // First cycle: Transition → Cruise (start ramp)
         throttle.on_phase_change(FlightPhase::Ground, FlightPhase::Transition);
         throttle.on_phase_change(FlightPhase::Transition, FlightPhase::Cruise);
-        std::thread::sleep(Duration::from_millis(50));
-        let mid_ramp = throttle.fraction();
-        assert!(mid_ramp > 0.25 && mid_ramp < 1.0);
+        let started = throttle.fraction();
+        assert!(started >= 0.25 && started < 0.35);
 
         // Touch-and-go: Cruise → Ground → Transition → Cruise
         throttle.on_phase_change(FlightPhase::Cruise, FlightPhase::Ground);
@@ -234,19 +251,28 @@ mod tests {
     }
 
     #[test]
-    fn test_ramp_linear_at_midpoint() {
-        let mut throttle = TransitionThrottle::with_config(Duration::from_millis(100), 0.25);
-        throttle.on_phase_change(FlightPhase::Ground, FlightPhase::Transition);
-        throttle.on_phase_change(FlightPhase::Transition, FlightPhase::Cruise);
+    fn test_ramp_fraction_is_linear_between_start_and_full() {
+        let ramp = Duration::from_millis(100);
 
-        std::thread::sleep(Duration::from_millis(50));
-        let frac = throttle.fraction();
+        // At t=0: the configured start fraction.
+        assert_eq!(ramp_fraction(Duration::ZERO, ramp, 0.25), Some(0.25));
+
         // At t=0.5: 0.25 + 0.5 * (1.0 - 0.25) = 0.625
-        let expected = 0.625;
-        assert!(
-            (frac - expected).abs() < 0.1,
-            "Expected ~{expected} at midpoint, got {frac}"
-        );
+        let mid = ramp_fraction(Duration::from_millis(50), ramp, 0.25).unwrap();
+        assert!((mid - 0.625).abs() < 1e-9, "expected 0.625, got {mid}");
+
+        // At t=0.75: 0.25 + 0.75 * 0.75 = 0.8125
+        let late = ramp_fraction(Duration::from_millis(75), ramp, 0.25).unwrap();
+        assert!((late - 0.8125).abs() < 1e-9, "expected 0.8125, got {late}");
+    }
+
+    #[test]
+    fn test_ramp_fraction_completes_at_and_beyond_duration() {
+        let ramp = Duration::from_millis(100);
+        assert_eq!(ramp_fraction(ramp, ramp, 0.25), None);
+        assert_eq!(ramp_fraction(Duration::from_millis(101), ramp, 0.25), None);
+        // A zero-length ramp completes immediately rather than dividing by zero.
+        assert_eq!(ramp_fraction(Duration::ZERO, Duration::ZERO, 0.25), None);
     }
 
     #[test]

--- a/xearthlayer/src/publisher/archive.rs
+++ b/xearthlayer/src/publisher/archive.rs
@@ -3,7 +3,8 @@
 //! Creates tar.gz archives from package directories and splits them
 //! into manageable parts for distribution.
 //!
-//! Uses external tools (`tar`, `split`) which are standard on Linux.
+//! Uses external tools (`tar`, `split`) which are standard on Linux and
+//! macOS. Only flags shared by the GNU and BSD variants are used.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -50,7 +51,9 @@ pub struct ArchivePart {
 /// Check if required external tools are available.
 pub fn check_required_tools() -> PublishResult<()> {
     check_tool_available("tar", &["--version"])?;
-    check_tool_available("split", &["--version"])?;
+    // BSD split (macOS) has no --version flag; splitting /dev/null is a
+    // portable no-op probe (empty input produces no output files).
+    check_tool_available("split", &["-b", "1", "/dev/null"])?;
     Ok(())
 }
 
@@ -225,11 +228,7 @@ fn split_archive(archive_path: &Path, part_size: u64) -> PublishResult<Vec<Archi
 
     let output = Command::new("split")
         .current_dir(archive_dir)
-        .args([
-            &format!("--bytes={}", part_size),
-            archive_name,
-            &split_prefix,
-        ])
+        .args(["-b", &part_size.to_string(), archive_name, &split_prefix])
         .output()
         .map_err(|e| PublishError::ArchiveFailed(format!("failed to run split: {}", e)))?;
 

--- a/xearthlayer/src/system/filesystem.rs
+++ b/xearthlayer/src/system/filesystem.rs
@@ -50,8 +50,15 @@ pub fn fs_info(path: &Path) -> io::Result<FilesystemInfo> {
     // f_bsize for almost all filesystems, but the standard says capacity
     // calculations should use f_frsize.
     let frsize = stat.fragment_size();
-    let total_bytes = stat.blocks().saturating_mul(frsize);
-    let available_bytes = stat.blocks_available().saturating_mul(frsize);
+    // Block counts are `fsblkcnt_t`, which is 32-bit on macOS and 64-bit on
+    // Linux. Normalize to u64 so the capacity math is identical on both; the
+    // macOS branch widens, the Linux branch is already u64.
+    #[cfg(target_os = "macos")]
+    let (blocks, blocks_available) = (u64::from(stat.blocks()), u64::from(stat.blocks_available()));
+    #[cfg(not(target_os = "macos"))]
+    let (blocks, blocks_available) = (stat.blocks(), stat.blocks_available());
+    let total_bytes = blocks.saturating_mul(frsize);
+    let available_bytes = blocks_available.saturating_mul(frsize);
     Ok(FilesystemInfo {
         total_bytes,
         available_bytes,

--- a/xearthlayer/src/system/hardware.rs
+++ b/xearthlayer/src/system/hardware.rs
@@ -59,7 +59,11 @@ pub struct SystemInfo {
     pub cpu_cores: usize,
     /// Total system memory in bytes
     pub total_memory: usize,
-    /// Detected storage type for the cache path
+    /// Whether `total_memory` was actually detected. False means the
+    /// 8 GB fallback is in use and displays should say so.
+    pub memory_detected: bool,
+    /// Detected storage type for the cache path. `Unknown` when detection
+    /// failed and the SSD profile is a fallback guess.
     pub storage_type: StorageType,
     /// The underlying DiskIoProfile for configuration
     pub disk_io_profile: DiskIoProfile,
@@ -87,14 +91,23 @@ impl SystemInfo {
     /// ```
     pub fn detect(cache_path: &Path) -> Self {
         let cpu_cores = detect_cpu_cores();
-        let total_memory = detect_total_memory();
-        let disk_io_profile = DiskIoProfile::Auto.resolve_for_path(cache_path);
-        let storage_type = StorageType::from_disk_io_profile(disk_io_profile);
+        let (total_memory, memory_detected) = match try_detect_total_memory() {
+            Some(mem) => (mem, true),
+            None => (fallback_memory(), false),
+        };
+        // Distinguish a detected profile from the SSD fallback so displays
+        // can flag the guess instead of presenting it as a detection.
+        let (disk_io_profile, storage_type) =
+            match DiskIoProfile::Auto.try_resolve_for_path(cache_path) {
+                Some(profile) => (profile, StorageType::from_disk_io_profile(profile)),
+                None => (DiskIoProfile::Ssd, StorageType::Unknown),
+            };
         let cache_path_available_bytes = available_bytes_for(cache_path);
 
         Self {
             cpu_cores,
             total_memory,
+            memory_detected,
             storage_type,
             disk_io_profile,
             cache_path_available_bytes,
@@ -125,6 +138,7 @@ impl SystemInfo {
         Self {
             cpu_cores,
             total_memory,
+            memory_detected: true,
             storage_type,
             disk_io_profile,
             cache_path_available_bytes,
@@ -164,8 +178,18 @@ impl SystemInfo {
     // =========================================================================
 
     /// Get formatted memory string (e.g., "32 GB").
+    ///
+    /// When detection failed, the fallback value is flagged as a guess
+    /// (e.g., "8 GB (assumed, detection failed)") so the user can verify.
     pub fn memory_display(&self) -> String {
-        format_size(self.total_memory)
+        if self.memory_detected {
+            format_size(self.total_memory)
+        } else {
+            format!(
+                "{} (assumed, detection failed)",
+                format_size(self.total_memory)
+            )
+        }
     }
 
     /// Get formatted recommended memory cache size (e.g., "8 GB").
@@ -212,39 +236,47 @@ pub fn detect_cpu_cores() -> usize {
 
 /// Detect total system memory in bytes.
 ///
+/// Falls back to 8GB if detection fails. Use [`try_detect_total_memory`]
+/// when the caller needs to distinguish a detected value from the fallback.
+///
 /// # Platform Support
 ///
 /// - **Linux**: Parses `/proc/meminfo`
 /// - **macOS**: Reads `hw.memsize` via `sysctl(8)`
 /// - **Other platforms**: Returns fallback of 8GB
-#[cfg(target_os = "linux")]
 pub fn detect_total_memory() -> usize {
+    try_detect_total_memory().unwrap_or_else(fallback_memory)
+}
+
+/// Detect total system memory in bytes, surfacing failure.
+///
+/// Returns `None` when detection fails so callers (e.g. the setup wizard)
+/// can flag the fallback instead of presenting it as a detection.
+#[cfg(target_os = "linux")]
+pub fn try_detect_total_memory() -> Option<usize> {
     use std::fs;
 
     // Parse /proc/meminfo
-    if let Ok(content) = fs::read_to_string("/proc/meminfo") {
-        for line in content.lines() {
-            if line.starts_with("MemTotal:") {
-                // Format: "MemTotal:       16384000 kB"
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() >= 2 {
-                    if let Ok(kb) = parts[1].parse::<usize>() {
-                        return kb * 1024; // Convert to bytes
-                    }
+    let content = fs::read_to_string("/proc/meminfo").ok()?;
+    for line in content.lines() {
+        if line.starts_with("MemTotal:") {
+            // Format: "MemTotal:       16384000 kB"
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 2 {
+                if let Ok(kb) = parts[1].parse::<usize>() {
+                    return Some(kb * 1024); // Convert to bytes
                 }
             }
         }
     }
-
-    // Fallback: 8GB
-    fallback_memory()
+    None
 }
 
 /// macOS has no `/proc/meminfo`; `hw.memsize` reports total physical RAM in
 /// bytes. Without this, the setup wizard silently sized the cache from the 8GB
 /// fallback (RAM/12 → ~682MB) on every Mac regardless of actual memory.
 #[cfg(target_os = "macos")]
-pub fn detect_total_memory() -> usize {
+pub fn try_detect_total_memory() -> Option<usize> {
     use std::process::Command;
 
     Command::new("sysctl")
@@ -253,7 +285,6 @@ pub fn detect_total_memory() -> usize {
         .ok()
         .filter(|out| out.status.success())
         .and_then(|out| parse_sysctl_memsize(&String::from_utf8_lossy(&out.stdout)))
-        .unwrap_or_else(fallback_memory)
 }
 
 /// Parse the byte count printed by `sysctl -n hw.memsize`.
@@ -271,9 +302,9 @@ fn parse_sysctl_memsize(output: &str) -> Option<usize> {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-pub fn detect_total_memory() -> usize {
-    // Fallback for unsupported platforms: 8GB
-    fallback_memory()
+pub fn try_detect_total_memory() -> Option<usize> {
+    // No detection on unsupported platforms; callers fall back to 8GB.
+    None
 }
 
 /// Fallback memory value when detection fails.
@@ -355,6 +386,26 @@ mod tests {
         // 16GB / 12 = 1.333... GB → format_size renders as "1.3 GB"
         assert_eq!(info.recommended_memory_cache_display(), "1.3 GB");
         assert_eq!(info.storage_display(), "SATA SSD");
+    }
+
+    #[test]
+    fn memory_display_flags_fallback_when_detection_failed() {
+        let mut info = SystemInfo::new(8, fallback_memory(), StorageType::Ssd);
+        info.memory_detected = false;
+        assert_eq!(info.memory_display(), "8 GB (assumed, detection failed)");
+
+        info.memory_detected = true;
+        assert_eq!(info.memory_display(), "8 GB");
+    }
+
+    #[test]
+    fn detect_flags_memory_as_detected_on_supported_platforms() {
+        // Linux (/proc/meminfo) and macOS (sysctl) both detect reliably;
+        // the flag must be true so no caveat is shown for real values.
+        // Storage is not asserted: /tmp may be tmpfs where detection
+        // legitimately fails (and Unknown is then the correct answer).
+        let info = SystemInfo::detect(Path::new("/tmp"));
+        assert!(info.memory_detected);
     }
 
     #[test]

--- a/xearthlayer/src/system/hardware.rs
+++ b/xearthlayer/src/system/hardware.rs
@@ -342,14 +342,12 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn detect_total_memory_reads_real_ram_on_macos() {
-        // Exercises the sysctl call end to end. Any real Mac has at least the
-        // 8GB fallback worth of RAM, so this both confirms it doesn't panic and
-        // that we get a plausible value rather than a parse failure.
-        let mem = detect_total_memory();
-        assert!(
-            mem >= fallback_memory(),
-            "should detect at least the fallback worth of RAM, got {mem}"
-        );
+        // Exercise the sysctl path via the failure-surfacing variant: a sysctl
+        // failure is None here, not the 8GB fallback, so this test cannot pass
+        // by failing. The floor is 2GB rather than the fallback because CI
+        // runners are macOS hosts with less than 8GB (macos-15 has 7GB).
+        let mem = try_detect_total_memory().expect("sysctl hw.memsize should succeed on macOS");
+        assert!(mem >= 2 * GB, "detected RAM implausibly low: {mem}");
     }
 
     #[test]

--- a/xearthlayer/src/system/hardware.rs
+++ b/xearthlayer/src/system/hardware.rs
@@ -215,6 +215,7 @@ pub fn detect_cpu_cores() -> usize {
 /// # Platform Support
 ///
 /// - **Linux**: Parses `/proc/meminfo`
+/// - **macOS**: Reads `hw.memsize` via `sysctl(8)`
 /// - **Other platforms**: Returns fallback of 8GB
 #[cfg(target_os = "linux")]
 pub fn detect_total_memory() -> usize {
@@ -239,9 +240,39 @@ pub fn detect_total_memory() -> usize {
     fallback_memory()
 }
 
-#[cfg(not(target_os = "linux"))]
+/// macOS has no `/proc/meminfo`; `hw.memsize` reports total physical RAM in
+/// bytes. Without this, the setup wizard silently sized the cache from the 8GB
+/// fallback (RAM/12 → ~682MB) on every Mac regardless of actual memory.
+#[cfg(target_os = "macos")]
 pub fn detect_total_memory() -> usize {
-    // Fallback for non-Linux: 8GB
+    use std::process::Command;
+
+    Command::new("sysctl")
+        .args(["-n", "hw.memsize"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| parse_sysctl_memsize(&String::from_utf8_lossy(&out.stdout)))
+        .unwrap_or_else(fallback_memory)
+}
+
+/// Parse the byte count printed by `sysctl -n hw.memsize`.
+///
+/// Pure function (no I/O) so the parsing is unit-testable. The output is a
+/// single decimal byte count, e.g. `137438953472\n`. Returns `None` for empty,
+/// non-numeric, or zero values so the caller can fall back.
+#[cfg(target_os = "macos")]
+fn parse_sysctl_memsize(output: &str) -> Option<usize> {
+    output
+        .trim()
+        .parse::<usize>()
+        .ok()
+        .filter(|&bytes| bytes > 0)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn detect_total_memory() -> usize {
+    // Fallback for unsupported platforms: 8GB
     fallback_memory()
 }
 
@@ -265,6 +296,29 @@ mod tests {
     fn test_detect_total_memory_returns_positive() {
         let memory = detect_total_memory();
         assert!(memory > 0, "Should detect some memory");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn parse_sysctl_memsize_parses_bytes_and_rejects_garbage() {
+        assert_eq!(parse_sysctl_memsize("137438953472\n"), Some(137438953472));
+        assert_eq!(parse_sysctl_memsize("  68719476736  "), Some(68719476736));
+        assert_eq!(parse_sysctl_memsize(""), None);
+        assert_eq!(parse_sysctl_memsize("not-a-number"), None);
+        assert_eq!(parse_sysctl_memsize("0"), None, "zero is not a valid total");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn detect_total_memory_reads_real_ram_on_macos() {
+        // Exercises the sysctl call end to end. Any real Mac has at least the
+        // 8GB fallback worth of RAM, so this both confirms it doesn't panic and
+        // that we get a plausible value rather than a parse failure.
+        let mem = detect_total_memory();
+        assert!(
+            mem >= fallback_memory(),
+            "should detect at least the fallback worth of RAM, got {mem}"
+        );
     }
 
     #[test]

--- a/xearthlayer/src/system/mod.rs
+++ b/xearthlayer/src/system/mod.rs
@@ -42,4 +42,4 @@ pub use recommendations::{
     recommended_disk_cache, recommended_disk_io_profile, recommended_memory_cache,
     RecommendedSettings, MIN_DISK_CACHE_BYTES, MIN_MEMORY_CACHE_BYTES,
 };
-pub use unmount::unmount_fuse;
+pub use unmount::{is_stale_fuse_mount, recover_stale_fuse_mount, unmount_fuse};

--- a/xearthlayer/src/system/mod.rs
+++ b/xearthlayer/src/system/mod.rs
@@ -30,6 +30,7 @@ pub mod filesystem;
 pub mod gpu;
 mod hardware;
 mod recommendations;
+pub mod unmount;
 
 pub use filesystem::{fs_info, is_immutable_os, FilesystemInfo};
 pub use gpu::{
@@ -41,3 +42,4 @@ pub use recommendations::{
     recommended_disk_cache, recommended_disk_io_profile, recommended_memory_cache,
     RecommendedSettings, MIN_DISK_CACHE_BYTES, MIN_MEMORY_CACHE_BYTES,
 };
+pub use unmount::unmount_fuse;

--- a/xearthlayer/src/system/mod.rs
+++ b/xearthlayer/src/system/mod.rs
@@ -42,4 +42,4 @@ pub use recommendations::{
     recommended_disk_cache, recommended_disk_io_profile, recommended_memory_cache,
     RecommendedSettings, MIN_DISK_CACHE_BYTES, MIN_MEMORY_CACHE_BYTES,
 };
-pub use unmount::{is_stale_fuse_mount, recover_stale_fuse_mount, unmount_fuse};
+pub use unmount::{is_path_mounted, is_stale_fuse_mount, recover_stale_fuse_mount, unmount_fuse};

--- a/xearthlayer/src/system/unmount.rs
+++ b/xearthlayer/src/system/unmount.rs
@@ -1,8 +1,11 @@
-//! Platform-abstracted FUSE unmounting.
+//! Platform-abstracted FUSE mount-table operations.
 //!
-//! Linux unmounts FUSE filesystems with `fusermount3`/`fusermount`, while
-//! macOS (macFUSE) uses the BSD `umount(8)`. Both the panic handler and the
-//! spawned-mount Drop fallback need the same logic, so it lives here once.
+//! Linux unmounts FUSE filesystems with `fusermount3`/`fusermount` and exposes
+//! the mount table as `/proc/mounts`, while macOS (macFUSE) uses the BSD
+//! `umount(8)` and `mount(8)`. Everything that needs to unmount a mount or ask
+//! "is this path mounted?" shares the same platform logic, so it lives here
+//! once: the panic handler, the spawned-mount Drop fallback, and the package
+//! manager's status display.
 
 use std::path::Path;
 use std::process::Command;
@@ -44,6 +47,70 @@ pub fn unmount_fuse(mountpoint: &Path, force: bool) -> bool {
         fallback.arg(flag).arg(mountpoint);
         run_unmount(&mut fallback, mountpoint)
     }
+}
+
+/// Whether `path` is currently a mountpoint, per the OS mount table.
+///
+/// Platform-specific because the mount table lives in different places: Linux
+/// exposes it as `/proc/mounts`; macOS has no such file and must be queried via
+/// `mount(8)`. A wrong answer here is not cosmetic — callers gate real `umount`
+/// escalation (`SpawnedMountHandle`) and the user-facing package mount status on
+/// it, so a Linux-only implementation silently mis-reports every macOS mount.
+///
+/// This answers "is the kernel mount-table entry present", which is also `true`
+/// for a wedged macFUSE mount (daemon dead, entry lingering) — exactly the
+/// zombie the unmount fallback must still act on. Use [`is_stale_fuse_mount`] to
+/// distinguish a healthy mount from a wedged one.
+pub fn is_path_mounted(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+
+    #[cfg(target_os = "macos")]
+    {
+        match Command::new("/sbin/mount").output() {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                mount_output_contains(&stdout, &path_str)
+            }
+            Err(_) => false,
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        match std::fs::read_to_string("/proc/mounts") {
+            Ok(mounts) => proc_mounts_contains(&mounts, &path_str),
+            Err(_) => false,
+        }
+    }
+}
+
+/// Whether `/proc/mounts` content lists `path` as a mountpoint.
+///
+/// Pure function (no I/O) so the parsing is unit-testable. Each line is
+/// `device mountpoint fstype opts ...`; we match field 2.
+#[cfg(not(target_os = "macos"))]
+fn proc_mounts_contains(mounts: &str, path: &str) -> bool {
+    mounts.lines().any(|line| {
+        let mut fields = line.split_whitespace();
+        fields.next(); // device
+        fields.next() == Some(path)
+    })
+}
+
+/// Whether BSD `mount(8)` output lists `path` as a mountpoint.
+///
+/// Pure function (no I/O) so the parsing is unit-testable. Lines look like
+/// `device on /mount/point (fstype, opts...)`; the mountpoint sits between
+/// " on " and the trailing " (". Splitting on the last " (" keeps mountpoints
+/// that contain spaces (e.g. `X-Plane 12`) intact.
+#[cfg(target_os = "macos")]
+fn mount_output_contains(output: &str, path: &str) -> bool {
+    output.lines().any(|line| {
+        line.split_once(" on ")
+            .and_then(|(_, rest)| rest.rsplit_once(" (").map(|(mp, _)| mp))
+            .map(|mp| mp == path)
+            .unwrap_or(false)
+    })
 }
 
 /// Detect a stale FUSE mount at `mountpoint`.
@@ -189,5 +256,38 @@ mod tests {
     fn recover_on_healthy_mountpoint_is_noop() {
         let dir = tempfile::tempdir().expect("tempdir");
         assert!(!recover_stale_fuse_mount(dir.path()));
+    }
+
+    /// A freshly created directory is not a mountpoint. Exercises the real
+    /// platform mount-table query end to end without needing a live mount.
+    #[test]
+    fn ordinary_directory_is_not_mounted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(!is_path_mounted(dir.path()));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn proc_mounts_contains_detects_mountpoint() {
+        let mounts = "proc /proc proc rw,nosuid 0 0\n\
+                      fuse.xel /mnt/zzXEL_ortho fuse rw 0 0\n\
+                      /dev/sda1 / ext4 rw 0 0\n";
+        assert!(proc_mounts_contains(mounts, "/mnt/zzXEL_ortho"));
+        assert!(proc_mounts_contains(mounts, "/"));
+        assert!(!proc_mounts_contains(mounts, "/mnt/not_mounted"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mount_output_contains_detects_macfuse_mountpoint() {
+        // Real macFUSE line shape, including a mountpoint that contains spaces.
+        let output = "/dev/disk1s1 on / (apfs, local, journaled)\n\
+                      xearthlayer@macfuse0 on /Users/me/X-Plane 12/Custom Scenery/zzXEL_ortho (macfuse, nodev, nosuid, synchronous, mounted by me)\n";
+        assert!(mount_output_contains(
+            output,
+            "/Users/me/X-Plane 12/Custom Scenery/zzXEL_ortho"
+        ));
+        assert!(mount_output_contains(output, "/"));
+        assert!(!mount_output_contains(output, "/Users/me/elsewhere"));
     }
 }

--- a/xearthlayer/src/system/unmount.rs
+++ b/xearthlayer/src/system/unmount.rs
@@ -46,6 +46,62 @@ pub fn unmount_fuse(mountpoint: &Path, force: bool) -> bool {
     }
 }
 
+/// Detect a stale FUSE mount at `mountpoint`.
+///
+/// A FUSE mount whose daemon died without unmounting (crash, SIGKILL,
+/// system sleep) stays in the kernel mount table, but every operation on
+/// it fails — on macOS/macFUSE with `ENXIO` ("Device not configured"),
+/// on Linux with `ENOTCONN` ("Transport endpoint is not connected").
+/// Mounting over such a corpse fails, so it must be cleared first.
+///
+/// A healthy mount, an ordinary directory, or a missing path are all
+/// reported as not stale.
+///
+/// Detection uses `opendir(2)` (via `read_dir`), not `stat(2)`: on macOS
+/// the kernel serves cached attributes for a dead macFUSE mountpoint, so
+/// `stat` succeeds while any real operation — including reading the
+/// directory — fails with `ENXIO` (verified empirically against a killed
+/// mount).
+pub fn is_stale_fuse_mount(mountpoint: &Path) -> bool {
+    match std::fs::read_dir(mountpoint) {
+        Ok(_) => false,
+        Err(e) => is_stale_mount_error(&e),
+    }
+}
+
+/// Classify an I/O error from `stat(2)` on a mountpoint as "stale FUSE
+/// mount" or not. Extracted as a pure function for testability.
+fn is_stale_mount_error(error: &std::io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(libc::ENXIO) | Some(libc::ENOTCONN)
+    )
+}
+
+/// Detect and clear a stale FUSE mount at `mountpoint`.
+///
+/// Returns `true` if a stale mount was found and successfully unmounted,
+/// `false` if the mountpoint was healthy (nothing to do). Logs a warning
+/// if a stale mount is found but cannot be cleared.
+pub fn recover_stale_fuse_mount(mountpoint: &Path) -> bool {
+    if !is_stale_fuse_mount(mountpoint) {
+        return false;
+    }
+    warn!(
+        mountpoint = %mountpoint.display(),
+        "Stale FUSE mount detected from a previous run; force-unmounting"
+    );
+    let cleared = unmount_fuse(mountpoint, true);
+    if !cleared {
+        warn!(
+            mountpoint = %mountpoint.display(),
+            "Could not clear stale FUSE mount; mounting will likely fail. \
+             Unmount manually with: umount <mountpoint>"
+        );
+    }
+    cleared
+}
+
 /// Run one unmount command, treating "already unmounted" as success.
 fn run_unmount(cmd: &mut Command, mountpoint: &Path) -> bool {
     match cmd.output() {
@@ -94,5 +150,44 @@ mod tests {
             unmount_fuse(dir.path(), false),
             "non-mountpoint should be reported as already unmounted"
         );
+    }
+
+    /// The stale-mount errno classification: ENXIO (macFUSE) and ENOTCONN
+    /// (Linux FUSE) mean a dead mount; anything else does not. A real dead
+    /// mount cannot be created in CI, so the policy is tested via the pure
+    /// classifier.
+    #[test]
+    fn stale_mount_error_classification() {
+        let stale_macos = std::io::Error::from_raw_os_error(libc::ENXIO);
+        let stale_linux = std::io::Error::from_raw_os_error(libc::ENOTCONN);
+        let missing = std::io::Error::from_raw_os_error(libc::ENOENT);
+        let denied = std::io::Error::from_raw_os_error(libc::EACCES);
+
+        assert!(is_stale_mount_error(&stale_macos), "ENXIO is stale");
+        assert!(is_stale_mount_error(&stale_linux), "ENOTCONN is stale");
+        assert!(!is_stale_mount_error(&missing), "ENOENT is not stale");
+        assert!(!is_stale_mount_error(&denied), "EACCES is not stale");
+    }
+
+    /// A healthy directory is not a stale mount.
+    #[test]
+    fn healthy_directory_is_not_stale() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(!is_stale_fuse_mount(dir.path()));
+    }
+
+    /// A missing path is not a stale mount (nothing to recover).
+    #[test]
+    fn missing_path_is_not_stale() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+        assert!(!is_stale_fuse_mount(&missing));
+    }
+
+    /// Recovery on a healthy mountpoint is a no-op that reports false.
+    #[test]
+    fn recover_on_healthy_mountpoint_is_noop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(!recover_stale_fuse_mount(dir.path()));
     }
 }

--- a/xearthlayer/src/system/unmount.rs
+++ b/xearthlayer/src/system/unmount.rs
@@ -1,0 +1,98 @@
+//! Platform-abstracted FUSE unmounting.
+//!
+//! Linux unmounts FUSE filesystems with `fusermount3`/`fusermount`, while
+//! macOS (macFUSE) uses the BSD `umount(8)`. Both the panic handler and the
+//! spawned-mount Drop fallback need the same logic, so it lives here once.
+
+use std::path::Path;
+use std::process::Command;
+
+use tracing::{debug, warn};
+
+/// Unmount the FUSE filesystem at `mountpoint`.
+///
+/// `force` requests the most aggressive unmount the platform offers — Linux's
+/// lazy `-uz` (detach now, clean up when idle) or macOS's `-f` (force). It is
+/// used as an escalation when a graceful unmount fails because the mount is
+/// still busy.
+///
+/// Returns `true` if the mountpoint ended up unmounted, including the benign
+/// case where it was already not mounted.
+pub fn unmount_fuse(mountpoint: &Path, force: bool) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        // macFUSE unmounts via BSD umount(8). This helper is only reached as a
+        // fallback from the panic handler and the Drop path, where the daemon
+        // may be wedged and we just want the mount gone — so we always force
+        // (`-f`) to detach immediately rather than risk blocking. The normal,
+        // clean teardown goes through the async `MountHandle::unmount`, not
+        // this path; `force` is therefore advisory on macOS.
+        let _ = force;
+        run_unmount(Command::new("umount").arg("-f").arg(mountpoint), mountpoint)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let flag = if force { "-uz" } else { "-u" };
+        // Prefer fusermount3 (libfuse3), fall back to fusermount (libfuse2).
+        let mut cmd = Command::new("fusermount3");
+        cmd.arg(flag).arg(mountpoint);
+        if run_unmount(&mut cmd, mountpoint) {
+            return true;
+        }
+        let mut fallback = Command::new("fusermount");
+        fallback.arg(flag).arg(mountpoint);
+        run_unmount(&mut fallback, mountpoint)
+    }
+}
+
+/// Run one unmount command, treating "already unmounted" as success.
+fn run_unmount(cmd: &mut Command, mountpoint: &Path) -> bool {
+    match cmd.output() {
+        Ok(output) if output.status.success() => true,
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // An already-detached mount is the outcome we want, so a "not
+            // mounted"/"not currently mounted" error still counts as success.
+            if stderr.contains("not mounted")
+                || stderr.contains("not currently mounted")
+                || stderr.contains("not found")
+            {
+                true
+            } else {
+                debug!(
+                    mountpoint = %mountpoint.display(),
+                    stderr = %stderr,
+                    "unmount command failed"
+                );
+                false
+            }
+        }
+        Err(e) => {
+            warn!(
+                mountpoint = %mountpoint.display(),
+                error = %e,
+                "failed to run unmount command"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unmounting a path that isn't a mountpoint must be treated as success
+    /// (the desired end state — nothing mounted there — already holds). This
+    /// also exercises the real platform unmount binary and its stderr parsing
+    /// without needing a live FUSE mount, so it is safe in CI.
+    #[test]
+    fn unmount_of_non_mountpoint_reports_success() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            unmount_fuse(dir.path(), false),
+            "non-mountpoint should be reported as already unmounted"
+        );
+    }
+}

--- a/xearthlayer/src/xplane/paths.rs
+++ b/xearthlayer/src/xplane/paths.rs
@@ -10,7 +10,7 @@ use super::detection::XPlanePathError;
 ///
 /// The location varies by OS:
 /// - Linux: `~/.x-plane/x-plane_install_12.txt`
-/// - macOS: `~/.x-plane/x-plane_install_12.txt`
+/// - macOS: `~/Library/Preferences/x-plane_install_12.txt`
 /// - Windows: `%LOCALAPPDATA%\x-plane\x-plane_install_12.txt`
 pub fn get_install_reference_path() -> Result<PathBuf, XPlanePathError> {
     #[cfg(target_os = "windows")]
@@ -23,9 +23,17 @@ pub fn get_install_reference_path() -> Result<PathBuf, XPlanePathError> {
             .join("x-plane_install_12.txt"))
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     {
-        // Linux and macOS use ~/.x-plane
+        let home = dirs::home_dir().ok_or(XPlanePathError::NoHomeDirectory)?;
+        Ok(home
+            .join("Library")
+            .join("Preferences")
+            .join("x-plane_install_12.txt"))
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
         let home = dirs::home_dir().ok_or(XPlanePathError::NoHomeDirectory)?;
         Ok(home.join(".x-plane").join("x-plane_install_12.txt"))
     }

--- a/xearthlayer/tests/macfuse_smoke.rs
+++ b/xearthlayer/tests/macfuse_smoke.rs
@@ -1,13 +1,17 @@
-//! macOS port spike: prove the live fuse3 backend can mount and serve
-//! files through macFUSE.
+//! Manual smoke test for the macFUSE mount path.
 //!
-//! This is a feasibility probe, not a permanent test. It mounts the real
-//! `Fuse3PassthroughFS` over a temp directory, reads a passthrough file back
-//! through the mountpoint, and unmounts. If this passes on macOS, the fuse3
-//! crate drives macFUSE end-to-end and no fuser port is required.
+//! Exercises the live fuse3 backend end-to-end: kernel → macFUSE → fuse3 →
+//! our filesystems. Mounts both the legacy `Fuse3PassthroughFS` and the
+//! production `Fuse3OrthoUnionFS` (the FS X-Plane actually talks to) over
+//! temp directories, reads files back through the mountpoints, and unmounts.
+//!
+//! Run this after bumping the pinned fuse3 fork revision or changing the
+//! mount/session code.
 //!
 //! Ignored by default because it needs macFUSE installed and the kext loaded.
-//! Run with: `cargo test --test macos_mount_spike -- --ignored --nocapture`
+//! Run with: `cargo test --test macfuse_smoke -- --ignored --nocapture`
+
+#![cfg(target_os = "macos")]
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/xearthlayer/tests/macos_mount_spike.rs
+++ b/xearthlayer/tests/macos_mount_spike.rs
@@ -15,7 +15,9 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 use xearthlayer::executor::ChannelDdsClient;
+use xearthlayer::fuse::fuse3::Fuse3OrthoUnionFS;
 use xearthlayer::fuse::Fuse3PassthroughFS;
+use xearthlayer::ortho_union::OrthoUnionIndexBuilder;
 use xearthlayer::runtime::JobRequest;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -63,4 +65,62 @@ async fn passthrough_mounts_and_serves_a_file_through_macfuse() {
     assert!(names.iter().any(|n| n == "subdir"), "names: {names:?}");
 
     handle.unmount().await.expect("unmount must succeed");
+}
+
+/// Mount the *production* consolidated ortho union FS over macFUSE and read a
+/// real passthrough scenery file back through it. This is the FS X-Plane
+/// actually talks to, exercising lookup → getattr → open → read → readdir →
+/// release on the live code path (not the legacy passthrough).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires macFUSE installed and kext loaded"]
+async fn ortho_union_fs_mounts_and_serves_a_file_through_macfuse() {
+    // A patches dir holding one patch with a known scenery file.
+    let patches = tempfile::tempdir().expect("patches tempdir");
+    let patch_dir = patches.path().join("TestPatch");
+    let dsf_rel = "Earth nav data/+30-120/+33-119.dsf";
+    let dsf_contents = b"fake dsf payload for macfuse spike";
+    std::fs::create_dir_all(patch_dir.join("Earth nav data/+30-120")).unwrap();
+    std::fs::write(patch_dir.join(dsf_rel), dsf_contents).unwrap();
+    std::fs::create_dir_all(patch_dir.join("terrain")).unwrap();
+    std::fs::write(patch_dir.join("terrain/test.ter"), b"fake terrain").unwrap();
+
+    let index = OrthoUnionIndexBuilder::new()
+        .with_patches_dir(patches.path())
+        .build()
+        .expect("build ortho union index");
+    assert!(index.file_count() > 0, "index should have scanned files");
+
+    let mountpoint = tempfile::tempdir().expect("mountpoint tempdir");
+    let mount_str = mountpoint.path().to_str().unwrap().to_string();
+
+    let (tx, _rx) = mpsc::channel::<JobRequest>(8);
+    let dds_client = Arc::new(ChannelDdsClient::new(tx));
+
+    let fs = Fuse3OrthoUnionFS::new(index, dds_client, 11_174_016);
+    let handle = fs
+        .mount_spawned(&mount_str)
+        .await
+        .expect("ortho union mount_spawned must succeed on macFUSE");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Read the real scenery file back through the union mount.
+    let mounted = mountpoint.path().join(dsf_rel);
+    let read_back = std::fs::read(&mounted).expect("read scenery file through union mount");
+    assert_eq!(
+        read_back, dsf_contents,
+        "file read through ortho union mount must match source"
+    );
+
+    // Root listing should expose the patch's top-level directory.
+    let names: Vec<String> = std::fs::read_dir(mountpoint.path())
+        .expect("readdir union mountpoint")
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "Earth nav data"),
+        "names: {names:?}"
+    );
+
+    handle.unmount().await.expect("union unmount must succeed");
 }

--- a/xearthlayer/tests/macos_mount_spike.rs
+++ b/xearthlayer/tests/macos_mount_spike.rs
@@ -1,0 +1,66 @@
+//! macOS port spike: prove the live fuse3 backend can mount and serve
+//! files through macFUSE.
+//!
+//! This is a feasibility probe, not a permanent test. It mounts the real
+//! `Fuse3PassthroughFS` over a temp directory, reads a passthrough file back
+//! through the mountpoint, and unmounts. If this passes on macOS, the fuse3
+//! crate drives macFUSE end-to-end and no fuser port is required.
+//!
+//! Ignored by default because it needs macFUSE installed and the kext loaded.
+//! Run with: `cargo test --test macos_mount_spike -- --ignored --nocapture`
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use xearthlayer::executor::ChannelDdsClient;
+use xearthlayer::fuse::Fuse3PassthroughFS;
+use xearthlayer::runtime::JobRequest;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires macFUSE installed and kext loaded"]
+async fn passthrough_mounts_and_serves_a_file_through_macfuse() {
+    // Source dir with a known passthrough file.
+    let source = tempfile::tempdir().expect("source tempdir");
+    let file_contents = b"xearthlayer macos spike\n";
+    std::fs::write(source.path().join("hello.txt"), file_contents).expect("write source file");
+    std::fs::create_dir(source.path().join("subdir")).expect("create subdir");
+
+    // Empty mountpoint.
+    let mountpoint = tempfile::tempdir().expect("mountpoint tempdir");
+    let mount_str = mountpoint.path().to_str().unwrap().to_string();
+
+    // DdsClient backed by a channel we never service — passthrough reads of
+    // real files never request DDS generation, so the receiver can idle.
+    let (tx, _rx) = mpsc::channel::<JobRequest>(8);
+    let dds_client = Arc::new(ChannelDdsClient::new(tx));
+
+    let fs = Fuse3PassthroughFS::new(source.path().to_path_buf(), dds_client, 11_174_016);
+
+    let handle = fs
+        .mount_spawned(&mount_str)
+        .await
+        .expect("mount_spawned must succeed on macFUSE");
+
+    // Give the kernel a moment to wire up the mount before we stat it.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Read the passthrough file back through the FUSE mount.
+    let mounted_file = mountpoint.path().join("hello.txt");
+    let read_back = std::fs::read(&mounted_file).expect("read file through mountpoint");
+    assert_eq!(
+        read_back, file_contents,
+        "file read through macFUSE mount must match source"
+    );
+
+    // Directory listing should surface both entries.
+    let names: Vec<String> = std::fs::read_dir(mountpoint.path())
+        .expect("readdir mountpoint")
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(names.iter().any(|n| n == "hello.txt"), "names: {names:?}");
+    assert!(names.iter().any(|n| n == "subdir"), "names: {names:?}");
+
+    handle.unmount().await.expect("unmount must succeed");
+}


### PR DESCRIPTION
## Summary

Ports XEarthLayer to macOS. The branch is strictly portability: no feature
changes, no behavior changes on Linux. Tested on Apple Silicon (M5 Max,
macOS 26, macFUSE 5.2) against stable X-Plane 12.4.2 with multi-hour
flights and no session losses.

Developed with AI assistance (Claude); all changes flight-tested by me.

## Changes

- Mount the fuse3 backend on macFUSE, with unified unmount handling and
  mount verification (`system/unmount.rs`)
- Page-cache the virtual DDS files so X-Plane's mmap reads do not crash
- Force-unmount on shutdown so the mountpoint is not left stale
- Auto-recover stale FUSE mounts at startup (a run killed by crash or
  SIGKILL leaves a dead mount; detection must use opendir, not stat,
  because macOS serves cached attributes for dead macFUSE mountpoints)
- Platform-aware mount failure hints (macFUSE install/approval/umount
  on macOS instead of apt/fusermount)
- macOS location for the X-Plane install reference file
  (~/Library/Preferences/x-plane_install_12.txt)
- BSD-compatible `split` invocation in the publisher (probe and `-b`)
- `run` falls back to Custom Scenery auto-detection like the packages
  commands already did
- fuse3 pinned by rev to a fork carrying one reply-resilience patch,
  submitted upstream as Sherlock-Holo/fuse3#137 (rebased on upstream
  master, which already includes Sherlock-Holo/fuse3#136). Once
  Sherlock-Holo/fuse3#137 merges, one commit
  repoints to upstream and also retires the samsoir/fuse3 branch pin
  currently on main.
- Docs: platform support updated in README and CLAUDE.md

## Related Issues

- Related: https://github.com/Sherlock-Holo/fuse3/pull/137 (upstream fuse3
dependency, pending)
- Closes #201

## Test Plan

- [x] `make pre-commit` passes (fmt + clippy + tests)
- [x] Full test suite green on macOS (2,420 lib tests + integration)
- [x] Manual on macOS: `xearthlayer run --airport <ICAO>` mounts, streams
      tiles, and unmounts cleanly on Ctrl-C; 2h and 4h+ real X-Plane
      flights without crashes
- [x] Stale mount recovery verified end-to-end: mount, kill -9, restart,
      observe "Stale FUSE mount detected" warning and healthy remount
- [ ] Regression check on Linux (no Linux hardware on my side; CI covers
      build and tests)

## Checklist

- [x] Code follows the project's SOLID principles and patterns
- [x] Tests added or updated for new/changed behavior
- [x] Documentation updated if applicable (CLAUDE.md, docs/, config reference)
- [x] No new warnings from `cargo clippy`

