### PR TITLE
chore(ci): add macOS build, test and release support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,26 @@ jobs:
       - name: Run make verify
         run: make verify
 
+  # macOS is a Tier 1 platform. Pinned to macos-15 (Apple Silicon) rather than
+  # macos-latest: that label has moved across both OS versions and CPU
+  # architectures, and a silent bump would surface as an unexplained failure on
+  # an unrelated PR.
+  #
+  # No dependency-install step is needed. The pinned fuse3 fork is pure Rust
+  # (no build.rs / pkg-config / cc) and xearthlayer/build.rs already emits
+  # -lc++ for macOS. macFUSE is a runtime dependency only, and cannot be loaded
+  # on hosted runners in any case (it is a kext).
+  verify-macos:
+    name: Verify (macOS)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run make verify
+        run: make verify

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -32,3 +32,28 @@ jobs:
 
       - name: Run make verify
         run: make verify
+
+  # macOS is a Tier 1 platform. Pinned to macos-15 (Apple Silicon) rather than
+  # macos-latest: that label has moved across both OS versions and CPU
+  # architectures, and a silent bump would surface as an unexplained failure on
+  # an unrelated PR.
+  #
+  # No dependency-install step is needed. The pinned fuse3 fork is pure Rust
+  # (no build.rs / pkg-config / cc) and xearthlayer/build.rs already emits
+  # -lc++ for macOS. macFUSE is a runtime dependency only, and cannot be loaded
+  # on hosted runners in any case (it is a kext).
+  verify-macos:
+    name: Verify (macOS)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run make verify
+        run: make verify
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,23 @@ jobs:
       - name: Run make verify
         run: make verify
 
+  # macOS release gate. Mirrors the Linux `verify` job; see ci.yml for why the
+  # runner is pinned and why no dependency install is required.
+  verify-macos:
+    name: Verify (macOS)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run make verify
+        run: make verify
+
   # Build the release binary once for reuse across Linux tarball and Debian package
   build-binary:
     name: Build Release Binary
@@ -117,6 +134,47 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: linux-binary
+          path: dist/*.tar.gz
+
+  # Package the macOS (Apple Silicon) binary tarball.
+  #
+  # Unlike the Linux path this builds AND packages in one job. actions/upload-artifact
+  # zips its payload and does not preserve the executable bit — which is why
+  # package-linux must `chmod +x` after downloading. Creating the tarball before
+  # upload puts the exec bit inside the archive, where the zip cannot strip it, and
+  # saves a macOS runner spin-up.
+  #
+  # No prerelease gate, matching package-linux: .deb/.rpm/AUR are stable-only because
+  # their version fields forbid the hyphen in `0.5.0-dev.1`; a tarball has no such
+  # constraint, and preview tags are exactly what macOS testers need.
+  package-macos:
+    name: Package macOS Binary
+    runs-on: macos-15
+    needs: [verify, verify-macos]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Package binary
+        env:
+          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
+        run: |
+          mkdir -p dist
+          cp target/release/xearthlayer dist/
+          cp README.md LICENSE dist/
+          cd dist
+          tar czvf xearthlayer-${RELEASE_TAG}-arm64-macos.tar.gz xearthlayer README.md LICENSE
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-binary
           path: dist/*.tar.gz
 
   # Build .deb package for Debian/Ubuntu (uses pre-built binary)
@@ -290,11 +348,12 @@ jobs:
   publish:
     name: Publish Release
     runs-on: ubuntu-latest
-    needs: [verify, package-linux, package-deb, build-rpm, prepare-aur]
+    needs: [verify, package-linux, package-macos, package-deb, build-rpm, prepare-aur]
     if: >-
       ${{ !cancelled()
       && needs.verify.result == 'success'
       && needs.package-linux.result == 'success'
+      && needs.package-macos.result == 'success'
       && needs.package-deb.result != 'failure'
       && needs.build-rpm.result != 'failure'
       && needs.prepare-aur.result != 'failure' }}
@@ -375,6 +434,13 @@ jobs:
           RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
         run: |
           gh release upload "${RELEASE_TAG}" artifacts/linux-binary/*.tar.gz
+
+      - name: Upload macOS binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
+        run: |
+          gh release upload "${RELEASE_TAG}" artifacts/macos-binary/*.tar.gz
 
       - name: Upload Debian package
         if: ${{ needs.verify.outputs.prerelease != 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **macOS (Apple Silicon) release tarball** ([#201](https://github.com/samsoir/xearthlayer/issues/201)): Releases now ship `xearthlayer-<tag>-arm64-macos.tar.gz` on both the stable and pre-release channels. CI gained a blocking `Verify (macOS)` job on `macos-15`, and a macOS packaging failure aborts release publication. The binary is unsigned, so first run needs `xattr -dr com.apple.quarantine ./xearthlayer`. Usable once the macOS port lands.
+
+- **`make verify-macos`**: Runs `make verify` plus the live macFUSE smoke tests that CI structurally cannot execute — macFUSE is a kernel extension and hosted runners cannot load one. Required before promoting a release to stable.
+
+- **`docs/dev/cicd.md`**: Reference for the build pipeline and merge strategy — branch model, release job graph, platform support tiers, release channels, status checks, and version propagation.
+
+### Fixed
+
+- **`make bump-version` was broken on macOS and covered only two files**: it used GNU-only `sed -i`, and updated only `Cargo.toml` and `pkg/rpm/xearthlayer.spec`. It now uses a portable in-place rewrite and updates all five version-carrying files — `Cargo.toml`, `Cargo.lock` and `version.json` get the full semver, while `pkg/rpm/xearthlayer.spec` and `pkg/arch/PKGBUILD` get the hyphen-stripped base version, since RPM and Arch version fields cannot contain a hyphen. That missing coverage is why the RPM spec had drifted to `0.2.5` and the PKGBUILD to `0.2.0`; both are now correct.
+
 ## [0.4.6] - 2026-05-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,6 +381,9 @@ make verify         # Format + lint + test
 cargo test          # Direct cargo test
 ```
 
+On macOS, `make verify-macos` additionally runs the live macFUSE smoke tests that CI
+cannot execute (macFUSE is a kext; hosted runners cannot load it).
+
 ### Building
 
 ```bash
@@ -404,6 +407,11 @@ This ensures:
 CI will fail if pre-commit checks were not run.
 
 **Exception**: For documentation-only changes (`.md`, `.txt`, or other static files that don't affect compilation), `make pre-commit` is not required.
+
+**Platform CI**: PRs run `Verify` (Linux, `ubuntu-latest`) and `Verify (macOS)`
+(Apple Silicon, `macos-15`). Both are blocking. Do not convert the `verify` job to a
+matrix — `main`'s branch protection requires the exact status context `Verify`, and
+matrix jobs are renamed.
 
 ### Key Crates Used
 
@@ -446,5 +454,6 @@ CI will fail if pre-commit checks were not run.
 - Zoom level overlap management: `docs/dev/zoom-level-overlap-design.md` (dedupe, gap analysis)
 - **Consolidated FUSE mounting**: `docs/dev/consolidated-mounting-design.md` (single ortho mount, patches + packages)
 - **GeoIndex design**: `docs/dev/geo-index-design.md` (geospatial reference database, patch region ownership)
+- **CI/CD pipeline**: `docs/dev/cicd.md` (branch model, release job graph, platform tiers, version propagation)
 - memorize review allow(dead_code) macros at major checkpoints. Refactor aggresively to remove them when appropriate.
 - memorize ensure to update the projects documentation to reflect the current state of the project before committing changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,12 @@ XEarthLayer maintains two long-lived branches, one per release channel:
 | Branch | Channel | Version format | Purpose |
 |--------|---------|----------------|---------|
 | `main` | Stable | `X.Y.Z` (e.g. `0.4.6`) | Production releases — what most users run. |
-| `develop/0.4.7` | Unstable | `X.Y.Z-dev.N` (e.g. `0.4.7-dev.3`) | The next release, including breaking changes. |
+| `develop/0.5.0` | Unstable | `X.Y.Z-dev.N` (e.g. `0.5.0-dev.3`) | The next release, including breaking changes. |
 
 Work branches off — and its PR targets — whichever long-lived branch owns the change:
 
 - **Fixes and small features for the current stable line** target `main`.
-- **Breaking changes and features for the next release** target `develop/0.4.7`.
+- **Breaking changes and features for the next release** target `develop/0.5.0`.
 
 Branch naming (the prefix names the *change*; the base branch selects the *channel*):
 
@@ -46,7 +46,7 @@ Branch naming (the prefix names the *change*; the base branch selects the *chann
 - `chore/<description>` — tooling, docs, maintenance
 
 **Golden rule — fixes flow one way.** Land fixes on `main` first, then forward-merge
-`main` → `develop/0.4.7` to carry them into the unstable line. `develop/0.4.7` is
+`main` → `develop/0.5.0` to carry them into the unstable line. `develop/0.5.0` is
 **never** merged back into `main` until the whole line is promoted as a stable release.
 This keeps `main` releasable at any moment.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,14 @@ The hook skips checks for documentation-only commits (no `.rs`, `.toml`, or `Mak
 
 CI will reject PRs that haven't passed these checks.
 
+**Every PR must pass two status checks:** `Verify` (Linux) and `Verify (macOS)`. Both
+are required by design — macOS is a Tier 1 platform, and every release is gated on both
+passing before publish. You do not need a Mac to contribute; CI builds and verifies
+macOS for you.
+
+See [CI/CD Pipeline](docs/dev/cicd.md) for the full pipeline description, including how
+merge-blocking and release-blocking currently differ per platform.
+
 ### Writing Code
 
 XEarthLayer follows **SOLID principles** and **Test-Driven Development (TDD)**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,9 @@ CI will reject PRs that haven't passed these checks.
 **Every PR must pass two status checks:** `Verify` (Linux) and `Verify (macOS)`. Both
 are required by design — macOS is a Tier 1 platform, and every release is gated on both
 passing before publish. You do not need a Mac to contribute; CI builds and verifies
-macOS for you.
+macOS for you. Note that `Verify (macOS)` is expected to fail on `develop/0.5.0` until
+the macOS port (PR #202) merges — don't try to fix it if your PR targets that branch
+in the meantime.
 
 See [CI/CD Pipeline](docs/dev/cicd.md) for the full pipeline description, including how
 merge-blocking and release-blocking currently differ per platform.

--- a/Makefile
+++ b/Makefile
@@ -459,6 +459,7 @@ bump-version: ## Bump version across all files (VERSION=x.y.z or x.y.z-dev.N)
 	@# read back from the current value rather than hardcoded: it drifts when CI's
 	@# Fedora base image upgrades, and the runbook has a reconciliation step for it.
 	@FC=$$(jq -r '.assets.rpm.filename' version.json | sed -E 's/.*\.(fc[0-9]+)\..*/\1/'); \
+		case "$$FC" in fc[0-9]*) ;; *) echo "$(RED)Error: could not read Fedora tag (fcNN) from version.json .assets.rpm.filename$(NC)"; exit 1;; esac; \
 		jq --arg v "$(VERSION)" --arg fc "$$FC" \
 			'.version = $$v | .tag = "v" + $$v | .download_base_url = "https://github.com/samsoir/xearthlayer/releases/download/v" + $$v | .assets.deb.filename = "xearthlayer_" + $$v + "-1_amd64.deb" | .assets.rpm.filename = "xearthlayer-" + $$v + "-1." + $$fc + ".x86_64.rpm" | .assets.tarball.filename = "xearthlayer-v" + $$v + "-x86_64-linux.tar.gz" | .assets.macos_tarball.filename = "xearthlayer-v" + $$v + "-arm64-macos.tar.gz"' \
 			version.json > version.json.tmp \

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ verify-macos: ## Full macOS verification: verify + live macFUSE smoke tests (mac
 		echo "$(RED)Error: macFUSE not installed. See docs/macos.md$(NC)"; exit 1; fi
 	@$(MAKE) verify
 	@echo "$(BLUE)Running macFUSE smoke tests...$(NC)"
