### PR TITLE
fix(lint): resolve clippy 1.97 toolchain-drift errors

### DIFF
--- a/xearthlayer/src/config/storage.rs
+++ b/xearthlayer/src/config/storage.rs
@@ -203,16 +203,13 @@ fn detect_storage_type(path: &Path) -> Option<DiskIoProfile> {
         Err(e) => {
             debug!("Failed to get metadata for {:?}: {}", path, e);
             // Try parent directory if path doesn't exist yet
-            if let Some(parent) = path.parent() {
-                match fs::metadata(parent) {
-                    Ok(m) => m,
-                    Err(e) => {
-                        debug!("Failed to get metadata for parent {:?}: {}", parent, e);
-                        return None;
-                    }
+            let parent = path.parent()?;
+            match fs::metadata(parent) {
+                Ok(m) => m,
+                Err(e) => {
+                    debug!("Failed to get metadata for parent {:?}: {}", parent, e);
+                    return None;
                 }
-            } else {
-                return None;
             }
         }
     };

--- a/xearthlayer/src/publisher/urls.rs
+++ b/xearthlayer/src/publisher/urls.rs
@@ -166,7 +166,7 @@ impl UrlVerifier {
                             "checksum mismatch: expected {}, got {}",
                             expected_checksum,
                             // Show first 16 chars for brevity
-                            &accessibility.content_length.map_or("???".to_string(), |_| {
+                            accessibility.content_length.map_or("???".to_string(), |_| {
                                 format!(
                                     "{}...",
                                     &expected_checksum[..16.min(expected_checksum.len())]


### PR DESCRIPTION
## Summary

CI's Rust toolchain (`dtolnay/rust-toolchain@stable`, unpinned) advanced to **Rust 1.97**, whose clippy promotes two lints to hard errors under `-D warnings` that the previously-resolved stable did not flag. This failed `make verify` on the first push to `develop/0.4.7` — but the affected code is **identical on `main`**, so `main` carries the same latent breakage, including in the release workflow's `verify` gate (i.e. `main` currently cannot cut a release).

Per the parallel-channel model, the fix lands on `main` first, then forward-merges into `develop/0.4.7`.

## Changes

- **`config/storage.rs`** — collapse `if let Some(parent) = … else { return None }` into `let parent = …?;` (`clippy::question_mark`)
- **`publisher/urls.rs`** — drop a redundant `&` on a `format!` argument (`clippy::useless_borrows_in_formatting`)

Both are clippy's own suggested rewrites — behavior-preserving, no logic change.

## Test plan

- Updated local toolchain `1.92 → 1.97.1` to match CI and **reproduced both errors exactly**
- Applied fixes; `make verify` (fmt + clippy + test) **passes** under 1.97.1
- No version bump — `main` stays `0.4.6`; this is a maintenance fix to keep the stable line releasable

## Follow-up

- Forward-merge `main` → `develop/0.4.7` once merged
- Consider pinning the CI toolchain to prevent future `@stable` drift (separate decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