-	RUST_BACKTRACE=$(RUST_BACKTRACE) $(CARGO) test -p xearthlayer --test macfuse_smoke -- --ignored --nocapture
+	RUST_BACKTRACE=$(RUST_BACKTRACE) RUSTFLAGS="$(STRICT_RUSTFLAGS)" $(CARGO) test -p xearthlayer --test macfuse_smoke -- --ignored --nocapture
 	@echo "$(GREEN)macOS verification complete!$(NC)"
 
 .PHONY: pre-commit
@@ -443,6 +443,10 @@ BASE_VERSION = $(firstword $(subst -, ,$(VERSION)))
 bump-version: ## Bump version across all files (VERSION=x.y.z or x.y.z-dev.N)
 	@if [ -z "$(VERSION)" ]; then echo "$(RED)Error: VERSION is required. Usage: make bump-version VERSION=0.5.0-dev.1$(NC)"; exit 1; fi
 	@command -v jq >/dev/null 2>&1 || { echo "$(RED)Error: jq not found. Install jq to update version.json$(NC)"; exit 1; }
+	@# Validate the Fedora tag BEFORE writing anything — a mid-recipe abort would
+	@# leave a half-bumped tree, which is the drift this target exists to prevent.
+	@FC=$$(jq -r '.assets.rpm.filename' version.json | sed -E 's/.*\.(fc[0-9]+)\..*/\1/'); \
+		case "$$FC" in fc[0-9]*) ;; *) echo "$(RED)Error: could not read Fedora tag (fcNN) from version.json .assets.rpm.filename$(NC)"; exit 1;; esac
 	@echo "$(BLUE)Bumping version to $(VERSION) (packaging base: $(BASE_VERSION))...$(NC)"
 	@# Workspace Cargo.toml — full semver.
 	@# `cat tmp > file` rather than in-place sed: portable across GNU and BSD sed,
@@ -458,10 +462,11 @@ bump-version: ## Bump version across all files (VERSION=x.y.z or x.y.z-dev.N)
 	@# version.json — full semver. The Fedora tag (fcNN) in the RPM filename is
 	@# read back from the current value rather than hardcoded: it drifts when CI's
 	@# Fedora base image upgrades, and the runbook has a reconciliation step for it.
+	@# Already validated above, before any file was written; re-extract here since
+	@# each recipe line runs in its own shell.
 	@FC=$$(jq -r '.assets.rpm.filename' version.json | sed -E 's/.*\.(fc[0-9]+)\..*/\1/'); \
-		case "$$FC" in fc[0-9]*) ;; *) echo "$(RED)Error: could not read Fedora tag (fcNN) from version.json .assets.rpm.filename$(NC)"; exit 1;; esac; \
 		jq --arg v "$(VERSION)" --arg fc "$$FC" \
-			'.version = $$v | .tag = "v" + $$v | .download_base_url = "https://github.com/samsoir/xearthlayer/releases/download/v" + $$v | .assets.deb.filename = "xearthlayer_" + $$v + "-1_amd64.deb" | .assets.rpm.filename = "xearthlayer-" + $$v + "-1." + $$fc + ".x86_64.rpm" | .assets.tarball.filename = "xearthlayer-v" + $$v + "-x86_64-linux.tar.gz" | .assets.macos_tarball.filename = "xearthlayer-v" + $$v + "-arm64-macos.tar.gz"' \
+			'.version = $$v | .tag = "v" + $$v | .download_base_url = "https://github.com/samsoir/xearthlayer/releases/download/v" + $$v | .assets.deb.filename = "xearthlayer_" + $$v + "-1_amd64.deb" | .assets.rpm.filename = "xearthlayer-" + $$v + "-1." + $$fc + ".x86_64.rpm" | .assets.tarball.filename = "xearthlayer-v" + $$v + "-x86_64-linux.tar.gz" | .assets.macos_tarball = {filename: ("xearthlayer-v" + $$v + "-arm64-macos.tar.gz"), description: "macOS (Apple Silicon) binary tarball"}' \
 			version.json > version.json.tmp \
 		&& cat version.json.tmp > version.json && rm -f version.json.tmp
 	@# Cargo.lock — refresh the two workspace member entries.

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,17 @@ lint-fix: ## Run clippy and automatically fix issues
 verify: format-check lint test-strict ## Run all verification checks (format, lint, test)
 	@echo "$(GREEN)All verification checks passed!$(NC)"
 
+.PHONY: verify-macos
+verify-macos: ## Full macOS verification: verify + live macFUSE smoke tests (macOS only)
+	@if [ "$$(uname -s)" != "Darwin" ]; then \
+		echo "$(RED)Error: verify-macos must be run on macOS$(NC)"; exit 1; fi
+	@if [ ! -d /Library/Filesystems/macfuse.fs ]; then \
+		echo "$(RED)Error: macFUSE not installed. See docs/macos.md$(NC)"; exit 1; fi
+	@$(MAKE) verify
+	@echo "$(BLUE)Running macFUSE smoke tests...$(NC)"
+	RUST_BACKTRACE=$(RUST_BACKTRACE) $(CARGO) test -p xearthlayer --test macfuse_smoke -- --ignored --nocapture
+	@echo "$(GREEN)macOS verification complete!$(NC)"
+
 .PHONY: pre-commit
 pre-commit: verify ## Run pre-commit checks (format-check + lint + test)
 	@echo "$(GREEN)Pre-commit checks passed! Ready to commit.$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -432,21 +432,47 @@ pkg-all: pkg-deb pkg-tarball ## Build all packages (deb + tarball)
 version: ## Show current version
 	@echo "$(BLUE)Current version:$(NC) $(PKG_VERSION)"
 
+# Pre-release suffix (e.g. `-dev.0`) stripped for RPM and PKGBUILD, whose version
+# fields cannot represent it: RPM uses `-` to delimit Version from Release, and
+# Arch `pkgver` forbids hyphens. This is the same constraint that makes
+# release.yml gate .deb/.rpm/AUR to stable tags. For a stable VERSION the two
+# forms are identical, so this is a no-op on the stable path.
+BASE_VERSION = $(firstword $(subst -, ,$(VERSION)))
+
 .PHONY: bump-version
-bump-version: ## Bump version across all files (VERSION=x.y.z)
-	@if [ -z "$(VERSION)" ]; then echo "$(RED)Error: VERSION is required. Usage: make bump-version VERSION=0.3.0$(NC)"; exit 1; fi
-	@echo "$(BLUE)Bumping version to $(VERSION)...$(NC)"
-	@# Update workspace Cargo.toml
-	@sed -i 's/^version = ".*"/version = "$(VERSION)"/' Cargo.toml
-	@# Update RPM spec file
-	@sed -i 's/^Version:.*/Version:        $(VERSION)/' pkg/rpm/xearthlayer.spec
+bump-version: ## Bump version across all files (VERSION=x.y.z or x.y.z-dev.N)
+	@if [ -z "$(VERSION)" ]; then echo "$(RED)Error: VERSION is required. Usage: make bump-version VERSION=0.5.0-dev.1$(NC)"; exit 1; fi
+	@command -v jq >/dev/null 2>&1 || { echo "$(RED)Error: jq not found. Install jq to update version.json$(NC)"; exit 1; }
+	@echo "$(BLUE)Bumping version to $(VERSION) (packaging base: $(BASE_VERSION))...$(NC)"
+	@# Workspace Cargo.toml — full semver.
+	@# `cat tmp > file` rather than in-place sed: portable across GNU and BSD sed,
+	@# and preserves the original file's inode and permissions.
+	@sed 's/^version = ".*"/version = "$(VERSION)"/' Cargo.toml > Cargo.toml.tmp \
+		&& cat Cargo.toml.tmp > Cargo.toml && rm -f Cargo.toml.tmp
+	@# RPM spec — base version only.
+	@sed 's/^Version:.*/Version:        $(BASE_VERSION)/' pkg/rpm/xearthlayer.spec > pkg/rpm/xearthlayer.spec.tmp \
+		&& cat pkg/rpm/xearthlayer.spec.tmp > pkg/rpm/xearthlayer.spec && rm -f pkg/rpm/xearthlayer.spec.tmp
+	@# Arch PKGBUILD — base version only.
+	@sed 's/^pkgver=.*/pkgver=$(BASE_VERSION)/' pkg/arch/PKGBUILD > pkg/arch/PKGBUILD.tmp \
+		&& cat pkg/arch/PKGBUILD.tmp > pkg/arch/PKGBUILD && rm -f pkg/arch/PKGBUILD.tmp
+	@# version.json — full semver. The Fedora tag (fcNN) in the RPM filename is
+	@# read back from the current value rather than hardcoded: it drifts when CI's
+	@# Fedora base image upgrades, and the runbook has a reconciliation step for it.
+	@FC=$$(jq -r '.assets.rpm.filename' version.json | sed -E 's/.*\.(fc[0-9]+)\..*/\1/'); \
+		jq --arg v "$(VERSION)" --arg fc "$$FC" \
+			'.version = $$v | .tag = "v" + $$v | .download_base_url = "https://github.com/samsoir/xearthlayer/releases/download/v" + $$v | .assets.deb.filename = "xearthlayer_" + $$v + "-1_amd64.deb" | .assets.rpm.filename = "xearthlayer-" + $$v + "-1." + $$fc + ".x86_64.rpm" | .assets.tarball.filename = "xearthlayer-v" + $$v + "-x86_64-linux.tar.gz" | .assets.macos_tarball.filename = "xearthlayer-v" + $$v + "-arm64-macos.tar.gz"' \
+			version.json > version.json.tmp \
+		&& cat version.json.tmp > version.json && rm -f version.json.tmp
+	@# Cargo.lock — refresh the two workspace member entries.
+	@$(CARGO) update --workspace --offline >/dev/null
 	@echo "$(GREEN)Version bumped to $(VERSION)$(NC)"
 	@echo ""
 	@echo "$(YELLOW)Next steps:$(NC)"
-	@echo "  1. Update CHANGELOG.md with release notes"
-	@echo "  2. Commit: git add -A && git commit -m 'Bump version to $(VERSION)'"
-	@echo "  3. Tag: git tag v$(VERSION)"
-	@echo "  4. Push: git push origin HEAD && git push origin v$(VERSION)"
+	@echo "  1. Update version.json release_date (not automated — see below)"
+	@echo "  2. Update CHANGELOG.md with release notes"
+	@echo "  3. Commit: git add -A && git commit -m 'Bump version to $(VERSION)'"
+	@echo "  4. Tag: git tag v$(VERSION)"
+	@echo "  5. Push: git push origin HEAD && git push origin v$(VERSION)"
 
 .PHONY: release-checklist
 release-checklist: ## Show release checklist

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -33,7 +33,6 @@ Technical documentation for XEarthLayer developers and contributors.
 | [Scenery Packages](scenery-packages.md) | File formats, naming conventions, metadata specs |
 | [Package Manager Design](package-manager-design.md) | Download, install, update architecture (parallel downloads, retry) |
 | [Package Publisher Design](package-publisher-design.md) | Build, archive, release pipeline |
-| [CI/CD Pipeline](cicd.md) | Build pipeline, merge strategy, release channels, platform tiers |
 | [GitHub Releases Publishing](github-releases-publishing.md) | Multi-part upload workflow |
 | [Zoom Level Overlap](zoom-level-overlap-design.md) | Dedupe and gap analysis tools |
 
@@ -54,6 +53,7 @@ Technical documentation for XEarthLayer developers and contributors.
 |----------|-------------|
 | [Debug Map](debug-map.md) | Live browser map for prefetch observability (`--features debug-map`) |
 | [Memory Profiling](memory-profiling.md) | Heaptrack profiling guide for memory optimization |
+| [CI/CD Pipeline](cicd.md) | Build pipeline, merge strategy, release channels, platform tiers |
 | [Application Release Runbook](app-release-runbook.md) | Release workflow, versioning, and troubleshooting |
 
 ## Root Cause Analysis

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -33,6 +33,7 @@ Technical documentation for XEarthLayer developers and contributors.
 | [Scenery Packages](scenery-packages.md) | File formats, naming conventions, metadata specs |
 | [Package Manager Design](package-manager-design.md) | Download, install, update architecture (parallel downloads, retry) |
 | [Package Publisher Design](package-publisher-design.md) | Build, archive, release pipeline |
+| [CI/CD Pipeline](cicd.md) | Build pipeline, merge strategy, release channels, platform tiers |
 | [GitHub Releases Publishing](github-releases-publishing.md) | Multi-part upload workflow |
 | [Zoom Level Overlap](zoom-level-overlap-design.md) | Dedupe and gap analysis tools |
 

--- a/docs/dev/app-release-runbook.md
+++ b/docs/dev/app-release-runbook.md
@@ -73,6 +73,7 @@ unfinished 0.5.0 work into a stable release.
 
 - Write access to the repository
 - `gh` CLI authenticated (`gh auth status`)
+- `jq` installed — `make bump-version` hard-fails without it
 - Clean working tree on the branch you're releasing from — `main` for a stable release or
   hotfix, `develop/0.5.0` for an unstable preview
 
@@ -322,7 +323,9 @@ Cut the release branch from `main` and run the **Stable Release** golden path wi
 ```bash
 git checkout main && git pull origin main
 git checkout -b release/X.Y.(Z+1)
-# fix + tests (TDD), bump Cargo.toml to X.Y.(Z+1), update CHANGELOG.md and version.json
+# fix + tests (TDD), then:
+#   make bump-version VERSION=X.Y.(Z+1)
+#   by hand: version.json release_date, and the CHANGELOG entry
 make pre-commit
 ```
 
@@ -343,6 +346,11 @@ git checkout develop/0.5.0 && git pull origin develop/0.5.0
 git merge --no-ff main          # bring the stable fix forward
 # Cargo.toml will conflict on `version`: keep develop's 0.5.0-dev.N string, take the
 # fix itself. Re-run cargo update -w if the lockfile needs it.
+# version.json, pkg/rpm/xearthlayer.spec and pkg/arch/PKGBUILD will also conflict —
+# main carries older stable version numbers than develop's -dev.N line. Resolution
+# rule: keep develop's side for every version-carrying file; the incoming stable
+# versions are older and would regress develop's packaging files. This self-heals at
+# promotion, when `make bump-version` rewrites all five version-carrying files.
 make pre-commit
 git push origin develop/0.5.0
 ```
@@ -389,40 +397,8 @@ following cycle.
 
 ## Release Workflow Architecture
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                        Release Workflow Pipeline                         │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                         │
-│  Tag Push (vX.Y.Z)                                                      │
-│        │                                                                │
-│        ▼                                                                │
-│  ┌─────────────┐                                                        │
-│  │   Verify    │ ◄── Gate: format, lint, test                          │
-│  └─────────────┘                                                        │
-│        │                                                                │
-│        ▼                                                                │
-│  ┌─────────────────┐                                                    │
-│  │  Build Binary   │ ◄── Single build, reused by packaging jobs        │
-│  └─────────────────┘                                                    │
-│        │                                                                │
-│        ├──────────────┬───────────────┬──────────────┐                  │
-│        ▼              ▼               ▼              ▼                  │
-│  ┌──────────┐  ┌───────────┐  ┌───────────┐  ┌───────────┐             │
-│  │  Linux   │  │  Debian   │  │    RPM    │  │    AUR    │             │
-│  │ Tarball  │  │  Package  │  │  Package  │  │  Package  │             │
-│  └──────────┘  └───────────┘  └───────────┘  └───────────┘             │
-│        │              │               │              │                  │
-│        └──────────────┴───────────────┴──────────────┘                  │
-│                              │                                          │
-│                              ▼                                          │
-│                     ┌────────────────┐                                  │
-│                     │ Publish Release│ ◄── Upload assets, update        │
-│                     │                │     version.json, notify website │
-│                     └────────────────┘                                  │
-│                                                                         │
-└─────────────────────────────────────────────────────────────────────────┘
-```
+See [CI/CD Pipeline — The Release Job Graph](cicd.md#the-release-job-graph) for the
+job dependency graph and the `publish` gate, kept in step with the workflow itself.
 
 ## Troubleshooting
 
@@ -641,19 +617,14 @@ Update the comparison links at the bottom of CHANGELOG.md:
 
 - [ ] Working tree clean, on `main`, up to date
 - [ ] `make pre-commit` passes
-- [ ] Version updated in `Cargo.toml`
+- [ ] `make bump-version VERSION=X.Y.Z` run — updates `Cargo.toml`, `Cargo.lock`, `version.json`, `pkg/rpm/xearthlayer.spec`, `pkg/arch/PKGBUILD`
+- [ ] `version.json` `release_date` set by hand (`bump-version` deliberately leaves it)
 - [ ] CHANGELOG.md updated with all changes
-- [ ] `version.json` updated with new version, date, and asset filenames
 - [ ] Release branch created and PR opened
 - [ ] CI passes on PR
 - [ ] **macOS verification (required for stable promotion).** CI compiles the macFUSE
       smoke tests but cannot run them — macFUSE is a kext and hosted runners cannot
-      load it. A maintainer with Apple Silicon hardware must run:
-
-      ```bash
-      make verify-macos
-      ```
-
+      load it. A maintainer with Apple Silicon hardware must run `make verify-macos`
       and post the output on the release PR. See
       [CI/CD Pipeline](cicd.md#what-ci-cannot-verify) for why this gap exists.
 - [ ] Tag created and pushed (BEFORE merging PR)

--- a/docs/dev/app-release-runbook.md
+++ b/docs/dev/app-release-runbook.md
@@ -16,9 +16,9 @@ Releases are automated via GitHub Actions when a version tag (`v*`) is pushed. T
    `website-sync.yml` reads `version.json` and notifies the website
 
 XEarthLayer runs two release channels in parallel — a stable line on `main` and an
-unstable line on `develop/0.4.7`. The **Stable Release** golden path below is the common
+unstable line on `develop/0.5.0`. The **Stable Release** golden path below is the common
 case; **Unstable / Preview Release**, **Hotfix Release**, and **Promoting
-`develop/0.4.7` to Stable** follow it.
+`develop/0.5.0` to Stable** follow it.
 
 ## Branch Model & Release Channels
 
@@ -27,7 +27,7 @@ XEarthLayer ships on two parallel channels, each anchored to a long-lived branch
 | Channel | Branch | Version | Example | GitHub Release | Assets | version.json / website |
 |---------|--------|---------|---------|----------------|--------|------------------------|
 | **Stable** | `main` | `X.Y.Z` | `0.4.6` | Latest | tarball + `.deb` + `.rpm` + AUR | ✅ updated |
-| **Unstable** | `develop/0.4.7` | `X.Y.Z-dev.N` | `0.4.7-dev.3` | Pre-release (`--latest=false`) | tarball only | ❌ skipped |
+| **Unstable** | `develop/0.5.0` | `X.Y.Z-dev.N` | `0.5.0-dev.3` | Pre-release (`--latest=false`) | tarball only | ❌ skipped |
 
 As the unstable line matures toward release, the pre-release identifier progresses
 `-dev.N` → `-alpha.N` → `-beta.N` → `-rc.N`, and finally drops the suffix when the branch
@@ -42,20 +42,20 @@ main (stable, v0.4.x)
   │                       │
   │                       └──────────── merge forward ───────────┐
   │                                                               ▼
-  └── develop/0.4.7 (unstable, long-lived) ◀──────────────────────┘
-        ├── feature/* ──PR──▶ develop/0.4.7
-        └── ──tag──▶ v0.4.7-dev.N · -alpha.N · -beta.N · -rc.N     # preview
+  └── develop/0.5.0 (unstable, long-lived) ◀──────────────────────┘
+        ├── feature/* ──PR──▶ develop/0.5.0
+        └── ──tag──▶ v0.5.0-dev.N · -alpha.N · -beta.N · -rc.N     # preview
                           │
         release-ready:    └─ release/0.4.7 ──PR──▶ main ──tag──▶ v0.4.7   # promote
 ```
 
 **The one-way rule.** Fixes land on `main` first, then forward-merge into
-`develop/0.4.7`. The develop branch is **never** merged directly back into `main`;
+`develop/0.5.0`. The develop branch is **never** merged directly back into `main`;
 promotion happens through a `release/*` branch cut from develop (see **Promoting
-`develop/0.4.7` to Stable**). This keeps `main` releasable at any moment without dragging
+`develop/0.5.0` to Stable**). This keeps `main` releasable at any moment without dragging
 unfinished 0.4.7 work into a stable release.
 
-> **Version collision when develop targets the next patch.** `develop/0.4.7` reserves
+> **Version collision when develop targets the next patch.** `develop/0.5.0` reserves
 > `0.4.7` for its own promotion. Because that is the *immediate* next number, an urgent
 > **Hotfix Release** cut from `main` cannot also be `0.4.7`. If a hotfix must ship before
 > the develop line promotes, give it the next patch (`0.4.7` → the hotfix becomes the
@@ -68,12 +68,12 @@ unfinished 0.4.7 work into a stable release.
 - Write access to the repository
 - `gh` CLI authenticated (`gh auth status`)
 - Clean working tree on the branch you're releasing from — `main` for a stable release or
-  hotfix, `develop/0.4.7` for an unstable preview
+  hotfix, `develop/0.5.0` for an unstable preview
 
 ## Stable Release (Golden Path)
 
 > This is the standard path: a stable `X.Y.Z` release cut from `main`. For an unstable
-> preview from `develop/0.4.7`, see **Unstable / Preview Release**; for an urgent fix to
+> preview from `develop/0.5.0`, see **Unstable / Preview Release**; for an urgent fix to
 > the stable line, see **Hotfix Release**.
 
 ### Step 1: Prepare the Release
@@ -214,7 +214,7 @@ curl -s https://xearthlayer.app | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+'
 
 `CHANGELOG.md` keeps a single `## [Unreleased]` section at the top ([Keep a
 Changelog](https://keepachangelog.com/) format). **All** merged changes are recorded
-there as they land — on `main` or on `develop/0.4.7` — under the usual
+there as they land — on `main` or on `develop/0.5.0` — under the usual
 Added / Changed / Fixed / Removed groups.
 
 - Entries accumulate under `## [Unreleased]` throughout a development cycle.
@@ -226,7 +226,7 @@ Added / Changed / Fixed / Removed groups.
 
 ## Unstable / Preview Release
 
-Preview releases are cut from `develop/0.4.7` and published as GitHub **pre-releases**.
+Preview releases are cut from `develop/0.5.0` and published as GitHub **pre-releases**.
 They deliberately skip the stable end-user surfaces: no `version.json` change, no website
 notification, no package library, and no `.deb`/`.rpm`/AUR artifacts. Only the Linux
 tarball is published, so testers grab the binary directly from the release. The stable
@@ -236,7 +236,7 @@ line on `main` stays authoritative for everything user-facing.
 
 | | Stable | Preview |
 |---|--------|---------|
-| Branch | `main` | `develop/0.4.7` |
+| Branch | `main` | `develop/0.5.0` |
 | Version | `X.Y.Z` | `X.Y.Z-dev.N` (`-alpha`/`-beta`/`-rc`) |
 | Assets | tarball + `.deb` + `.rpm` + AUR | tarball only |
 | GitHub Release | Latest | Pre-release, `--latest=false` |
@@ -252,11 +252,11 @@ the `.deb`/`.rpm`/AUR jobs. `website-sync.yml` never fires because it only trigg
 
 ```bash
 # 1. On develop, ensure it's current (stable fixes forward-merged in — see Hotfix)
-git checkout develop/0.4.7
-git pull origin develop/0.4.7
+git checkout develop/0.5.0
+git pull origin develop/0.5.0
 
 # 2. Bump the pre-release identifier in Cargo.toml, then sync the lockfile
-#    [workspace.package] version = "0.4.7-dev.N"
+#    [workspace.package] version = "0.5.0-dev.N"
 #    (increment N per preview: dev.0, dev.1, …; advance to -alpha/-beta/-rc as the
 #    line matures)
 cargo update -w
@@ -266,33 +266,33 @@ cargo update -w
 # 4. Verify, commit, and push on develop
 make pre-commit
 git add Cargo.toml Cargo.lock CHANGELOG.md
-git commit -m "chore(release): 0.4.7-dev.N"
-git push origin develop/0.4.7
+git commit -m "chore(release): 0.5.0-dev.N"
+git push origin develop/0.5.0
 
 # 5. Tag from develop and push — this triggers the release workflow
-git tag v0.4.7-dev.N
-git push origin v0.4.7-dev.N
+git tag v0.5.0-dev.N
+git push origin v0.5.0-dev.N
 ```
 
-There is no release PR and no merge step: the preview lives entirely on `develop/0.4.7`.
+There is no release PR and no merge step: the preview lives entirely on `develop/0.5.0`.
 
 ### Verify
 
 ```bash
 # Confirm it is a pre-release and NOT marked latest
-gh release view v0.4.7-dev.N --json isPrerelease,isLatest
+gh release view v0.5.0-dev.N --json isPrerelease,isLatest
 # Expect: {"isPrerelease": true, "isLatest": false}
 
 # Confirm the stable release is still "Latest"
 gh release list --limit 5
 
 # Confirm only the tarball was attached (no .deb/.rpm/AUR)
-gh release view v0.4.7-dev.N --json assets --jq '.assets[].name'
+gh release view v0.5.0-dev.N --json assets --jq '.assets[].name'
 ```
 
 ## Hotfix Release
 
-A hotfix ships an urgent patch to the **stable** line while `develop/0.4.7` is in flight.
+A hotfix ships an urgent patch to the **stable** line while `develop/0.5.0` is in flight.
 Mechanically it is a normal stable patch release, plus a mandatory forward-merge into
 develop so the fix is not lost when the next release ships.
 
@@ -321,12 +321,12 @@ verify website.
 Once the fix is merged to `main`, carry it into the unstable line:
 
 ```bash
-git checkout develop/0.4.7 && git pull origin develop/0.4.7
+git checkout develop/0.5.0 && git pull origin develop/0.5.0
 git merge --no-ff main          # bring the stable fix forward
-# Cargo.toml will conflict on `version`: keep develop's 0.4.7-dev.N string, take the
+# Cargo.toml will conflict on `version`: keep develop's 0.5.0-dev.N string, take the
 # fix itself. Re-run cargo update -w if the lockfile needs it.
 make pre-commit
-git push origin develop/0.4.7
+git push origin develop/0.5.0
 ```
 
 > **Why forward-merge, never back-merge.** `main` must stay releasable at any moment.
@@ -334,7 +334,7 @@ git push origin develop/0.4.7
 > merging `main` → `develop` only adds already-shipped, already-tested fixes to the
 > unstable line. Fixes therefore always travel `main` → `develop`, never the reverse.
 
-## Promoting `develop/0.4.7` to Stable
+## Promoting `develop/0.5.0` to Stable
 
 When the unstable line is feature-complete and has progressed through `-rc.N`, promote it
 to a stable release. Promotion goes through a `release/*` branch (not a direct
@@ -343,7 +343,7 @@ commit message — fires correctly.
 
 ```bash
 # 1. Ensure every stable fix is forward-merged and develop is green
-git checkout develop/0.4.7 && git pull origin develop/0.4.7
+git checkout develop/0.5.0 && git pull origin develop/0.5.0
 make pre-commit
 
 # 2. Cut the release branch from develop

--- a/docs/dev/app-release-runbook.md
+++ b/docs/dev/app-release-runbook.md
@@ -46,22 +46,23 @@ main (stable, v0.4.x)
         ├── feature/* ──PR──▶ develop/0.5.0
         └── ──tag──▶ v0.5.0-dev.N · -alpha.N · -beta.N · -rc.N     # preview
                           │
-        release-ready:    └─ release/0.4.7 ──PR──▶ main ──tag──▶ v0.4.7   # promote
+        release-ready:    └─ release/0.5.0 ──PR──▶ main ──tag──▶ v0.5.0   # promote
 ```
 
 **The one-way rule.** Fixes land on `main` first, then forward-merge into
 `develop/0.5.0`. The develop branch is **never** merged directly back into `main`;
 promotion happens through a `release/*` branch cut from develop (see **Promoting
 `develop/0.5.0` to Stable**). This keeps `main` releasable at any moment without dragging
-unfinished 0.4.7 work into a stable release.
+unfinished 0.5.0 work into a stable release.
 
-> **Version collision when develop targets the next patch.** `develop/0.5.0` reserves
-> `0.4.7` for its own promotion. Because that is the *immediate* next number, an urgent
-> **Hotfix Release** cut from `main` cannot also be `0.4.7`. If a hotfix must ship before
-> the develop line promotes, give it the next patch (`0.4.7` → the hotfix becomes the
-> stable release and develop re-targets `0.4.8`), or fold the fix into the develop line
-> and promote once. Reserve a develop line for a further-out minor (e.g. `develop/0.5.0`)
-> when you expect stable patches to keep flowing in parallel.
+> **Version collision when a develop line targets the next patch.** If the unstable
+> branch reserves the *immediate* next patch number — say `develop/0.4.7` while `main`
+> sits at `0.4.6` — an urgent **Hotfix Release** cut from `main` cannot claim that
+> number too. Either give the hotfix the next patch and re-target the develop line
+> (the hotfix ships `0.4.7`, develop moves to `0.4.8`), or fold the fix into the
+> develop line and promote once. The current line sidesteps this by targeting a
+> further-out minor: `develop/0.5.0` promotes to `v0.5.0`, leaving `v0.4.7` free for
+> a stable hotfix off `main`.
 
 ## Prerequisites
 
@@ -330,7 +331,7 @@ git push origin develop/0.5.0
 ```
 
 > **Why forward-merge, never back-merge.** `main` must stay releasable at any moment.
-> Merging `develop` → `main` would drag unfinished 0.4.7 work into a stable release;
+> Merging `develop` → `main` would drag unfinished 0.5.0 work into a stable release;
 > merging `main` → `develop` only adds already-shipped, already-tested fixes to the
 > unstable line. Fixes therefore always travel `main` → `develop`, never the reverse.
 
@@ -347,25 +348,25 @@ git checkout develop/0.5.0 && git pull origin develop/0.5.0
 make pre-commit
 
 # 2. Cut the release branch from develop
-git checkout -b release/0.4.7
+git checkout -b release/0.5.0
 
 # 3. Drop the pre-release suffix and finalize the stable surfaces:
-#    - Cargo.toml: [workspace.package] version = "0.4.7"   (then cargo update -w)
-#    - CHANGELOG.md: move "Unreleased" entries under ## [0.4.7] - YYYY-MM-DD
-#    - version.json: author 0.4.7 metadata + asset filenames (now in play)
+#    - Cargo.toml: [workspace.package] version = "0.5.0"   (then cargo update -w)
+#    - CHANGELOG.md: move "Unreleased" entries under ## [0.5.0] - YYYY-MM-DD
+#    - version.json: author 0.5.0 metadata + asset filenames (now in play)
 cargo update -w
 make pre-commit
 git add Cargo.toml Cargo.lock CHANGELOG.md version.json
-git commit -m "Release v0.4.7"
+git commit -m "Release v0.5.0"
 
-# 4. Push and open the promotion PR (base main, head release/0.4.7)
-git push -u origin release/0.4.7
-gh pr create --base main --title "Release v0.4.7" --body "Release v0.4.7"
+# 4. Push and open the promotion PR (base main, head release/0.5.0)
+git push -u origin release/0.5.0
+gh pr create --base main --title "Release v0.5.0" --body "Release v0.5.0"
 ```
 
-From here follow the **Stable Release** golden path from Step 4 (tag `v0.4.7` before
+From here follow the **Stable Release** golden path from Step 4 (tag `v0.5.0` before
 merging, run the release workflow, reconcile assets, merge, verify website). After
-promotion, open the next unstable branch (e.g. `develop/0.5.0`) from `main` for the
+promotion, open the next unstable branch (e.g. `develop/0.6.0`) from `main` for the
 following cycle.
 
 ## Release Workflow Architecture

--- a/docs/dev/app-release-runbook.md
+++ b/docs/dev/app-release-runbook.md
@@ -141,7 +141,8 @@ make bump-version VERSION=X.Y.Z
 git checkout -b release/X.Y.Z
 
 # Commit changes
-git add Cargo.toml Cargo.lock CHANGELOG.md version.json
+git add Cargo.toml Cargo.lock CHANGELOG.md version.json \
+        pkg/rpm/xearthlayer.spec pkg/arch/PKGBUILD
 git commit -m "Release vX.Y.Z"
 
 # Push and create PR
@@ -272,6 +273,10 @@ git pull origin develop/0.5.0
 #    [workspace.package] version = "0.5.0-dev.N"
 #    (increment N per preview: dev.0, dev.1, …; advance to -alpha/-beta/-rc as the
 #    line matures)
+#    Deliberately hand-edited rather than `make bump-version`: that tool also rewrites
+#    version.json, and previews must leave the stable end-user surfaces untouched.
+#    No drift results — the base version of X.Y.Z-dev.N is X.Y.Z, which the RPM spec
+#    and PKGBUILD already carry.
 cargo update -w
 
 # 3. Record changes under the CHANGELOG "Unreleased" heading (do NOT date a section)

--- a/docs/dev/app-release-runbook.md
+++ b/docs/dev/app-release-runbook.md
@@ -7,8 +7,9 @@ This runbook documents the complete workflow for releasing new versions of XEart
 Releases are automated via GitHub Actions when a version tag (`v*`) is pushed. The workflow:
 1. Runs `make verify` (format, lint, test)
 2. Builds the release binary once
-3. Packages for multiple platforms (Linux tarball, Debian, RPM, AUR) — **stable
-   releases only**; pre-release tags ship the Linux tarball alone
+3. Packages for multiple platforms (Linux tarball, macOS tarball, Debian, RPM, AUR) —
+   the Debian/RPM/AUR packages are **stable releases only**; pre-release tags ship the
+   Linux and macOS tarballs alone
 4. Creates a GitHub Release with all assets — a **pre-release** (not marked "Latest")
    for unstable tags (`-dev.N` / `-alpha.N` / `-beta.N` / `-rc.N`), a normal release
    for stable `X.Y.Z` tags
@@ -20,20 +21,24 @@ unstable line on `develop/0.5.0`. The **Stable Release** golden path below is th
 case; **Unstable / Preview Release**, **Hotfix Release**, and **Promoting
 `develop/0.5.0` to Stable** follow it.
 
+> For how the pipeline itself is structured — the job graph, platform tiers, status
+> checks and version propagation — see [CI/CD Pipeline](cicd.md). This runbook is the
+> procedure; that document is the system.
+
 ## Branch Model & Release Channels
 
 XEarthLayer ships on two parallel channels, each anchored to a long-lived branch:
 
 | Channel | Branch | Version | Example | GitHub Release | Assets | version.json / website |
 |---------|--------|---------|---------|----------------|--------|------------------------|
-| **Stable** | `main` | `X.Y.Z` | `0.4.6` | Latest | tarball + `.deb` + `.rpm` + AUR | ✅ updated |
-| **Unstable** | `develop/0.5.0` | `X.Y.Z-dev.N` | `0.5.0-dev.3` | Pre-release (`--latest=false`) | tarball only | ❌ skipped |
+| **Stable** | `main` | `X.Y.Z` | `0.4.6` | Latest | Linux + macOS tarballs + `.deb` + `.rpm` + AUR | ✅ updated |
+| **Unstable** | `develop/0.5.0` | `X.Y.Z-dev.N` | `0.5.0-dev.3` | Pre-release (`--latest=false`) | Linux + macOS tarballs | ❌ skipped |
 
 As the unstable line matures toward release, the pre-release identifier progresses
 `-dev.N` → `-alpha.N` → `-beta.N` → `-rc.N`, and finally drops the suffix when the branch
 is promoted to a stable `X.Y.Z` on `main`. All four pre-release forms are treated
-identically by the release workflow (published as GitHub pre-releases, Linux tarball
-only).
+identically by the release workflow (published as GitHub pre-releases, Linux and macOS
+tarballs only).
 
 ```
 main (stable, v0.4.x)
@@ -91,18 +96,20 @@ make pre-commit
 ### Step 2: Update Version, Changelog, and version.json
 
 ```bash
-# Update workspace version in Cargo.toml
-# Edit: [workspace.package] version = "X.Y.Z"
+# Update every version-carrying file in one step
+make bump-version VERSION=X.Y.Z
+#   Full semver  -> Cargo.toml, Cargo.lock, version.json
+#   Base version -> pkg/rpm/xearthlayer.spec, pkg/arch/PKGBUILD
+#   (RPM and Arch version fields cannot contain a hyphen — see docs/dev/cicd.md)
 
-# Update CHANGELOG.md
-# - Add new version header: ## [X.Y.Z] - YYYY-MM-DD
-# - Document all changes under Added/Changed/Fixed/Removed
-# - Update comparison links at bottom
-
-# Update version.json
-# - version, tag, release_date
-# - Asset filenames (replace old version with X.Y.Z)
-# - download_base_url
+# Then by hand — bump-version deliberately leaves these alone:
+# - version.json: release_date
+#   Leaving it manual keeps `make bump-version VERSION=<current>` a no-op, so
+#   re-running it doubles as a drift check.
+# - CHANGELOG.md:
+#   - Add new version header: ## [X.Y.Z] - YYYY-MM-DD
+#   - Document all changes under Added/Changed/Fixed/Removed
+#   - Update comparison links at bottom
 ```
 
 > **⚠ RPM filename drift:** The RPM asset name embeds the Fedora base image
@@ -160,13 +167,18 @@ gh run watch --repo samsoir/xearthlayer
 
 # Expected jobs (all should succeed):
 # ✓ Verify (~3-4 min)
+# ✓ Verify (macOS) (~10-15 min)
 # ✓ Build Release Binary (~4 min)
 # ✓ Prepare AUR Package (~5 sec)
 # ✓ Build RPM Package (~7-8 min)
 # ✓ Package Linux Binary (~10 sec)
+# ✓ Package macOS Binary (~5-6 min)
 # ✓ Package Debian Package (~1 min)
 # ✓ Publish Release (~15 sec)
 ```
+
+macOS timings are estimates — the runner has fewer cores than `ubuntu-latest`. Replace
+them with measured values after the first `v0.5.0-dev.N` release.
 
 ### Step 6: Reconcile Asset Filenames, Then Merge PR
 
@@ -229,9 +241,9 @@ Added / Changed / Fixed / Removed groups.
 
 Preview releases are cut from `develop/0.5.0` and published as GitHub **pre-releases**.
 They deliberately skip the stable end-user surfaces: no `version.json` change, no website
-notification, no package library, and no `.deb`/`.rpm`/AUR artifacts. Only the Linux
-tarball is published, so testers grab the binary directly from the release. The stable
-line on `main` stays authoritative for everything user-facing.
+notification, no package library, and no `.deb`/`.rpm`/AUR artifacts. Only the Linux and
+macOS tarballs are published, so testers grab the binary directly from the release. The
+stable line on `main` stays authoritative for everything user-facing.
 
 ### What differs from a stable release
 
@@ -239,7 +251,7 @@ line on `main` stays authoritative for everything user-facing.
 |---|--------|---------|
 | Branch | `main` | `develop/0.5.0` |
 | Version | `X.Y.Z` | `X.Y.Z-dev.N` (`-alpha`/`-beta`/`-rc`) |
-| Assets | tarball + `.deb` + `.rpm` + AUR | tarball only |
+| Assets | Linux + macOS tarballs + `.deb` + `.rpm` + AUR | Linux + macOS tarballs |
 | GitHub Release | Latest | Pre-release, `--latest=false` |
 | `version.json` / website | updated | untouched |
 | Release PR / merge | yes (`release/*` → `main`) | none — lives on `develop` |
@@ -287,7 +299,7 @@ gh release view v0.5.0-dev.N --json isPrerelease,isLatest
 # Confirm the stable release is still "Latest"
 gh release list --limit 5
 
-# Confirm only the tarball was attached (no .deb/.rpm/AUR)
+# Confirm only the tarballs were attached (no .deb/.rpm/AUR)
 gh release view v0.5.0-dev.N --json assets --jq '.assets[].name'
 ```
 
@@ -351,12 +363,13 @@ make pre-commit
 git checkout -b release/0.5.0
 
 # 3. Drop the pre-release suffix and finalize the stable surfaces:
-#    - Cargo.toml: [workspace.package] version = "0.5.0"   (then cargo update -w)
+make bump-version VERSION=0.5.0
+#    Then by hand:
+#    - version.json: release_date
 #    - CHANGELOG.md: move "Unreleased" entries under ## [0.5.0] - YYYY-MM-DD
-#    - version.json: author 0.5.0 metadata + asset filenames (now in play)
-cargo update -w
 make pre-commit
-git add Cargo.toml Cargo.lock CHANGELOG.md version.json
+git add Cargo.toml Cargo.lock CHANGELOG.md version.json \
+        pkg/rpm/xearthlayer.spec pkg/arch/PKGBUILD
 git commit -m "Release v0.5.0"
 
 # 4. Push and open the promotion PR (base main, head release/0.5.0)
@@ -628,6 +641,16 @@ Update the comparison links at the bottom of CHANGELOG.md:
 - [ ] `version.json` updated with new version, date, and asset filenames
 - [ ] Release branch created and PR opened
 - [ ] CI passes on PR
+- [ ] **macOS verification (required for stable promotion).** CI compiles the macFUSE
+      smoke tests but cannot run them — macFUSE is a kext and hosted runners cannot
+      load it. A maintainer with Apple Silicon hardware must run:
+
+      ```bash
+      make verify-macos
+      ```
+
+      and post the output on the release PR. See
+      [CI/CD Pipeline](cicd.md#what-ci-cannot-verify) for why this gap exists.
 - [ ] Tag created and pushed (BEFORE merging PR)
 - [ ] Release workflow completes successfully
 - [ ] **Asset filenames reconciled against `version.json`** (RPM `fcNN` drift) — fix on release branch before merge if mismatched
@@ -665,7 +688,7 @@ gh release delete vX.Y.Z --yes
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/release.yml` | Main release workflow. Detects pre-release tags (`-dev`/`-alpha`/`-beta`/`-rc`) → GitHub pre-release, tarball only; stable tags → full packaging |
+| `.github/workflows/release.yml` | Main release workflow. Detects pre-release tags (`-dev`/`-alpha`/`-beta`/`-rc`) → GitHub pre-release, Linux + macOS tarballs only; stable tags → full packaging |
 | `.github/workflows/website-sync.yml` | Website notification (triggers on `release/*` merge to `main` — stable only) |
 | `.github/workflows/ci.yml` | PR/push CI checks (runs on `main` and `develop/**`, push and PR) |
 | `version.json` | Current version metadata for website |

--- a/docs/dev/cicd.md
+++ b/docs/dev/cicd.md
@@ -236,6 +236,11 @@ make bump-version VERSION=$(grep '^version' Cargo.toml | cut -d'"' -f2)
 git diff --stat   # empty == all layers agree
 ```
 
+On `develop`, the preview-release path (see the runbook's **Unstable / Preview
+Release**) deliberately hand-edits only `Cargo.toml`, so `version.json` intentionally
+lags behind it between preview bumps — the drift check is therefore meaningful on
+`main` and on `release/*` branches, not on `develop` itself.
+
 **Why drift used to go unnoticed.** `release.yml` rewrites the RPM `Version:` at build
 time and generates the AUR `PKGBUILD` from a heredoc, ignoring `pkg/arch/PKGBUILD`
 entirely. Both files are inert in CI while remaining live in the Makefile path — so

--- a/docs/dev/cicd.md
+++ b/docs/dev/cicd.md
@@ -104,8 +104,24 @@ are skipped on every pre-release tag. Jobs that always run are checked with
 
 ## Platform Support Tiers
 
-Linux and macOS are both **Tier 1 — blocking**: a failure blocks PR merge and aborts
-release publication.
+Linux and macOS are both **Tier 1**: a failure is meant to block a PR merge, and does
+abort release publication.
+
+The two halves are enforced by different mechanisms, and only one is live today:
+
+| Gate | Linux (`Verify`) | macOS (`Verify (macOS)`) |
+|------|------------------|--------------------------|
+| Aborts release publication | ✅ live — `publish` requires `package-linux` | ✅ live — `publish` requires `package-macos` |
+| Blocks a PR merge | ✅ live on `main` (required context) | ⏳ pending branch protection |
+
+Release publication is gated for both: `publish` names each packaging job in its
+`needs:` *and* its `if:` expression (see the job graph above). Merge blocking, by
+contrast, is **branch protection** — a repository setting, not a workflow. `main`
+currently requires only the `Verify` context, and `develop/0.5.0` is unprotected, so a
+red `Verify (macOS)` is visible but not merge-blocking. Adding it as a required check
+is deliberately deferred until the macOS port merges: protecting the branch while that
+job is red would block every merge, including the port itself. See
+[Status Checks and Branch Protection](#status-checks-and-branch-protection).
 
 | Platform | Arch | CI runner | Notes |
 |----------|------|-----------|-------|
@@ -168,12 +184,14 @@ Some behaviour is structurally untestable on hosted runners. Know the gaps.
 Silicon requires booting to Recovery, downgrading to Reduced Security, enabling user
 management of kexts, and rebooting. Hosted runners permit none of that.
 
-`xearthlayer/tests/macfuse_smoke.rs` is designed to be `#[ignore]`d for exactly this
-reason: CI **compiles** it — which catches API and type breakage under `-Dwarnings` —
-but never **runs** it. As of this writing that test file does not yet exist on this
+As of this writing, `xearthlayer/tests/macfuse_smoke.rs` does not yet exist on this
 branch; it ships with the macOS port (PR #202, still open against `develop/0.5.0`).
 Until that merges, `make verify-macos`'s final step has no test to run — the platform
 and macFUSE guards ahead of it still work today.
+
+Once present, the test is designed to be `#[ignore]`d for exactly this reason: CI
+**compiles** it — which catches API and type breakage under `-Dwarnings` — but never
+**runs** it, because macFUSE is a kext and hosted runners cannot load one.
 
 **Live FUSE mounts on Linux** are equally uncovered: `make verify` runs
 `cargo test` without `--ignored`, so `#[ignore]`d tests are skipped on both platforms.

--- a/docs/dev/cicd.md
+++ b/docs/dev/cicd.md
@@ -1,0 +1,249 @@
+# CI/CD Pipeline and Merge Strategy
+
+How XEarthLayer builds, tests and releases itself on GitHub Actions.
+
+This document describes the **system**. For the step-by-step procedure to cut a
+release, see the [Application Release Runbook](app-release-runbook.md). For publishing
+*scenery packages* (a separate pipeline), see
+[GitHub Releases Publishing](github-releases-publishing.md).
+
+## Branch Model
+
+Two long-lived branches, one per release channel:
+
+| Branch | Channel | Version format | Purpose |
+|--------|---------|----------------|---------|
+| `main` | Stable | `X.Y.Z` | Production releases — what most users run |
+| `develop/X.Y.Z` | Unstable | `X.Y.Z-dev.N` | The next release, including breaking changes |
+
+Work branches are named for the *kind* of change; the base branch selects the
+*channel*:
+
+- `feature/<name>` — new functionality
+- `bugfix/<issue>-<description>` — bug fixes
+- `hotfix/<description>` — urgent fix to stable (branch from `main`)
+- `chore/<description>` — tooling, docs, maintenance
+- `release/<version>` — version bump and changelog, immediately before a tag
+
+**Fixes flow one way.** Land fixes on `main`, then forward-merge `main` into the
+unstable branch. The unstable branch is never merged back into `main` until the whole
+line is promoted as a stable release. This keeps `main` releasable at any moment.
+
+## Workflows
+
+| Workflow | Triggers | Purpose |
+|----------|----------|---------|
+| `ci.yml` | push to `main`, `develop/**`, `feature/**`, `bugfix/**`, `hotfix/**`, `chore/**`; PRs to `main` and `develop/**` | Verification on every change |
+| `release-test.yml` | push and PRs on `release/*` | Same verification for release-prep branches |
+| `release.yml` | push of a `v*` tag; manual dispatch | Build, package, publish a GitHub Release |
+| `website-sync.yml` | push to `main` touching `version.json` | Notify the website repo of a new release |
+
+`ci.yml` and `release-test.yml` each run two jobs — `Verify` (Linux) and
+`Verify (macOS)`.
+
+## The Release Job Graph
+
+`release.yml` is a DAG with two independent entry points: `verify` (Linux) and
+`verify-macos` (macOS) both start directly off the tag push and run in parallel —
+neither gates the other. `publish` fans in from every packaging job, so a failure in
+any of them prevents the release from being created.
+
+```
+┌──────────┐                                    ┌────────────┐
+│  verify  │ (ubuntu; also emits release_tag/    │verify-macos│ (macos-15)
+│          │  version/prerelease)                │            │
+└────┬─────┘                                    └─────┬──────┘
+     │                                                 │
+     ├──────────────┬──────────────┐                   │
+     │              │              │                   │
+┌────▼───────┐┌──────▼─────┐┌──────▼───────┐     ┌──────▼───────┐
+│build-binary││ build-rpm  ││ prepare-aur  │     │package-macos │
+│  (ubuntu)  ││stable only ││ stable only  │     │ (macos-15)   │
+└──┬──────┬──┘└──────┬─────┘└──────┬───────┘     └──────┬───────┘
+   │      │          │             │                    │
+┌──▼───┐┌─▼─────────┐│             │                    │
+│pkg-  ││pkg-deb    ││             │                    │
+│linux ││stable only││             │                    │
+└──┬───┘└─────┬──────┘│             │                    │
+   │          │        │             │                    │
+   └──────────┴────────┴─────────────┴────────────────────┘
+                              │
+                        ┌─────▼─────┐
+                        │  publish  │
+                        └───────────┘
+```
+
+`package-macos` needs **both** `verify` and `verify-macos` (`needs: [verify,
+verify-macos]`) — it is the only packaging job with two independent parents, since it
+sits at the point where the Linux and macOS verification paths converge. Every other
+packaging job needs only `verify`, directly or transitively through `build-binary`.
+The diagram omits the direct `verify → package-macos` edge for readability; the `needs:`
+list above is the source of truth.
+
+`publish` uses `!cancelled()` plus explicit per-dependency result checks rather than
+relying on `needs:` alone:
+
+```yaml
+needs: [verify, package-linux, package-macos, package-deb, build-rpm, prepare-aur]
+if: >-
+  ${{ !cancelled()
+  && needs.verify.result == 'success'
+  && needs.package-linux.result == 'success'
+  && needs.package-macos.result == 'success'
+  && needs.package-deb.result != 'failure'
+  && needs.build-rpm.result != 'failure'
+  && needs.prepare-aur.result != 'failure' }}
+```
+
+A **skipped** dependency would otherwise skip `publish` too, and the stable-only jobs
+are skipped on every pre-release tag. Jobs that always run are checked with
+`== 'success'`; jobs that may legitimately be skipped are checked with `!= 'failure'`.
+
+**When adding a packaging job, add it to both `needs:` and this `if:`.** Adding it to
+`needs:` alone does not gate the release.
+
+## Platform Support Tiers
+
+Linux and macOS are both **Tier 1 — blocking**: a failure blocks PR merge and aborts
+release publication.
+
+| Platform | Arch | CI runner | Notes |
+|----------|------|-----------|-------|
+| Linux | x86_64 | `ubuntu-latest` | Primary development platform |
+| macOS | arm64 (Apple Silicon) | `macos-15` | Intel is untested and not built |
+
+macOS is Apple Silicon only. GitHub does offer native Intel runners
+(`macos-15-intel`), but no maintainer flight-tests XEarthLayer on an Intel Mac, and a
+blocking gate on unvalidated hardware is worse than no gate.
+
+The macOS runner is pinned to `macos-15`, not `macos-latest`. That label has moved
+across both OS versions and CPU architectures; with a pinned `fuse3` fork and an
+ISPC-backed encoder, a silent bump would surface as an unexplained failure on an
+unrelated PR.
+
+**macOS jobs install no dependencies.** The pinned `fuse3` fork is pure Rust — no
+`build.rs`, no `pkg-config`, no `cc` — and `xearthlayer/build.rs` already emits `-lc++`
+on macOS. macFUSE is required only at runtime.
+
+## Release Channels
+
+| Channel | Tag | GitHub Release | Assets |
+|---------|-----|----------------|--------|
+| Stable | `vX.Y.Z` | Latest | Linux tarball, macOS tarball, `.deb`, `.rpm`, AUR |
+| Pre-release | `vX.Y.Z-dev.N`, `-alpha.N`, `-beta.N`, `-rc.N` | Pre-release, never "Latest" | Linux tarball, macOS tarball |
+
+`verify` classifies the tag and emits a `prerelease` output; `package-deb`,
+`build-rpm` and `prepare-aur` are gated on it.
+
+**Why those three are stable-only — do not "fix" this.** It is not policy, it is a
+format constraint. RPM uses `-` to delimit `Version` from `Release`, so
+`Version: 0.5.0-dev.1` is malformed. Arch's `pkgver` forbids hyphens outright. Neither
+can represent a pre-release version at all. Tarballs have no such constraint, which is
+why both ship on every channel.
+
+## Status Checks and Branch Protection
+
+`main` requires the status check context **`Verify`** — an exact string match.
+
+This constrains the pipeline's shape. GitHub Actions names matrix jobs
+`Verify (ubuntu-latest)`, `Verify (macos-15)`. Converting the `verify` job to a matrix
+would mean the required context `Verify` never reports again, and **merges to `main`
+would hang forever** waiting for a check that no longer exists.
+
+That is why macOS is a separate, explicitly-named job rather than a matrix dimension.
+Never rename or matrix-ify `verify`.
+
+Required contexts:
+
+| Branch | Required checks |
+|--------|-----------------|
+| `main` | `Verify` |
+| `develop/0.5.0` | `Verify`, `Verify (macOS)` — planned, pending the macOS port merge |
+
+## What CI Cannot Verify
+
+Some behaviour is structurally untestable on hosted runners. Know the gaps.
+
+**macFUSE mounts.** macFUSE is a kernel extension. Loading a third-party kext on Apple
+Silicon requires booting to Recovery, downgrading to Reduced Security, enabling user
+management of kexts, and rebooting. Hosted runners permit none of that.
+
+`xearthlayer/tests/macfuse_smoke.rs` is designed to be `#[ignore]`d for exactly this
+reason: CI **compiles** it — which catches API and type breakage under `-Dwarnings` —
+but never **runs** it. As of this writing that test file does not yet exist on this
+branch; it ships with the macOS port (PR #202, still open against `develop/0.5.0`).
+Until that merges, `make verify-macos`'s final step has no test to run — the platform
+and macFUSE guards ahead of it still work today.
+
+**Live FUSE mounts on Linux** are equally uncovered: `make verify` runs
+`cargo test` without `--ignored`, so `#[ignore]`d tests are skipped on both platforms.
+
+The human gates that close these holes:
+
+| Command | Covers | When |
+|---------|--------|------|
+| `make verify` | fmt, clippy, unit and integration tests | Every commit; both CI platforms |
+| `make verify-macos` | `make verify` plus live macFUSE mount tests | Before promoting a release to stable, on real Apple Silicon |
+| `make integration-tests` | `#[ignore]`d integration tests | Manually, on real hardware |
+
+## Version Propagation
+
+Five files carry the version. `make bump-version VERSION=<semver>` is the single tool
+that updates them, and it writes **two different forms**:
+
+| File | Form | Example for `0.5.0-dev.1` |
+|------|------|---------------------------|
+| `Cargo.toml` | Full semver | `0.5.0-dev.1` |
+| `Cargo.lock` | Full semver | `0.5.0-dev.1` |
+| `version.json` | Full semver | `0.5.0-dev.1` |
+| `pkg/rpm/xearthlayer.spec` | Base version | `0.5.0` |
+| `pkg/arch/PKGBUILD` | Base version | `0.5.0` |
+
+The base form exists for the hyphen constraint described under Release Channels.
+
+`version.json`'s RPM asset filename also embeds the Fedora release tag the CI
+container resolves to (e.g. `fc44`). `bump-version` cannot know that tag in advance, so
+it reads the current one back out of the existing `version.json` and carries it
+forward into the new filename. If it cannot extract a valid `fcNN` tag — a missing or
+malformed `.assets.rpm.filename` — it **aborts with an error** rather than silently
+writing a corrupted filename. See the runbook's RPM 404 troubleshooting entry for the
+scenario (a Fedora base-image upgrade) this guards against.
+
+`version.json` `release_date` is **not** automated. Excluding it preserves a useful
+invariant: running `make bump-version VERSION=<current>` on a synchronised tree
+produces no diff, so the target doubles as a drift detector.
+
+```bash
+make bump-version VERSION=$(grep '^version' Cargo.toml | cut -d'"' -f2)
+git diff --stat   # empty == all layers agree
+```
+
+**Why drift used to go unnoticed.** `release.yml` rewrites the RPM `Version:` at build
+time and generates the AUR `PKGBUILD` from a heredoc, ignoring `pkg/arch/PKGBUILD`
+entirely. Both files are inert in CI while remaining live in the Makefile path — so
+`pkg/rpm/xearthlayer.spec` sat at `0.2.5` and `pkg/arch/PKGBUILD` at `0.2.0` while CI
+published correct artifacts, and `make pkg-rpm` quietly produced an RPM labelled
+`0.2.5`. Both files have since been swept to `0.5.0`; `make bump-version` and its
+idempotence check above exist to keep it from recurring.
+
+## Secrets and External Repositories
+
+| Secret | Used by | Notes |
+|--------|---------|-------|
+| `GITHUB_TOKEN` | `release.yml` | Automatic; creates the release and uploads assets |
+| `AUR_SSH_PRIVATE_KEY` | `release.yml` | Optional. Absent, the AUR files are attached to the release for manual submission |
+| `WEBSITE_DISPATCH_TOKEN` | `website-sync.yml` | 90-day PAT. **Expiry is silent** — the website then lags by up to 24h until the daily fallback cron runs |
+
+### The `version.json` contract
+
+`version.json` on `main` is the interface to `samsoir/xearthlayer-website`. The website's
+`sync-version.yml` fetches it, extracts specific keys with `jq`, and rewrites its own
+`data/release.json`.
+
+It reads exactly `deb`, `rpm` and `tarball` and ignores everything else — `aur` is
+already carried in `version.json` and silently dropped. Adding a key is therefore safe,
+but a new asset will not appear on the website until that workflow is taught to read it.
+
+Website updates fire on a push to `main` that changes `version.json`, gated on the
+commit message indicating a `release/*` branch merge — so merging a release PR is what
+triggers the site, not the release workflow itself.

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Sam de Freyssinet <sam@def.reyssi.net>
 pkgname=xearthlayer
-pkgver=0.2.0
+pkgver=0.5.0
 pkgrel=1
 pkgdesc="High-quality satellite imagery for X-Plane, streamed on demand"
 arch=('x86_64')

--- a/pkg/rpm/xearthlayer.spec
+++ b/pkg/rpm/xearthlayer.spec
@@ -1,5 +1,5 @@
 Name:           xearthlayer
-Version:        0.2.5
+Version:        0.5.0
 Release:        1%{?dist}
 Summary:        High-quality satellite imagery for X-Plane, streamed on demand
 

--- a/version.json
+++ b/version.json
@@ -16,6 +16,10 @@
       "filename": "xearthlayer-v0.4.6-x86_64-linux.tar.gz",
       "description": "Linux binary tarball"
     },
+    "macos_tarball": {
+      "filename": "xearthlayer-v0.4.6-arm64-macos.tar.gz",
+      "description": "macOS (Apple Silicon) binary tarball"
+    },
     "aur": {
       "filename": "aur-package.zip",
       "description": "Arch Linux AUR package"

--- a/version.json
+++ b/version.json
@@ -1,23 +1,23 @@
 {
-  "version": "0.4.6",
-  "tag": "v0.4.6",
-  "release_date": "2026-05-10",
+  "version": "0.5.0-dev.0",
+  "tag": "v0.5.0-dev.0",
+  "release_date": "2026-07-27",
   "homepage": "https://xearthlayer.app",
   "assets": {
     "deb": {
-      "filename": "xearthlayer_0.4.6-1_amd64.deb",
+      "filename": "xearthlayer_0.5.0-dev.0-1_amd64.deb",
       "description": "Debian/Ubuntu package"
     },
     "rpm": {
-      "filename": "xearthlayer-0.4.6-1.fc44.x86_64.rpm",
+      "filename": "xearthlayer-0.5.0-dev.0-1.fc44.x86_64.rpm",
       "description": "Fedora/RHEL package"
     },
     "tarball": {
-      "filename": "xearthlayer-v0.4.6-x86_64-linux.tar.gz",
+      "filename": "xearthlayer-v0.5.0-dev.0-x86_64-linux.tar.gz",
       "description": "Linux binary tarball"
     },
     "macos_tarball": {
-      "filename": "xearthlayer-v0.4.6-arm64-macos.tar.gz",
+      "filename": "xearthlayer-v0.5.0-dev.0-arm64-macos.tar.gz",
       "description": "macOS (Apple Silicon) binary tarball"
     },
     "aur": {
@@ -25,5 +25,5 @@
       "description": "Arch Linux AUR package"
     }
   },
-  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.6"
+  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.5.0-dev.0"
 }


### PR DESCRIPTION
## Summary

Makes macOS a **Tier 1 platform** in the CI/CD pipeline, ahead of merging #202 (the macOS port), and brings every version-carrying file on `develop/0.5.0` into `0.5.x` agreement.

> **Expected red check.** `Verify (macOS)` fails on this branch because `develop/0.5.0` contains no `cfg(target_os = "macos")` code — that all arrives with #202. This is deliberate. Because `pull_request` workflows run from the merge ref, **#202's own run compiles `develop/0.5.0` + #202 together and should go green** — which is precisely the automated macOS evidence this branch exists to provide. The red window closes when #202 merges.

## Changes

- **CI** — new blocking `Verify (macOS)` job on pinned `macos-15` in `ci.yml` and `release-test.yml`. The existing `Verify` job is deliberately untouched: `main`'s branch protection requires that *exact* status context, and GitHub renames matrix jobs (`Verify (ubuntu-latest)`), so a matrix would leave merges to `main` waiting forever on a check that never reports.
- **Release** — `verify-macos` + `package-macos` jobs. `publish` is gated on `package-macos` in **both** its `needs:` list and its `if:` expression, because that gate uses `!cancelled()` plus per-job result checks so it still runs when the stable-only jobs are skipped on a pre-release tag — `needs:` alone would not block publication. Ships `xearthlayer-<tag>-arm64-macos.tar.gz` on both channels. Build and package are fused into one job: `actions/upload-artifact` does not preserve the executable bit, so the tarball is created before upload rather than `chmod`'d after download.
- **`make verify-macos`** — guards on macOS and macFUSE, runs `make verify`, then the live `macfuse_smoke` tests that CI structurally cannot execute (macFUSE is a kernel extension; hosted runners cannot load one). This is the human half of the Tier 1 gate.
- **`make bump-version` repaired** — GNU-only `sed -i` replaced with a portable rewrite (it was simply broken under BSD sed on macOS); coverage widened from 2 files to 5; two version forms, since RPM uses `-` to delimit `Version` from `Release` and Arch `pkgver` forbids hyphens:

  | Target | Form |
  |---|---|
  | `Cargo.toml`, `Cargo.lock`, `version.json` | full semver (`0.5.0-dev.0`) |
  | `pkg/rpm/xearthlayer.spec`, `pkg/arch/PKGBUILD` | hyphen-stripped base (`0.5.0`) |

  It also validates the Fedora tag (`fcNN`) read back from `version.json` **before writing any file**, so a malformed value aborts cleanly instead of leaving a half-bumped tree.
- **Version sweep** — `version.json` `0.4.6` → `0.5.0-dev.0`, `pkg/rpm/xearthlayer.spec` `0.2.5` → `0.5.0`, `pkg/arch/PKGBUILD` `0.2.0` → `0.5.0`. Those last two had drifted invisibly: CI rewrites the RPM `Version:` at build time and generates the AUR `PKGBUILD` from a heredoc, so their staleness never surfaced — while `make pkg-rpm`, which does *not* rewrite, was producing an RPM labelled `0.2.5`. The root cause was `bump-version` never knowing those files existed, which is why the tool fix and the sweep are both here.
- **Docs** — new `docs/dev/cicd.md` (pipeline and merge-strategy reference: branch model, release job graph, platform tiers, release channels, status checks, version propagation). Runbook, `CONTRIBUTING.md`, `CLAUDE.md` and `CHANGELOG.md` updated. The runbook's release procedures now point at `make bump-version` and stage all five files — three `git add` lists were silently invalidated when the tool's coverage widened.

## Related Issues

- Related: #201 (macOS support)
- Related: #202 (macOS port — this branch is its CI/CD prerequisite and provides the automated macOS evidence for approving it)

## Test Plan

- [x] `make pre-commit` passes (fmt + clippy + tests) — ~2398 lib tests, 0 failures, at the branch tip
- [x] `bump-version` idempotence: re-running at the current version yields an **empty** diff. Because `release_date` is deliberately left manual, this doubles as a drift detector
- [x] Fedora-tag guard verified *firing*: missing `.assets.rpm`, malformed JSON, filename with no `fcNN`, and empty file all abort non-zero with `version.json` left unmodified
- [x] `make verify-macos` platform guard exits non-zero on Linux in milliseconds without invoking cargo
- [x] Workflow YAML validated with `actionlint`; the `publish` DAG and `if:` gate asserted programmatically against the parsed YAML
- [x] macOS tarball filename cross-checked between `release.yml`, `bump-version`'s `jq` filter, and `version.json` — all three agree, so no 404 download link
- [ ] **Requires Apple Silicon** — `make bump-version` under BSD sed, and `make verify-macos`'s full path (needs macFUSE installed plus `tests/macfuse_smoke.rs`, which arrives with #202)
- [ ] **First `v0.5.0-dev.N` tag** — confirm the macOS tarball appears as a release asset and that `publish` waited on `package-macos`

## Checklist

- [x] Code follows the project's SOLID principles and patterns — no Rust source changed
- [x] Tests added or updated for new/changed behavior
- [x] Documentation updated if applicable (CLAUDE.md, docs/, config reference)
- [x] No new warnings from `cargo clippy`

## Follow-ups (not in this PR)

1. **Branch protection on `develop/0.5.0`** requiring `Verify` + `Verify (macOS)` — must wait until #202 merges, since protecting the branch while that job is red would block every merge including #202 itself.
2. **`docs/macos.md` Gatekeeper note** (`xattr -dr com.apple.quarantine`) — that file arrives with #202.
3. **Website `macos_tarball` support** — `sync-version.yml` reads only `deb`/`rpm`/`tarball`, so the macOS asset ships with no download link on the site. Verified non-breaking (unknown keys are ignored, as `aur` already is), but needs tracking.
4. **Website `aur` shortcode** renders a broken URL — pre-existing; `getting-started.md` references an asset key the sync never writes.
5. **Homebrew tap** — would sidestep Gatekeeper entirely by building from source.
6. **`make pkg-tarball` vs CI tarball naming** disagree on the `v` prefix — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
