### PR TITLE
feat(metrics): periodic memory telemetry and log verbosity cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,5 +446,6 @@ CI will fail if pre-commit checks were not run.
 - Zoom level overlap management: `docs/dev/zoom-level-overlap-design.md` (dedupe, gap analysis)
 - **Consolidated FUSE mounting**: `docs/dev/consolidated-mounting-design.md` (single ortho mount, patches + packages)
 - **GeoIndex design**: `docs/dev/geo-index-design.md` (geospatial reference database, patch region ownership)
+- **Memory telemetry**: `docs/dev/memory-telemetry.md` (periodic memory sampling, trace interpretation, confounders)
 - memorize review allow(dead_code) macros at major checkpoints. Refactor aggresively to remove them when appropriate.
 - memorize ensure to update the projects documentation to reflect the current state of the project before committing changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -963,7 +963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2049,6 +2049,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "metal"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,7 +2206,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2986,7 +2996,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2999,7 +3009,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3281,7 +3291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3404,7 +3414,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4284,7 +4294,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4748,6 +4758,7 @@ dependencies = [
  "image",
  "intel_tex_2",
  "libc",
+ "memory-stats",
  "moka",
  "nix",
  "parking_lot",

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -53,6 +53,7 @@ Technical documentation for XEarthLayer developers and contributors.
 |----------|-------------|
 | [Debug Map](debug-map.md) | Live browser map for prefetch observability (`--features debug-map`) |
 | [Memory Profiling](memory-profiling.md) | Heaptrack profiling guide for memory optimization |
+| [Memory Telemetry](memory-telemetry.md) | Periodic in-process memory sampling for long-flight diagnosis (v0.4.7+) |
 | [Application Release Runbook](app-release-runbook.md) | Release workflow, versioning, and troubleshooting |
 
 ## Root Cause Analysis

--- a/docs/dev/memory-profiling.md
+++ b/docs/dev/memory-profiling.md
@@ -2,6 +2,10 @@
 
 This guide covers how to profile XEarthLayer's memory usage using [heaptrack](https://github.com/KDE/heaptrack), a Linux heap memory profiler that tracks allocations, identifies peak consumers, and detects leaks.
 
+> For long unattended flights, or when the process may be killed by the OOM
+> killer, use [Memory Telemetry](memory-telemetry.md) instead — heaptrack loses
+> all data on `kill -9`.
+
 ## Installation
 
 ```bash

--- a/docs/dev/memory-telemetry.md
+++ b/docs/dev/memory-telemetry.md
@@ -29,7 +29,9 @@ so that a single unattended flight discriminates between them:
    storage through `tokio::fs`, which queues on the tokio blocking pool. Neither
    spawn is gated by the executor's `max_concurrent_jobs` or by any
    `ResourcePool` permit, so if the blocking pool saturates the queue and its
-   buffers grow without limit.
+   buffers grow without limit. The two spawns are independently observable as
+   `disk_writes_active` and `mem_cache_writes_active` respectively — a backlog
+   in either one is this candidate.
 2. **glibc arena retention.** An 11.2 MB buffer sits just below glibc's adaptive
    `mmap` threshold ceiling of 32 MB. Once the threshold has adapted upward past
    the buffer size, those allocations are served from per-thread arenas rather
@@ -41,10 +43,10 @@ so that a single unattended flight discriminates between them:
 ## The sample line
 
 ```
-2026-08-06 06:20:33Z  INFO Memory sample uptime_s=60 rss_mb=873 vm_mb=1459 threads=71 tiles_done=0 encodes_active=0 chunks_ok=0 chunks_failed=0 mem_cache_mb=0 dds_disk_mb=158268 chunk_disk_mb=55301 gc_evicted_mb=0 chunk_index_entries=3803083 disk_writes_active=0
+2026-08-06 06:20:33Z  INFO Memory sample uptime_s=60 rss_mb=873 vm_mb=1459 swap_mb=0 threads=71 tiles_done=0 encodes_active=0 chunks_ok=0 chunks_failed=0 mem_cache_mb=0 dds_disk_mb=158268 chunk_disk_mb=55301 gc_evicted_mb=0 chunk_index_entries=3803083 disk_writes_active=0 mem_cache_writes_active=0
 ```
 
-Fourteen fields, in emission order. Every `_mb` value is truncating integer
+Sixteen fields, in emission order. Every `_mb` value is truncating integer
 division by 1 MiB (1 048 576 bytes), so a value of `0` means "under one
 mebibyte", not necessarily "nothing".
 
@@ -53,6 +55,7 @@ mebibyte", not necessarily "nothing".
 | `uptime_s` | `AggregatedState::uptime()` | Whole seconds since the metrics daemon started, which is effectively service start. Use it as the x-axis. |
 | `rss_mb` | `MemoryProbe` → sum of `Rss:` in `/proc/self/smaps` | Physical pages currently held. **Excludes anything the kernel has swapped out.** |
 | `vm_mb` | `MemoryProbe` → sum of `Size:` in `/proc/self/smaps` | Total mapped address space. Counts anonymous mappings whether resident or paged out. |
+| `swap_mb` | `MemoryProbe` → `/proc/self/status` `VmSwap:` | Anonymous memory swapped out to disk. **This is the field that actually caught #209**: at the moment of the kill, `rss_mb` alone read a healthy 9.3 GB while `swap_mb` would have read 54.7 GB. `0` means **not readable on this platform**, not "nothing swapped" — same convention as `threads`. Linux-only; read in the same `/proc/self/status` pass as `threads`, so it costs no extra file open. |
 | `threads` | `/proc/self/status` `Threads:` | OS thread count. `0` means **not readable on this platform**, not "no threads" — see below. |
 | `tiles_done` | `state.encodes_completed` | Cumulative DDS encodes completed. The load counter: divide by `uptime_s` for tiles/second. |
 | `encodes_active` | `state.encodes_active` | Encodes in flight right now. Each one holds a 4096×4096 RGBA source image (64 MiB) plus its output buffer. |
@@ -62,35 +65,80 @@ mebibyte", not necessarily "nothing".
 | `dds_disk_mb` | `state.dds_disk_cache_size_bytes` | Current DDS disk tier size, from that tier's LRU index. |
 | `chunk_disk_mb` | `state.chunk_disk_cache_size_bytes` | Current chunk disk tier size, from that tier's LRU index. |
 | `gc_evicted_mb` | `state.disk_bytes_evicted` | Cumulative bytes freed by the disk GC daemons, **summed across both disk tiers**. |
-| `chunk_index_entries` | `state.chunk_index_entries` | Live entries in the **chunk** tier's `LruIndex`. The DDS tier does not report this. |
+| `chunk_index_entries` | `state.chunk_index_entries` | Live entries in the **chunk** tier's `LruIndex`. The DDS tier does not report this. Refreshed on every chunk-tier set/delete and once at startup (`DiskCacheProvider::report_size_to_metrics`), **but the GC batch task (`tasks/cache_gc_batch.rs`) removes entries from the index directly and does not call it**, so this gauge can lag behind the true index size during heavy GC — a burst of evictions may not be reflected until the next unrelated set/delete nudges a report. See the bytes-per-entry estimate below for translating a raw count into an approximate memory footprint. |
 | `disk_writes_active` | `state.disk_writes_active` | Fire-and-forget disk cache writes currently in flight, counting both chunk writes from `DownloadChunksTask` and DDS tile writes from `BuildAndCacheDdsTask`. |
+| `mem_cache_writes_active` | `state.mem_cache_writes_active` | Fire-and-forget **memory**-cache writes currently in flight — the `cache.put()` spawn in `BuildAndCacheDdsTask`, mirroring `disk_writes_active` but for the moka tier. Added specifically because this spawn previously emitted no start/complete pair at all (only `mem_cache_mb`, which only moves after the write completes), which meant a backlog concentrated there was invisible and would misread as candidate 2 (allocator retention). See the decision table below. |
+
+### Estimating `chunk_index_entries` memory footprint
+
+`chunk_index_entries` is a raw count, not a byte figure, so it is easy to
+misjudge whether 12 million entries means roughly 1 GB or roughly 10 GB. The
+index is `DashMap<String, CacheEntryMetadata>` (`cache/lru_index.rs`), and
+per entry, on a 64-bit build, roughly:
+
+- `CacheEntryMetadata` value: `size_bytes: u64` (8 bytes) + `last_accessed:
+  Instant` (16 bytes) ≈ **24 bytes**.
+- `String` key struct (ptr/len/cap): **24 bytes**, plus a separate heap
+  allocation for the key text itself. Chunk keys look like
+  `"chunk:15:12754:5279:8:12"` (~25 bytes); with allocator rounding, call it
+  **~32–48 bytes**.
+- `DashMap`/`hashbrown` bucket overhead (control bytes, load-factor slack):
+  a few bytes per entry, **negligible** at this scale.
+
+Summing to roughly **80–100 bytes per entry**, 12 million entries is
+approximately **1–1.2 GB** — order-of-magnitude closer to 1 GB than 10 GB.
+**This is an order-of-magnitude estimate derived from the type definitions,
+not a measurement** (no allocator introspection or heap profiler was run to
+confirm it); treat it as a sanity check on `chunk_index_entries`, not a
+precise accounting figure.
 
 ### `threads=0` means unreadable, not zero
 
 Thread count is read from `/proc/self/status`, which only exists on Linux.
 `memory-stats` does not expose a thread count, and hand-rolling mach FFI for
 macOS was judged not worth the risk on a CI-blocking platform, so
-`ProcessMemoryProbe::thread_count()` returns `None` everywhere except Linux and
-the emit line renders `None` as `0`. A macOS trace will show `threads=0` on
-every line; that tells you nothing about the process.
+`ProcessMemoryProbe::linux_status_fields()` returns `(None, None)` everywhere
+except Linux and the emit line renders `None` as `0` for both `threads` and
+`swap_mb`. A macOS trace will show `threads=0` and `swap_mb=0` on every line;
+that tells you nothing about the process.
 
-### `rss_mb` and `vm_mb` are not interchangeable
+### `vm_mb` on macOS is not comparable to the Linux figure
+
+On macOS, `vm_bytes` comes from mach `task_info`'s virtual size, which
+includes the entire shared address space (shared libraries, framework
+mappings, and other machinery the Linux `Size:` figure does not count the same
+way). It routinely reads in the hundreds of gigabytes for an otherwise
+ordinary process and is **not a meaningful growth signal** on that platform —
+do not compare a macOS `vm_mb` trend against a Linux one, and do not read a
+large absolute macOS `vm_mb` as evidence of anything by itself.
+
+### `rss_mb` and `vm_mb` are not interchangeable — and neither is enough alone
 
 `rss_mb` counts resident pages only. On a machine that is swapping — which is
 exactly the machine that is about to be OOM-killed — a growing process can show
 a **flat or falling** `rss_mb` while the kernel quietly moves its pages to swap.
 In the #209 flight only 9.3 GB of the 64 GB was resident at the moment of the
-kill.
+kill; `rss_mb` alone would have read as healthy right up to the `SIGKILL`.
 
 `vm_mb` counts the whole mapping regardless of residency, so it keeps rising.
 The gap between the two is lazily-reserved-but-never-touched address space plus
-anything paged out. A widening `vm_mb - rss_mb` gap on a system with swap
-enabled is the signal that matters; do not read `rss_mb` alone.
+anything paged out.
+
+`swap_mb` closes this gap directly: it is anonymous memory the kernel has
+actually swapped out, read straight from `VmSwap:` in the same
+`/proc/self/status` pass as `threads`. **Watch `rss_mb + swap_mb`, not
+`rss_mb` alone** — that sum is what actually tracks the process's total
+anonymous footprint, and it is what would have shown the #209 flight climbing
+toward 64 GB instead of sitting at a reassuring 9.3 GB. A widening
+`vm_mb - (rss_mb + swap_mb)` gap on top of that is lazily-reserved address
+space that was never touched at all.
 
 ### The allocator environment line
 
-`log_allocator_environment()` runs once at startup from `CliRunner::log_startup`
-and emits a line only when at least one of `MALLOC_ARENA_MAX`,
+`log_allocator_environment()` runs from `CliRunner::log_startup`, whose only
+caller is the `run` command (`xearthlayer-cli/src/commands/run.rs`) — it does
+**not** run for every subcommand, only when actually starting the service. It
+emits a line only when at least one of `MALLOC_ARENA_MAX`,
 `MALLOC_MMAP_THRESHOLD_` or `MALLOC_TRIM_THRESHOLD_` is set:
 
 ```
@@ -104,29 +152,35 @@ behaviour. Always check for it before comparing two traces.
 
 ## Reading a trace
 
-Plot `rss_mb`, `vm_mb`, `disk_writes_active` and `chunk_index_entries` against
-`uptime_s`. The shape of the first against the other three is what
-discriminates the three candidates.
+Plot `rss_mb`, `swap_mb`, `vm_mb`, `disk_writes_active`,
+`mem_cache_writes_active` and `chunk_index_entries` against `uptime_s`. Treat
+`rss_mb + swap_mb` as the real growth signal (see above), and read its shape
+against the other four — **both** active-write gauges, not just the disk one
+— to discriminate the three candidates.
 
-| `rss_mb` / `vm_mb` | `disk_writes_active` | `chunk_index_entries` | Reading |
-|--------------------|----------------------|-----------------------|---------|
-| climbing | climbing | any | **Candidate 1** — the fire-and-forget cache-write backlog in `tasks/build_and_cache_dds.rs`. Each queued write pins ~11.2 MB, and the paired memory-cache write pins another ~11.2 MB that this gauge does not count. |
-| climbing | flat | climbing | **Candidate 3** — chunk LRU index growth. Cross-check that `chunk_disk_mb` is at its configured ceiling and `gc_evicted_mb` is rising: an index that grows while the tier size is pinned means entries are accumulating faster than GC removes them. |
-| climbing | flat | flat | **Candidate 2** — allocator retention. Nothing in the process is holding more logical data, but the resident footprint grows anyway. Confirm by re-running with `MALLOC_MMAP_THRESHOLD_=1048576`; if growth stops, glibc was hoarding freed buffers in per-thread arenas. |
+| `rss_mb + swap_mb` | `disk_writes_active` | `mem_cache_writes_active` | `chunk_index_entries` | Reading |
+|---------------------|-----------------------|-----------------------------|-------------------------|---------|
+| climbing | climbing | any | any | **Candidate 1** — the fire-and-forget **DDS-disk** cache-write backlog in `tasks/build_and_cache_dds.rs`. Each queued write pins ~11.2 MB. |
+| climbing | any | climbing | any | **Candidate 1** — the fire-and-forget **memory**-cache-write backlog in the same task. Each queued write pins its own ~11.2 MB clone, separately from the disk-write backlog above. |
+| climbing | flat | flat | climbing | **Candidate 3** — chunk LRU index growth. Cross-check that `chunk_disk_mb` is at its configured ceiling and `gc_evicted_mb` is rising: an index that grows while the tier size is pinned means entries are accumulating faster than GC removes them. Remember `chunk_index_entries` can lag during heavy GC (see field table), so confirm with `gc_evicted_mb` rather than reading a momentarily-flat count as proof nothing changed. |
+| climbing | flat | flat | flat | **Candidate 2** — allocator retention. Nothing in the process is holding more logical data, but the resident footprint grows anyway. Confirm by re-running with `MALLOC_MMAP_THRESHOLD_=1048576`; if growth stops, glibc was hoarding freed buffers in per-thread arenas. **This conclusion requires `mem_cache_writes_active` to be flat, not just `disk_writes_active`.** Before `mem_cache_writes_active` existed, this exact disk-flat/index-flat shape was reachable with a backlog concentrated entirely in the uncounted memory-cache spawn — rss climbing while both older gauges sat flat — and would have been misdiagnosed as candidate 2 when it was actually candidate 1. |
 
 Supporting reads:
 
-- **`disk_writes_active` is a lower bound.** The counter is incremented by the
-  first statement *inside* each spawned write task, so a write that has been
-  spawned but not yet polled is invisible. If the tokio worker threads are
-  themselves starved, the real backlog is larger than the number printed.
+- **`disk_writes_active` and `mem_cache_writes_active` are both lower bounds.**
+  Each counter is incremented by the first statement *inside* its spawned
+  write task, so a write that has been spawned but not yet polled is
+  invisible to either gauge. If the tokio worker threads are themselves
+  starved, the real backlog is larger than the numbers printed — for both
+  tiers.
 - **`encodes_active` × 64 MiB is the floor of what encoding costs.** Each
   in-flight encode holds a 4096×4096 RGBA source image (64 MiB) plus its output
   buffer. The number should track the CPU resource pool capacity; if it runs
   materially above that, CPU admission control is not bounding the pipeline and
   the peak is unbounded with it.
 - **`threads`** climbing toward 512 points at the tokio blocking pool (default
-  512 threads) filling up, which is the mechanism behind candidate 1.
+  512 threads) filling up, which is one of the mechanisms behind candidate 1
+  (the DDS-disk write path queues onto it via `tokio::fs`).
 - **`tiles_done` per hour** is the load normaliser. Two traces at wildly
   different tile rates are not telling you about memory, they are telling you
   about workload.
@@ -174,9 +228,12 @@ regime:
    present in only one?
 5. **`tiles_done / uptime_s`** — comparable tile rates.
 
-Only then is a difference in `rss_mb` attributable to the change under test.
-Change one variable per flight. To test candidate 2 properly, the allocator
-override must be flown against a cache that is already full and evicting.
+Only then is a difference in `rss_mb + swap_mb` attributable to the change
+under test. Change one variable per flight. To test candidate 2 properly, the
+allocator override must be flown against a cache that is already full and
+evicting, **and** with `mem_cache_writes_active` confirmed flat throughout —
+otherwise a memory-cache-write backlog (candidate 1) is still on the table and
+the retest proves nothing about the allocator.
 
 ## Submitting a trace
 
@@ -226,14 +283,19 @@ pub trait MemoryProbe: Send + Sync {
 }
 ```
 
-`MemorySample` carries `rss_bytes`, `vm_bytes` and `threads: Option<u64>`.
-Returning `Option` rather than a `Result` is deliberate: a platform that cannot
-supply a reading is not an error condition, it just means no sample line.
+`MemorySample` carries `rss_bytes`, `vm_bytes`, `threads: Option<u64>` and
+`swap_bytes: Option<u64>`. Returning `Option` rather than a `Result` is
+deliberate: a platform that cannot supply a reading is not an error condition,
+it just means no sample line (or, for the two `Option` fields, no value for
+just that field).
 
 `ProcessMemoryProbe` is the production implementation. It delegates to the
 `memory-stats` crate for the byte counts (Linux, macOS and Windows; on Unix its
-only dependency is `libc`, already in the tree) and reads thread count itself
-from `/proc/self/status` on Linux only.
+only dependency is `libc`, already in the tree) and reads thread count and
+swap bytes itself from `/proc/self/status` on Linux only, via
+`ProcessMemoryProbe::linux_status_fields()` — a single read of the file that
+extracts both the `Threads:` and `VmSwap:` lines in one pass, so adding
+`swap_bytes` did not add a second file open per sample.
 
 ### The `memory-stats` initialisation workaround
 
@@ -254,6 +316,13 @@ producing a silent, non-erroring reading of `physical_mem = 0` and
 has completed before any concurrent use. Without it, the first sample of a run
 can be a plausible-looking `rss_mb=0 vm_mb=0`.
 
+As defense in depth for exactly this failure mode, `log_memory_sample` in
+`metrics/daemon.rs` also treats a returned sample with `rss_bytes == 0` as
+equivalent to `None` (same warn-once path, no line emitted), rather than
+trusting the `Once` alone. A `rss_mb=0` line in a trace would otherwise read
+as "process using no memory" instead of "reading failed" — the same class of
+silently-misleading zero this `Once` exists to prevent.
+
 ### Injection and sampling cadence
 
 `MetricsDaemon::new` wires in `ProcessMemoryProbe`; `with_memory_probe` takes an
@@ -271,9 +340,12 @@ to reconcile before two traces could be compared — precisely the failure mode
 described above. Both intervals use `MissedTickBehavior::Skip` so a stalled
 daemon does not emit a burst of catch-up samples.
 
-If the probe returns `None`, the daemon logs one warning
-(`"Memory probe unavailable; memory samples disabled"`), latches
-`memory_probe_failed`, and emits nothing further. The warning is not repeated.
+If the probe returns `None`, **or returns `Some` with `rss_bytes == 0`**, the
+daemon logs one warning (`"Memory probe unavailable; memory samples
+disabled"`), latches `memory_probe_failed`, and emits nothing further for that
+tick. The warning is not repeated, but the probe is retried every subsequent
+tick — a later tick returning a valid reading resumes normal sampling without
+re-latching anything.
 
 Because `MetricsSystem::new` is constructed unconditionally in
 `XEarthLayerService::start`, memory sampling is active for every run, including
@@ -281,18 +353,26 @@ TUI mode.
 
 ### Adding a platform implementation
 
-To add thread count (or any other field) for a new platform:
+To add thread count, swap, or any other field for a new platform:
 
-1. Add a `#[cfg(target_os = "…")]` branch to `ProcessMemoryProbe::thread_count`.
-   The existing `#[cfg(not(target_os = "linux"))]` fallback returns `None`, so
-   nothing breaks if you add a platform and forget a branch — the field just
-   renders as `0`.
+1. Add a `#[cfg(target_os = "…")]` branch to
+   `ProcessMemoryProbe::linux_status_fields` (or a differently-named
+   platform-specific reader, if the new platform's data doesn't come from a
+   single `/proc`-style file the way Linux's does). The existing
+   `#[cfg(not(target_os = "linux"))]` fallback returns `(None, None)`, so
+   nothing breaks if you add a platform and forget a branch — the fields just
+   render as `0`.
 2. Extend `MemorySample` if the platform can supply something the others cannot.
    Any new field must be `Option`-typed with an emit-time default, so a trace
    from one platform stays diffable against a trace from another.
 3. Add the field to the `tracing::info!` call in `log_memory_sample` **at the
-   end** of the field list. Existing field positions are what makes traces from
-   different builds comparable by eye.
+   end** of the field list, once the format has shipped in a release. Existing
+   field positions are what makes traces from different builds comparable by
+   eye. (`swap_mb` and `mem_cache_writes_active` were inserted mid-line rather
+   than appended — grouped next to `vm_mb` and `disk_writes_active`
+   respectively, for readability — because this happened before v0.4.7 first
+   shipped, so no released trace format existed yet to stay compatible with.
+   Once a format has shipped, prefer appending.)
 4. Update the field table in this document and the assertion list in
    `memory_sample_line_carries_every_field_from_its_correct_source`, which seeds
    every field to a distinct value specifically so a swapped or dropped source

--- a/docs/dev/memory-telemetry.md
+++ b/docs/dev/memory-telemetry.md
@@ -1,0 +1,339 @@
+# Memory Telemetry
+
+**Status**: Implemented
+**Added**: v0.4.7
+**Issue**: [#209](https://github.com/samsoir/xearthlayer/issues/209)
+
+## Purpose
+
+XEarthLayer emits one structured memory sample per minute into the normal log
+file for the entire life of the process. The sample is always on, needs no
+flags, no environment variables, and no profiler, and it costs one read of
+`/proc/self/smaps` plus one `tracing::info!` every 60 seconds.
+
+It exists because of issue #209. A 12-hour flight ended with the kernel
+OOM-killing the process at 64 GB of anonymous memory — 9.3 GB resident plus
+54.7 GB swapped — against a configured 4 GB memory cache. There was no
+application error and no panic: the last line in the log is the instant of the
+kill. The profiler the project already had — heaptrack — writes its output on
+exit, so a `SIGKILL` leaves nothing behind. The trace is deliberately coarse,
+but it is already on disk when the kernel fires.
+
+Three candidate causes for #209 are still live, and the sample line is designed
+so that a single unattended flight discriminates between them:
+
+1. **Unbounded fire-and-forget cache-write backlog.** `BuildAndCacheDdsTask`
+   issues two ungated `tokio::spawn` calls per completed tile — one memory cache
+   write, one DDS disk cache write — each holding its own clone of the encoded
+   tile (~11.2 MB for BC1 with a full mipmap chain). The disk write reaches
+   storage through `tokio::fs`, which queues on the tokio blocking pool. Neither
+   spawn is gated by the executor's `max_concurrent_jobs` or by any
+   `ResourcePool` permit, so if the blocking pool saturates the queue and its
+   buffers grow without limit.
+2. **glibc arena retention.** An 11.2 MB buffer sits just below glibc's adaptive
+   `mmap` threshold ceiling of 32 MB. Once the threshold has adapted upward past
+   the buffer size, those allocations are served from per-thread arenas rather
+   than by `mmap`, and freeing them returns the memory to the arena free list,
+   not to the OS.
+3. **Chunk LRU index growth.** The chunk disk cache index held roughly
+   12 million entries during the OOM flight.
+
+## The sample line
+
+```
+2026-08-06 06:20:33Z  INFO Memory sample uptime_s=60 rss_mb=873 vm_mb=1459 threads=71 tiles_done=0 encodes_active=0 chunks_ok=0 chunks_failed=0 mem_cache_mb=0 dds_disk_mb=158268 chunk_disk_mb=55301 gc_evicted_mb=0 chunk_index_entries=3803083 disk_writes_active=0
+```
+
+Fourteen fields, in emission order. Every `_mb` value is truncating integer
+division by 1 MiB (1 048 576 bytes), so a value of `0` means "under one
+mebibyte", not necessarily "nothing".
+
+| Field | Source | Meaning |
+|-------|--------|---------|
+| `uptime_s` | `AggregatedState::uptime()` | Whole seconds since the metrics daemon started, which is effectively service start. Use it as the x-axis. |
+| `rss_mb` | `MemoryProbe` → sum of `Rss:` in `/proc/self/smaps` | Physical pages currently held. **Excludes anything the kernel has swapped out.** |
+| `vm_mb` | `MemoryProbe` → sum of `Size:` in `/proc/self/smaps` | Total mapped address space. Counts anonymous mappings whether resident or paged out. |
+| `threads` | `/proc/self/status` `Threads:` | OS thread count. `0` means **not readable on this platform**, not "no threads" — see below. |
+| `tiles_done` | `state.encodes_completed` | Cumulative DDS encodes completed. The load counter: divide by `uptime_s` for tiles/second. |
+| `encodes_active` | `state.encodes_active` | Encodes in flight right now. Each one holds a 4096×4096 RGBA source image (64 MiB) plus its output buffer. |
+| `chunks_ok` | `state.chunks_downloaded` | Cumulative successful chunk downloads. |
+| `chunks_failed` | `state.chunks_failed` | Cumulative failed chunk downloads. A rising count means tiles are being served but not persisted (see issue #180). |
+| `mem_cache_mb` | `state.memory_cache_size_bytes` | Current moka memory cache size. Compare against `cache.memory_size`. |
+| `dds_disk_mb` | `state.dds_disk_cache_size_bytes` | Current DDS disk tier size, from that tier's LRU index. |
+| `chunk_disk_mb` | `state.chunk_disk_cache_size_bytes` | Current chunk disk tier size, from that tier's LRU index. |
+| `gc_evicted_mb` | `state.disk_bytes_evicted` | Cumulative bytes freed by the disk GC daemons, **summed across both disk tiers**. |
+| `chunk_index_entries` | `state.chunk_index_entries` | Live entries in the **chunk** tier's `LruIndex`. The DDS tier does not report this. |
+| `disk_writes_active` | `state.disk_writes_active` | Fire-and-forget disk cache writes currently in flight, counting both chunk writes from `DownloadChunksTask` and DDS tile writes from `BuildAndCacheDdsTask`. |
+
+### `threads=0` means unreadable, not zero
+
+Thread count is read from `/proc/self/status`, which only exists on Linux.
+`memory-stats` does not expose a thread count, and hand-rolling mach FFI for
+macOS was judged not worth the risk on a CI-blocking platform, so
+`ProcessMemoryProbe::thread_count()` returns `None` everywhere except Linux and
+the emit line renders `None` as `0`. A macOS trace will show `threads=0` on
+every line; that tells you nothing about the process.
+
+### `rss_mb` and `vm_mb` are not interchangeable
+
+`rss_mb` counts resident pages only. On a machine that is swapping — which is
+exactly the machine that is about to be OOM-killed — a growing process can show
+a **flat or falling** `rss_mb` while the kernel quietly moves its pages to swap.
+In the #209 flight only 9.3 GB of the 64 GB was resident at the moment of the
+kill.
+
+`vm_mb` counts the whole mapping regardless of residency, so it keeps rising.
+The gap between the two is lazily-reserved-but-never-touched address space plus
+anything paged out. A widening `vm_mb - rss_mb` gap on a system with swap
+enabled is the signal that matters; do not read `rss_mb` alone.
+
+### The allocator environment line
+
+`log_allocator_environment()` runs once at startup from `CliRunner::log_startup`
+and emits a line only when at least one of `MALLOC_ARENA_MAX`,
+`MALLOC_MMAP_THRESHOLD_` or `MALLOC_TRIM_THRESHOLD_` is set:
+
+```
+Allocator environment overrides active allocator_env=MALLOC_MMAP_THRESHOLD_=1048576 MALLOC_ARENA_MAX=2
+```
+
+These variables change whether freed memory goes back to the OS, so a trace
+gathered with them set is not comparable to one gathered without. **The absence
+of this line is itself information**: it means the run used stock glibc
+behaviour. Always check for it before comparing two traces.
+
+## Reading a trace
+
+Plot `rss_mb`, `vm_mb`, `disk_writes_active` and `chunk_index_entries` against
+`uptime_s`. The shape of the first against the other three is what
+discriminates the three candidates.
+
+| `rss_mb` / `vm_mb` | `disk_writes_active` | `chunk_index_entries` | Reading |
+|--------------------|----------------------|-----------------------|---------|
+| climbing | climbing | any | **Candidate 1** — the fire-and-forget cache-write backlog in `tasks/build_and_cache_dds.rs`. Each queued write pins ~11.2 MB, and the paired memory-cache write pins another ~11.2 MB that this gauge does not count. |
+| climbing | flat | climbing | **Candidate 3** — chunk LRU index growth. Cross-check that `chunk_disk_mb` is at its configured ceiling and `gc_evicted_mb` is rising: an index that grows while the tier size is pinned means entries are accumulating faster than GC removes them. |
+| climbing | flat | flat | **Candidate 2** — allocator retention. Nothing in the process is holding more logical data, but the resident footprint grows anyway. Confirm by re-running with `MALLOC_MMAP_THRESHOLD_=1048576`; if growth stops, glibc was hoarding freed buffers in per-thread arenas. |
+
+Supporting reads:
+
+- **`disk_writes_active` is a lower bound.** The counter is incremented by the
+  first statement *inside* each spawned write task, so a write that has been
+  spawned but not yet polled is invisible. If the tokio worker threads are
+  themselves starved, the real backlog is larger than the number printed.
+- **`encodes_active` × 64 MiB is the floor of what encoding costs.** Each
+  in-flight encode holds a 4096×4096 RGBA source image (64 MiB) plus its output
+  buffer. The number should track the CPU resource pool capacity; if it runs
+  materially above that, CPU admission control is not bounding the pipeline and
+  the peak is unbounded with it.
+- **`threads`** climbing toward 512 points at the tokio blocking pool (default
+  512 threads) filling up, which is the mechanism behind candidate 1.
+- **`tiles_done` per hour** is the load normaliser. Two traces at wildly
+  different tile rates are not telling you about memory, they are telling you
+  about workload.
+- **`chunks_failed`** rising alongside `tiles_done` means tiles are being served
+  to X-Plane but never persisted, so the same tiles will be regenerated
+  repeatedly. That inflates apparent load without inflating cache size.
+
+## Comparing two runs — read this first
+
+**Matching load between two runs is not sufficient to make them comparable.**
+
+The worked example is the 2026-08-05 retest of issue #209. It was run with
+`MALLOC_MMAP_THRESHOLD_=1048576 MALLOC_ARENA_MAX=2` and held at 5.3 GB, against
+an OOM kill at 64 GB. It also matched the OOM flight to within 1% on tiles
+generated per hour. It looked like a clean confirmation of candidate 2. It was
+not:
+
+| | OOM flight | 2026-08-05 retest |
+|---|---|---|
+| Peak anonymous memory | 64 GB (killed) | 5.3 GB |
+| Tiles generated per hour | baseline | within 1% of baseline |
+| Allocator overrides | none | `MALLOC_MMAP_THRESHOLD_=1048576`, `MALLOC_ARENA_MAX=2` |
+| Disk tier occupancy (DDS / chunks) | 89% / 85% | empty throughout |
+| GC evictions over the run | ~24 million files | zero |
+| Chunk index entries | ~12 million | small and growing from zero |
+
+Two major variables moved between the runs, not one. The retest changed the
+allocator *and* removed all cache pressure. A run that never evicts anything
+never exercises the GC path, never grows the LRU index to steady state, and
+never sustains the disk write queue depth that a full cache produces. The
+experiment therefore discriminated nothing: the 5.3 GB ceiling is equally
+consistent with "the allocator fix worked" and with "an empty cache produces a
+fundamentally different workload".
+
+Before comparing two traces, check that all of the following are in the same
+regime:
+
+1. **`dds_disk_mb` and `chunk_disk_mb`** — are both runs at their configured
+   ceilings, or is one starting from empty? A cold cache is a different program.
+2. **`gc_evicted_mb`** — is GC actually running in both? Zero evictions means
+   the eviction path was never exercised.
+3. **`chunk_index_entries`** — is the index at steady state in both, or growing
+   from zero in one?
+4. **The allocator environment line** — present in both, absent in both, or
+   present in only one?
+5. **`tiles_done / uptime_s`** — comparable tile rates.
+
+Only then is a difference in `rss_mb` attributable to the change under test.
+Change one variable per flight. To test candidate 2 properly, the allocator
+override must be flown against a cache that is already full and evicting.
+
+## Submitting a trace
+
+The trace is plain text in the normal log file, `~/.xearthlayer/xearthlayer.log`
+by default (configurable via `logging.file`; see
+[Configuration](../configuration.md)). Attach the whole file to the GitHub
+issue — the memory samples are hard to interpret without the surrounding startup
+lines: the version banner, the resolved cache sizes, and the allocator
+environment line if one was emitted.
+
+> **The log file is truncated on every start.** `init_logging_full` clears the
+> file before opening it, so relaunching XEarthLayer destroys the previous
+> flight's trace. Copy it aside *before* the next launch:
+>
+> ```bash
+> cp ~/.xearthlayer/xearthlayer.log ~/flight-$(date +%Y%m%d-%H%M).log
+> ```
+
+To extract just the samples for plotting:
+
+```bash
+grep "Memory sample" ~/.xearthlayer/xearthlayer.log
+```
+
+A 12-hour flight produces 720 sample lines.
+
+## Architecture
+
+```
+metrics/memory_probe.rs                    metrics/daemon.rs
+───────────────────────                    ─────────────────
+MemoryProbe (trait)          injected      MetricsDaemon
+  fn sample() -> Option<     ───────────▶    with_memory_probe(rx, probe)
+      MemorySample>                          run() → select! { … }
+                                               MEMORY_SAMPLE_INTERVAL tick
+ProcessMemoryProbe                             → log_memory_sample()
+  memory-stats + /proc                              │
+StaticMemoryProbe (test)                            ▼
+                                             tracing::info!("Memory sample", …)
+```
+
+### `MemoryProbe`
+
+```rust
+pub trait MemoryProbe: Send + Sync {
+    fn sample(&self) -> Option<MemorySample>;
+}
+```
+
+`MemorySample` carries `rss_bytes`, `vm_bytes` and `threads: Option<u64>`.
+Returning `Option` rather than a `Result` is deliberate: a platform that cannot
+supply a reading is not an error condition, it just means no sample line.
+
+`ProcessMemoryProbe` is the production implementation. It delegates to the
+`memory-stats` crate for the byte counts (Linux, macOS and Windows; on Unix its
+only dependency is `libc`, already in the tree) and reads thread count itself
+from `/proc/self/status` on Linux only.
+
+### The `memory-stats` initialisation workaround
+
+`ProcessMemoryProbe::sample()` funnels the first call through a
+`std::sync::Once`:
+
+```rust
+static MEMORY_STATS_INIT: std::sync::Once = std::sync::Once::new();
+```
+
+This works around a race in memory-stats 1.2.0. Its Linux path guards
+initialisation with an atomic compare-exchange on `SMAPS_CHECKED`. A thread that
+loses that CAS can read the still-default `SMAPS_EXIST` (`false`) before the
+winner has stored the real value, fall through to the `/proc/self/statm`
+fallback, and multiply the page counts by a `PAGE_SIZE` that is still `0` —
+producing a silent, non-erroring reading of `physical_mem = 0` and
+`virtual_mem = 0`. Serialising the first call ensures upstream initialisation
+has completed before any concurrent use. Without it, the first sample of a run
+can be a plausible-looking `rss_mb=0 vm_mb=0`.
+
+### Injection and sampling cadence
+
+`MetricsDaemon::new` wires in `ProcessMemoryProbe`; `with_memory_probe` takes an
+`Arc<dyn MemoryProbe>` so tests can substitute `StaticMemoryProbe` and assert on
+the emitted event without reading real process memory. The daemon owns a second
+`tokio::time::interval` alongside the 100 ms time-series sampler:
+
+```rust
+const MEMORY_SAMPLE_INTERVAL: Duration = Duration::from_secs(60);
+```
+
+Sixty seconds is fixed and **deliberately not configurable**. Traces are pooled
+across users and machines, and a configurable cadence would be one more variable
+to reconcile before two traces could be compared — precisely the failure mode
+described above. Both intervals use `MissedTickBehavior::Skip` so a stalled
+daemon does not emit a burst of catch-up samples.
+
+If the probe returns `None`, the daemon logs one warning
+(`"Memory probe unavailable; memory samples disabled"`), latches
+`memory_probe_failed`, and emits nothing further. The warning is not repeated.
+
+Because `MetricsSystem::new` is constructed unconditionally in
+`XEarthLayerService::start`, memory sampling is active for every run, including
+TUI mode.
+
+### Adding a platform implementation
+
+To add thread count (or any other field) for a new platform:
+
+1. Add a `#[cfg(target_os = "…")]` branch to `ProcessMemoryProbe::thread_count`.
+   The existing `#[cfg(not(target_os = "linux"))]` fallback returns `None`, so
+   nothing breaks if you add a platform and forget a branch — the field just
+   renders as `0`.
+2. Extend `MemorySample` if the platform can supply something the others cannot.
+   Any new field must be `Option`-typed with an emit-time default, so a trace
+   from one platform stays diffable against a trace from another.
+3. Add the field to the `tracing::info!` call in `log_memory_sample` **at the
+   end** of the field list. Existing field positions are what makes traces from
+   different builds comparable by eye.
+4. Update the field table in this document and the assertion list in
+   `memory_sample_line_carries_every_field_from_its_correct_source`, which seeds
+   every field to a distinct value specifically so a swapped or dropped source
+   cannot pass.
+
+## Relationship to heaptrack
+
+The two tools answer different questions and neither replaces the other.
+
+[Memory Profiling](memory-profiling.md) with heaptrack gives allocation-level
+attribution: which call site allocated what, ranked by contribution to peak
+heap, with full backtraces. That is what you want when you already know a
+workload reproduces the growth and you need to know *which line of code* is
+responsible. But heaptrack writes its summary on exit — a crash or `kill -9`
+loses data — so it cannot capture an OOM kill, which is by definition a
+`SIGKILL`. It also adds a 2-3× slowdown on allocation-heavy code, which makes it
+impractical for a 12-hour flight.
+
+Memory telemetry gives no attribution at all. It tells you the footprint grew,
+roughly how fast, and which of a small number of subsystem gauges moved with it.
+Its advantages are that it costs nothing, runs unattended for the whole flight,
+and is durably on disk one minute at a time, so it survives the kill that
+heaptrack cannot.
+
+| | Memory telemetry | heaptrack |
+|---|---|---|
+| Granularity | Process-level gauges | Per-call-site allocations |
+| Overhead | Negligible | 2-3× on allocation-heavy paths |
+| Survives `kill -9` | Yes | No |
+| Practical duration | Unbounded | Minutes |
+| Usable by other users | Yes — always on, just attach the log | No — requires a profiler build and a local run |
+
+Use the trace for long unattended flights and for data reported by other users.
+Use heaptrack for local attribution once the trace has narrowed the search to a
+reproducible workload.
+
+## References
+
+- [Memory Profiling](memory-profiling.md) — heaptrack guide
+- [Cache Service Design](cache-service-design.md) — `CacheLayer`, GC daemons, the tiers behind `mem_cache_mb` / `dds_disk_mb` / `chunk_disk_mb`
+- [Job Executor Design](job-executor-design.md) — resource pools and `max_concurrent_jobs`, which the fire-and-forget cache writes bypass
+- [Configuration](../configuration.md) — `logging.file`, `cache.memory_size`, `cache.disk_size`
+- Issue [#209](https://github.com/samsoir/xearthlayer/issues/209) — the OOM kill this telemetry was added to diagnose
+- Issue [#180](https://github.com/samsoir/xearthlayer/issues/180) — why `chunks_failed` suppresses cache writes

--- a/xearthlayer-cli/src/runner.rs
+++ b/xearthlayer-cli/src/runner.rs
@@ -33,5 +33,6 @@ impl CliRunner {
     pub fn log_startup(&self, command: &str) {
         info!("XEarthLayer v{}", xearthlayer::VERSION);
         info!("XEarthLayer CLI: {} command", command);
+        xearthlayer::metrics::log_allocator_environment();
     }
 }

--- a/xearthlayer/Cargo.toml
+++ b/xearthlayer/Cargo.toml
@@ -49,6 +49,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio-tungstenite = { version = "0.24", features = ["connect"] }
 nix = { version = "0.31", default-features = false, features = ["fs"] }
+memory-stats = "1.2"
 tracing-chrome = { version = "0.7", optional = true }
 axum = { version = "0.7", optional = true }
 

--- a/xearthlayer/src/cache/providers/disk.rs
+++ b/xearthlayer/src/cache/providers/disk.rs
@@ -256,6 +256,7 @@ impl DiskCacheProvider {
                 client.dds_disk_cache_size(size);
             } else {
                 client.disk_cache_size(size);
+                client.chunk_index_entries(self.lru_index.entry_count());
             }
         }
     }

--- a/xearthlayer/src/executor/lifecycle.rs
+++ b/xearthlayer/src/executor/lifecycle.rs
@@ -17,7 +17,7 @@ use super::task::TaskResult;
 use super::telemetry::TelemetryEvent;
 use std::time::Duration;
 use tokio::sync::{mpsc, watch, OwnedSemaphorePermit};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 impl JobExecutor {
     /// Handles a newly submitted job.
@@ -28,7 +28,7 @@ impl JobExecutor {
         let name = submitted.name.clone();
         let priority = submitted.priority;
 
-        info!(
+        debug!(
             job_id = %job_id,
             job_name = %name,
             priority = ?priority,
@@ -299,7 +299,7 @@ impl JobExecutor {
     ) {
         match status {
             JobStatus::Succeeded => {
-                info!(
+                debug!(
                     job_id = %job_id,
                     duration_ms = result.duration.as_millis(),
                     tasks_succeeded = result.succeeded_tasks.len(),
@@ -401,7 +401,7 @@ impl JobExecutor {
         });
 
         let total_tasks = active.pending_tasks.len();
-        info!(job_id = %job_id, task_count = total_tasks, "Job started");
+        debug!(job_id = %job_id, task_count = total_tasks, "Job started");
 
         if !active.pending_tasks.is_empty() {
             let first_task = active.pending_tasks.remove(0);

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -197,6 +197,12 @@ impl MetricsClient {
         self.send(MetricEvent::DdsDiskCacheSizeUpdate { bytes });
     }
 
+    /// Reports the current chunk LRU index entry count.
+    #[inline]
+    pub fn chunk_index_entries(&self, entries: u64) {
+        self.send(MetricEvent::ChunkIndexEntriesUpdate { entries });
+    }
+
     // =========================================================================
     // Memory Cache Events
     // =========================================================================

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -233,6 +233,21 @@ impl MetricsClient {
         self.send(MetricEvent::MemoryCacheSizeUpdate { bytes });
     }
 
+    /// Records a fire-and-forget memory cache write starting.
+    ///
+    /// Mirrors `disk_write_started` for the memory-cache spawn in
+    /// `BuildAndCacheDdsTask`; see `MetricEvent::MemCacheWriteStarted`.
+    #[inline]
+    pub fn mem_cache_write_started(&self) {
+        self.send(MetricEvent::MemCacheWriteStarted);
+    }
+
+    /// Records a fire-and-forget memory cache write completing.
+    #[inline]
+    pub fn mem_cache_write_completed(&self) {
+        self.send(MetricEvent::MemCacheWriteCompleted);
+    }
+
     // =========================================================================
     // Job Events
     // =========================================================================
@@ -441,6 +456,23 @@ mod tests {
         assert!(matches!(
             rx.recv().await,
             Some(MetricEvent::MemoryCacheSizeUpdate { bytes: 1_000_000 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_client_mem_cache_write_events() {
+        let (client, mut rx) = create_client();
+
+        client.mem_cache_write_started();
+        client.mem_cache_write_completed();
+
+        assert!(matches!(
+            rx.recv().await,
+            Some(MetricEvent::MemCacheWriteStarted)
+        ));
+        assert!(matches!(
+            rx.recv().await,
+            Some(MetricEvent::MemCacheWriteCompleted)
         ));
     }
 

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -257,6 +257,13 @@ impl MetricsDaemon {
             MetricEvent::MemoryCacheSizeUpdate { bytes } => {
                 self.state.memory_cache_size_bytes = bytes;
             }
+            MetricEvent::MemCacheWriteStarted => {
+                self.state.mem_cache_writes_active += 1;
+            }
+            MetricEvent::MemCacheWriteCompleted => {
+                self.state.mem_cache_writes_active =
+                    self.state.mem_cache_writes_active.saturating_sub(1);
+            }
 
             // Job events
             MetricEvent::JobSubmitted { is_fuse } => {
@@ -330,7 +337,17 @@ impl MetricsDaemon {
     /// flights, which is what made them incomparable. `disk_writes_active`
     /// correlated against `rss_mb` is what discriminates the candidate causes.
     fn log_memory_sample(&mut self) {
-        let Some(sample) = self.memory_probe.sample() else {
+        // A sample with `rss_bytes == 0` is treated exactly like `None`: it is
+        // the signature of the memory-stats init race the `Once` in
+        // `memory_probe.rs` guards against (see its doc comment). Emitting it
+        // as `rss_mb=0` would read as a healthy, near-empty process instead of
+        // "unavailable" — the same misleading shape as swap being invisible.
+        let sample = self
+            .memory_probe
+            .sample()
+            .filter(|sample| sample.rss_bytes != 0);
+
+        let Some(sample) = sample else {
             if !self.memory_probe_failed {
                 self.memory_probe_failed = true;
                 tracing::warn!("Memory probe unavailable; memory samples disabled");
@@ -345,6 +362,11 @@ impl MetricsDaemon {
             uptime_s = state.uptime().as_secs(),
             rss_mb = sample.rss_bytes / MB,
             vm_mb = sample.vm_bytes / MB,
+            // Anonymous memory swapped out. This is the field that actually
+            // caught #209: rss_mb alone read a healthy 9.3 GB while 54.7 GB
+            // was swapped out. 0 means "not readable on this platform", not
+            // "nothing swapped" — same convention as `threads`.
+            swap_mb = sample.swap_bytes.unwrap_or(0) / MB,
             // 0 means "not readable on this platform", not "no threads".
             threads = sample.threads.unwrap_or(0),
             tiles_done = state.encodes_completed,
@@ -357,6 +379,10 @@ impl MetricsDaemon {
             gc_evicted_mb = state.disk_bytes_evicted / MB,
             chunk_index_entries = state.chunk_index_entries,
             disk_writes_active = state.disk_writes_active,
+            // Mirrors disk_writes_active for the memory-cache spawn, which
+            // previously had no in-flight gauge at all (see MemCacheWriteStarted
+            // doc comment in metrics/event.rs for why that was a diagnosis hole).
+            mem_cache_writes_active = state.mem_cache_writes_active,
             "Memory sample"
         );
     }
@@ -851,10 +877,13 @@ mod tests {
         let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let mut daemon = MetricsDaemon::with_memory_probe(
             rx,
-            std::sync::Arc::new(crate::metrics::memory_probe::StaticMemoryProbe::new(
-                5 * MB + 1, // deliberately not a whole number of MB
-                6 * MB,
-            )),
+            std::sync::Arc::new(
+                crate::metrics::memory_probe::StaticMemoryProbe::new(
+                    5 * MB + 1, // deliberately not a whole number of MB
+                    6 * MB,
+                )
+                .with_swap_bytes(7 * MB),
+            ),
         );
 
         // Every numeric field is seeded to a distinct value so that a
@@ -871,6 +900,7 @@ mod tests {
         daemon.state.disk_bytes_evicted = 17 * MB; // gc_evicted_mb
         daemon.state.chunk_index_entries = 18;
         daemon.state.disk_writes_active = 19;
+        daemon.state.mem_cache_writes_active = 20;
 
         let events = capture_events(|| daemon.log_memory_sample());
         let sample = find_memory_sample(&events)
@@ -883,6 +913,7 @@ mod tests {
         let expected: &[(&str, &str)] = &[
             ("rss_mb", "5"),
             ("vm_mb", "6"),
+            ("swap_mb", "7"),  // StaticMemoryProbe::with_swap_bytes
             ("threads", "42"), // StaticMemoryProbe::new fixes threads at 42
             ("tiles_done", "10"),
             ("encodes_active", "11"),
@@ -894,6 +925,7 @@ mod tests {
             ("gc_evicted_mb", "17"),
             ("chunk_index_entries", "18"),
             ("disk_writes_active", "19"),
+            ("mem_cache_writes_active", "20"),
         ];
 
         for (field, value) in expected {
@@ -938,6 +970,55 @@ mod tests {
         assert!(
             find_memory_sample(&events).is_none(),
             "no \"Memory sample\" event may be emitted when the probe is unavailable"
+        );
+    }
+
+    // =========================================================================
+    // rss_bytes == 0 guard (minor fix a)
+    //
+    // A `Some(sample)` with `rss_bytes == 0` must be treated exactly like a
+    // `None` sample: it is the observable signature of the memory-stats init
+    // race described on `MEMORY_STATS_INIT` in memory_probe.rs. Without this
+    // guard, that race would silently emit `rss_mb=0` — a plausible-looking
+    // but wrong reading — instead of latching the same "unavailable" path
+    // that `None` takes.
+    // =========================================================================
+
+    #[test]
+    fn memory_sample_is_skipped_when_rss_bytes_is_zero() {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut daemon = MetricsDaemon::with_memory_probe(
+            rx,
+            std::sync::Arc::new(crate::metrics::memory_probe::StaticMemoryProbe::new(
+                0,
+                6 * 1024 * 1024,
+            )),
+        );
+
+        assert!(!daemon.memory_probe_failed);
+        daemon.log_memory_sample();
+        assert!(
+            daemon.memory_probe_failed,
+            "a zeroed rss_bytes sample must be treated as unavailable, latching the warn-once flag"
+        );
+    }
+
+    #[test]
+    fn memory_sample_emits_no_event_when_rss_bytes_is_zero() {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut daemon = MetricsDaemon::with_memory_probe(
+            rx,
+            std::sync::Arc::new(crate::metrics::memory_probe::StaticMemoryProbe::new(
+                0,
+                6 * 1024 * 1024,
+            )),
+        );
+
+        let events = capture_events(|| daemon.log_memory_sample());
+
+        assert!(
+            find_memory_sample(&events).is_none(),
+            "no \"Memory sample\" event may be emitted when rss_bytes is zero"
         );
     }
 

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -14,6 +14,7 @@
 //! processing events. This ensures reporters never block event processing.
 
 use super::event::MetricEvent;
+use super::memory_probe::{MemoryProbe, ProcessMemoryProbe};
 use super::state::{AggregatedState, TimeSeriesHistory, DEFAULT_HISTORY_CAPACITY};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -22,6 +23,12 @@ use tokio_util::sync::CancellationToken;
 
 /// Interval between time-series samples (100ms).
 const SAMPLE_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Interval between process memory samples (60s).
+///
+/// Deliberately not configurable: traces are pooled across users and machines,
+/// so a fixed cadence removes one variable. A 12h flight adds 720 lines.
+const MEMORY_SAMPLE_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Shared state handle for read-only access by reporters.
 pub type SharedMetricsState = Arc<RwLock<MetricsStateSnapshot>>;
@@ -67,15 +74,34 @@ pub struct MetricsDaemon {
 
     /// Last FUSE requests completed (for rate calculation).
     last_fuse_completed: u64,
+
+    /// Probe for reading process memory.
+    memory_probe: Arc<dyn MemoryProbe>,
+
+    /// Set once the probe has failed, so the warning is logged only once.
+    memory_probe_failed: bool,
 }
 
 impl MetricsDaemon {
-    /// Creates a new metrics daemon.
+    /// Creates a new metrics daemon with the production memory probe.
     ///
     /// # Arguments
     ///
     /// * `rx` - Channel receiver for incoming events
     pub fn new(rx: mpsc::UnboundedReceiver<MetricEvent>) -> Self {
+        Self::with_memory_probe(rx, Arc::new(ProcessMemoryProbe::new()))
+    }
+
+    /// Creates a new metrics daemon with an injected memory probe.
+    ///
+    /// # Arguments
+    ///
+    /// * `rx` - Channel receiver for incoming events
+    /// * `memory_probe` - Probe used for periodic memory sampling
+    pub fn with_memory_probe(
+        rx: mpsc::UnboundedReceiver<MetricEvent>,
+        memory_probe: Arc<dyn MemoryProbe>,
+    ) -> Self {
         let shared_state = Arc::new(RwLock::new(MetricsStateSnapshot::default()));
 
         Self {
@@ -88,6 +114,8 @@ impl MetricsDaemon {
             last_disk_bytes_written: 0,
             last_jobs_completed: 0,
             last_fuse_completed: 0,
+            memory_probe,
+            memory_probe_failed: false,
         }
     }
 
@@ -111,6 +139,9 @@ impl MetricsDaemon {
         // Don't let missed ticks pile up
         sample_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+        let mut memory_interval = tokio::time::interval(MEMORY_SAMPLE_INTERVAL);
+        memory_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
         loop {
             tokio::select! {
                 biased;
@@ -130,6 +161,11 @@ impl MetricsDaemon {
                 _ = sample_interval.tick() => {
                     self.sample_time_series();
                     self.update_shared_state();
+                }
+
+                // Sample process memory
+                _ = memory_interval.tick() => {
+                    self.log_memory_sample();
                 }
             }
         }
@@ -285,6 +321,44 @@ impl MetricsDaemon {
                     self.state.fuse_requests_waiting.saturating_sub(1);
             }
         }
+    }
+
+    /// Emits one memory sample line.
+    ///
+    /// Every context field defeats a specific confounder: cache occupancy and
+    /// GC pressure differed by orders of magnitude between the two issue #209
+    /// flights, which is what made them incomparable. `disk_writes_active`
+    /// correlated against `rss_mb` is what discriminates the candidate causes.
+    fn log_memory_sample(&mut self) {
+        let Some(sample) = self.memory_probe.sample() else {
+            if !self.memory_probe_failed {
+                self.memory_probe_failed = true;
+                tracing::warn!("Memory probe unavailable; memory samples disabled");
+            }
+            return;
+        };
+
+        const MB: u64 = 1024 * 1024;
+        let state = &self.state;
+
+        tracing::info!(
+            uptime_s = state.uptime().as_secs(),
+            rss_mb = sample.rss_bytes / MB,
+            vm_mb = sample.vm_bytes / MB,
+            // 0 means "not readable on this platform", not "no threads".
+            threads = sample.threads.unwrap_or(0),
+            tiles_done = state.encodes_completed,
+            encodes_active = state.encodes_active,
+            chunks_ok = state.chunks_downloaded,
+            chunks_failed = state.chunks_failed,
+            mem_cache_mb = state.memory_cache_size_bytes / MB,
+            dds_disk_mb = state.dds_disk_cache_size_bytes / MB,
+            chunk_disk_mb = state.chunk_disk_cache_size_bytes / MB,
+            gc_evicted_mb = state.disk_bytes_evicted / MB,
+            chunk_index_entries = state.chunk_index_entries,
+            disk_writes_active = state.disk_writes_active,
+            "Memory sample"
+        );
     }
 
     /// Samples current rates for time-series history.
@@ -654,6 +728,47 @@ mod tests {
 
         daemon.process_event(MetricEvent::FuseRequestCompleted);
         assert_eq!(daemon.state.fuse_requests_active, 0);
+    }
+
+    #[test]
+    fn memory_sample_is_skipped_when_probe_unavailable() {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut daemon = MetricsDaemon::with_memory_probe(
+            rx,
+            std::sync::Arc::new(crate::metrics::memory_probe::StaticMemoryProbe::unavailable()),
+        );
+
+        assert!(!daemon.memory_probe_failed);
+        daemon.log_memory_sample();
+        assert!(
+            daemon.memory_probe_failed,
+            "first failure must latch the warn-once flag"
+        );
+
+        // Second call must not reset the flag (proves the warning is emitted once).
+        daemon.log_memory_sample();
+        assert!(daemon.memory_probe_failed);
+    }
+
+    #[test]
+    fn memory_sample_runs_with_a_working_probe() {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut daemon = MetricsDaemon::with_memory_probe(
+            rx,
+            std::sync::Arc::new(crate::metrics::memory_probe::StaticMemoryProbe::new(
+                5_412 * 1024 * 1024,
+                6_218 * 1024 * 1024,
+            )),
+        );
+
+        daemon.process_event(MetricEvent::ChunkIndexEntriesUpdate { entries: 99 });
+        daemon.log_memory_sample();
+
+        assert!(
+            !daemon.memory_probe_failed,
+            "working probe must not latch failure"
+        );
+        assert_eq!(daemon.state.chunk_index_entries, 99);
     }
 
     #[tokio::test]

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -188,6 +188,9 @@ impl MetricsDaemon {
             MetricEvent::DdsDiskCacheSizeUpdate { bytes } => {
                 self.state.dds_disk_cache_size_bytes = bytes;
             }
+            MetricEvent::ChunkIndexEntriesUpdate { entries } => {
+                self.state.chunk_index_entries = entries;
+            }
             MetricEvent::DdsDiskCacheHit { bytes, is_fuse } => {
                 self.state.dds_disk_cache_hits += 1;
                 self.state.dds_disk_bytes_read += bytes;
@@ -444,6 +447,18 @@ mod tests {
             bytes: 4_000_000_000,
         });
         assert_eq!(daemon.state.chunk_disk_cache_size_bytes, 4_000_000_000);
+    }
+
+    #[test]
+    fn chunk_index_entries_update_sets_gauge() {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut daemon = MetricsDaemon::new(rx);
+
+        daemon.process_event(MetricEvent::ChunkIndexEntriesUpdate {
+            entries: 12_046_463,
+        });
+
+        assert_eq!(daemon.state.chunk_index_entries, 12_046_463);
     }
 
     #[test]

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -745,7 +745,10 @@ mod tests {
             "first failure must latch the warn-once flag"
         );
 
-        // Second call must not reset the flag (proves the warning is emitted once).
+        // Second call must not reset the flag (the flag latches after the
+        // first failure and stays latched; see
+        // `memory_sample_emits_no_event_when_probe_unavailable` for the
+        // companion assertion that no event is actually emitted).
         daemon.log_memory_sample();
         assert!(daemon.memory_probe_failed);
     }
@@ -769,6 +772,173 @@ mod tests {
             "working probe must not latch failure"
         );
         assert_eq!(daemon.state.chunk_index_entries, 99);
+    }
+
+    // =========================================================================
+    // Tracing capture harness for asserting on the emitted "Memory sample"
+    // event itself (field names, sources, and MB truncation), not just that
+    // `log_memory_sample` runs without panicking.
+    // =========================================================================
+
+    /// Visitor that records every field of a tracing event as a string,
+    /// keyed by field name, using `record_debug` as the sole capture point.
+    ///
+    /// `Visit`'s other `record_*` methods (u64, i64, bool, str, ...) all have
+    /// default implementations that delegate to `record_debug`, so this one
+    /// override captures every field type emitted by `log_memory_sample`.
+    /// The implicit message field (`"Memory sample"`) arrives as a `Debug`
+    /// value too: `std::fmt::Arguments`'s `Debug` impl forwards to `Display`,
+    /// so the captured string has no surrounding quotes.
+    struct RecordingVisitor<'a>(&'a mut std::collections::HashMap<String, String>);
+
+    impl tracing::field::Visit for RecordingVisitor<'_> {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    /// A `tracing_subscriber::Layer` that appends every event's fields to a
+    /// shared buffer, in emission order.
+    struct RecordingLayer {
+        events: std::sync::Arc<std::sync::Mutex<Vec<std::collections::HashMap<String, String>>>>,
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for RecordingLayer {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut fields = std::collections::HashMap::new();
+            event.record(&mut RecordingVisitor(&mut fields));
+            self.events.lock().unwrap().push(fields);
+        }
+    }
+
+    /// Runs `f` under a tracing subscriber that captures every event's
+    /// fields, returning them in emission order. Uses only
+    /// `tracing`/`tracing-subscriber`, both already direct dependencies of
+    /// this crate (see Cargo.toml) — no new dependency is introduced.
+    fn capture_events<F: FnOnce()>(f: F) -> Vec<std::collections::HashMap<String, String>> {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let layer = RecordingLayer {
+            events: std::sync::Arc::clone(&events),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, f);
+        std::sync::Arc::try_unwrap(events)
+            .expect("no other references to the capture buffer should remain")
+            .into_inner()
+            .unwrap()
+    }
+
+    /// Finds the first captured event whose message is "Memory sample".
+    fn find_memory_sample(
+        events: &[std::collections::HashMap<String, String>],
+    ) -> Option<&std::collections::HashMap<String, String>> {
+        events
+            .iter()
+            .find(|fields| fields.get("message").map(String::as_str) == Some("Memory sample"))
+    }
+
+    #[test]
+    fn memory_sample_line_carries_every_field_from_its_correct_source() {
+        const MB: u64 = 1024 * 1024;
+
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut daemon = MetricsDaemon::with_memory_probe(
+            rx,
+            std::sync::Arc::new(crate::metrics::memory_probe::StaticMemoryProbe::new(
+                5 * MB + 1, // deliberately not a whole number of MB
+                6 * MB,
+            )),
+        );
+
+        // Every numeric field is seeded to a distinct value so that a
+        // swapped source, a renamed/reordered field, or a silently dropped
+        // field cannot pass this test: any of those would make at least one
+        // of the per-field assertions below fail.
+        daemon.state.encodes_completed = 10; // tiles_done
+        daemon.state.encodes_active = 11;
+        daemon.state.chunks_downloaded = 12; // chunks_ok
+        daemon.state.chunks_failed = 13;
+        daemon.state.memory_cache_size_bytes = 14 * MB + 999_999; // mem_cache_mb, also not a whole MB
+        daemon.state.dds_disk_cache_size_bytes = 15 * MB; // dds_disk_mb
+        daemon.state.chunk_disk_cache_size_bytes = 16 * MB; // chunk_disk_mb
+        daemon.state.disk_bytes_evicted = 17 * MB; // gc_evicted_mb
+        daemon.state.chunk_index_entries = 18;
+        daemon.state.disk_writes_active = 19;
+
+        let events = capture_events(|| daemon.log_memory_sample());
+        let sample = find_memory_sample(&events)
+            .expect("log_memory_sample must emit a \"Memory sample\" event");
+
+        // Field-by-field: name -> expected value. `rss_mb` and `mem_cache_mb`
+        // are seeded from byte counts that are NOT whole multiples of MB, so
+        // this also proves the emit line truncates to MB rather than leaking
+        // raw bytes through under an "_mb" name.
+        let expected: &[(&str, &str)] = &[
+            ("rss_mb", "5"),
+            ("vm_mb", "6"),
+            ("threads", "42"), // StaticMemoryProbe::new fixes threads at 42
+            ("tiles_done", "10"),
+            ("encodes_active", "11"),
+            ("chunks_ok", "12"),
+            ("chunks_failed", "13"),
+            ("mem_cache_mb", "14"),
+            ("dds_disk_mb", "15"),
+            ("chunk_disk_mb", "16"),
+            ("gc_evicted_mb", "17"),
+            ("chunk_index_entries", "18"),
+            ("disk_writes_active", "19"),
+        ];
+
+        for (field, value) in expected {
+            assert_eq!(
+                sample.get(*field).map(String::as_str),
+                Some(*value),
+                "field `{field}` did not carry the expected value from its source"
+            );
+        }
+
+        assert!(
+            sample.contains_key("uptime_s"),
+            "uptime_s field must be present"
+        );
+
+        // Belt-and-braces: confirm the fixture values (including the
+        // dynamically-read uptime_s) are pairwise distinct. If they were
+        // not, a swap between two fields sharing a value could pass the
+        // assertions above by coincidence.
+        let mut all_values: Vec<&str> = expected.iter().map(|(_, v)| *v).collect();
+        all_values.push(sample.get("uptime_s").unwrap().as_str());
+        let mut sorted = all_values.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            all_values.len(),
+            "fixture values must be pairwise distinct or a swapped source could go undetected"
+        );
+    }
+
+    #[test]
+    fn memory_sample_emits_no_event_when_probe_unavailable() {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut daemon = MetricsDaemon::with_memory_probe(
+            rx,
+            std::sync::Arc::new(crate::metrics::memory_probe::StaticMemoryProbe::unavailable()),
+        );
+
+        let events = capture_events(|| daemon.log_memory_sample());
+
+        assert!(
+            find_memory_sample(&events).is_none(),
+            "no \"Memory sample\" event may be emitted when the probe is unavailable"
+        );
     }
 
     #[tokio::test]

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -139,6 +139,21 @@ pub enum MetricEvent {
         bytes: u64,
     },
 
+    /// A fire-and-forget memory cache write operation started.
+    ///
+    /// Mirrors `DiskWriteStarted`/`DiskWriteCompleted` but for the memory-cache
+    /// spawn in `BuildAndCacheDdsTask`, which previously emitted no start/complete
+    /// pair at all — only `MemoryCacheSizeUpdate`, a size gauge that only moves
+    /// after `cache.put()` actually completes. A backlog concentrated in that
+    /// spawn (each task pinning its own ~11.2 MB DDS clone) would present as
+    /// rising RSS with both `disk_writes_active` and `chunk_index_entries` flat,
+    /// misreading as allocator retention (candidate 2) instead of the
+    /// fire-and-forget backlog (candidate 1). See issue #209.
+    MemCacheWriteStarted,
+
+    /// A fire-and-forget memory cache write operation completed.
+    MemCacheWriteCompleted,
+
     // =========================================================================
     // Job Lifecycle Events
     // =========================================================================
@@ -232,6 +247,8 @@ impl MetricEvent {
             Self::MemoryCacheHit { .. } => "memory_cache_hit",
             Self::MemoryCacheMiss { .. } => "memory_cache_miss",
             Self::MemoryCacheSizeUpdate { .. } => "memory_cache_size_update",
+            Self::MemCacheWriteStarted => "mem_cache_write_started",
+            Self::MemCacheWriteCompleted => "mem_cache_write_completed",
             Self::JobSubmitted { .. } => "job_submitted",
             Self::JobStarted => "job_started",
             Self::JobCompleted { .. } => "job_completed",
@@ -304,6 +321,18 @@ mod tests {
         assert_eq!(
             MetricEvent::DdsDiskCacheMiss { is_fuse: false }.event_type(),
             "dds_disk_cache_miss"
+        );
+    }
+
+    #[test]
+    fn test_mem_cache_write_event_types() {
+        assert_eq!(
+            MetricEvent::MemCacheWriteStarted.event_type(),
+            "mem_cache_write_started"
+        );
+        assert_eq!(
+            MetricEvent::MemCacheWriteCompleted.event_type(),
+            "mem_cache_write_completed"
         );
     }
 

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -108,6 +108,16 @@ pub enum MetricEvent {
         bytes: u64,
     },
 
+    /// Update the current chunk LRU index entry count.
+    ///
+    /// Emitted by the chunk `DiskCacheProvider` after writes and evictions.
+    /// The index is a memory consumer in its own right — millions of entries on
+    /// a full cache — so it is tracked alongside the byte totals.
+    ChunkIndexEntriesUpdate {
+        /// Current number of entries in the chunk LRU index.
+        entries: u64,
+    },
+
     // =========================================================================
     // Memory Cache Events (tile-level, tracked in daemon)
     // =========================================================================
@@ -218,6 +228,7 @@ impl MetricEvent {
             Self::DiskCacheEvicted { .. } => "disk_cache_evicted",
             Self::DiskCacheSizeUpdate { .. } => "disk_cache_size_update",
             Self::DdsDiskCacheSizeUpdate { .. } => "dds_disk_cache_size_update",
+            Self::ChunkIndexEntriesUpdate { .. } => "chunk_index_entries_update",
             Self::MemoryCacheHit { .. } => "memory_cache_hit",
             Self::MemoryCacheMiss { .. } => "memory_cache_miss",
             Self::MemoryCacheSizeUpdate { .. } => "memory_cache_size_update",

--- a/xearthlayer/src/metrics/memory_probe.rs
+++ b/xearthlayer/src/metrics/memory_probe.rs
@@ -14,6 +14,14 @@ pub struct MemorySample {
     pub vm_bytes: u64,
     /// OS thread count. `None` on platforms where it is not read.
     pub threads: Option<u64>,
+    /// Anonymous memory swapped out to disk, in bytes. `None` on platforms
+    /// where it is not read.
+    ///
+    /// This is the field that matters most for diagnosing issue #209: in the
+    /// OOM flight, 54.7 GB of 64 GB anonymous memory was swapped out while
+    /// `rss_bytes` alone read a healthy 9.3 GB. A trace that only logs
+    /// `rss_bytes` cannot see a process swapping itself to death.
+    pub swap_bytes: Option<u64>,
 }
 
 /// Reads the current process's memory footprint.
@@ -43,24 +51,47 @@ impl ProcessMemoryProbe {
         Self
     }
 
-    /// Reads the OS thread count.
+    /// Reads OS thread count and swapped-out anonymous memory in one pass
+    /// over `/proc/self/status`.
     ///
-    /// Linux-only and best-effort: `memory-stats` does not expose thread count,
-    /// and hand-rolling mach FFI for macOS is not worth the risk on a blocking
-    /// CI platform. Thread count is tracked because tokio's blocking pool
-    /// (default 512 threads) is implicated in issue #209.
+    /// Linux-only and best-effort: `memory-stats` does not expose either
+    /// value, and hand-rolling mach FFI for macOS is not worth the risk on a
+    /// blocking CI platform. Thread count is tracked because tokio's blocking
+    /// pool (default 512 threads) is implicated in issue #209; swap is
+    /// tracked because it is the field that actually caught #209 — see
+    /// `MemorySample::swap_bytes`.
+    ///
+    /// Both fields are read from the same file read so the file is only
+    /// opened once per sample.
     #[cfg(target_os = "linux")]
-    fn thread_count() -> Option<u64> {
-        let status = std::fs::read_to_string("/proc/self/status").ok()?;
-        status
-            .lines()
-            .find_map(|line| line.strip_prefix("Threads:"))
-            .and_then(|value| value.trim().parse().ok())
+    fn linux_status_fields() -> (Option<u64>, Option<u64>) {
+        let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+            return (None, None);
+        };
+
+        let mut threads = None;
+        let mut swap_bytes = None;
+
+        for line in status.lines() {
+            if let Some(value) = line.strip_prefix("Threads:") {
+                threads = value.trim().parse().ok();
+            } else if let Some(value) = line.strip_prefix("VmSwap:") {
+                // Format is like "      0 kB" - strip the "kB" suffix, then
+                // the value is already in kB per the /proc/self/status contract.
+                swap_bytes = value
+                    .trim()
+                    .strip_suffix("kB")
+                    .and_then(|kb| kb.trim().parse::<u64>().ok())
+                    .map(|kb| kb * 1024);
+            }
+        }
+
+        (threads, swap_bytes)
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn thread_count() -> Option<u64> {
-        None
+    fn linux_status_fields() -> (Option<u64>, Option<u64>) {
+        (None, None)
     }
 }
 
@@ -73,10 +104,12 @@ impl MemoryProbe for ProcessMemoryProbe {
         });
 
         let stats = memory_stats::memory_stats()?;
+        let (threads, swap_bytes) = Self::linux_status_fields();
         Some(MemorySample {
             rss_bytes: stats.physical_mem as u64,
             vm_bytes: stats.virtual_mem as u64,
-            threads: Self::thread_count(),
+            threads,
+            swap_bytes,
         })
     }
 }
@@ -117,15 +150,26 @@ pub(crate) struct StaticMemoryProbe {
 
 #[cfg(test)]
 impl StaticMemoryProbe {
-    /// Creates a probe returning the given byte counts and 42 threads.
+    /// Creates a probe returning the given byte counts, 42 threads, and zero swap.
     pub(crate) fn new(rss_bytes: u64, vm_bytes: u64) -> Self {
         Self {
             sample: Some(MemorySample {
                 rss_bytes,
                 vm_bytes,
                 threads: Some(42),
+                swap_bytes: Some(0),
             }),
         }
+    }
+
+    /// Overrides the configured swap byte count.
+    ///
+    /// No-op if the probe was built with [`Self::unavailable`].
+    pub(crate) fn with_swap_bytes(mut self, swap_bytes: u64) -> Self {
+        if let Some(sample) = self.sample.as_mut() {
+            sample.swap_bytes = Some(swap_bytes);
+        }
+        self
     }
 
     /// Creates a probe that always fails to sample.
@@ -161,6 +205,14 @@ mod tests {
         let sample = probe.sample().unwrap();
         assert_eq!(sample.rss_bytes, 1024);
         assert_eq!(sample.vm_bytes, 2048);
+        assert_eq!(sample.swap_bytes, Some(0));
+    }
+
+    #[test]
+    fn static_probe_swap_bytes_can_be_overridden() {
+        let probe = StaticMemoryProbe::new(1024, 2048).with_swap_bytes(9_999);
+        let sample = probe.sample().unwrap();
+        assert_eq!(sample.swap_bytes, Some(9_999));
     }
 
     #[test]
@@ -175,6 +227,16 @@ mod tests {
         assert!(
             sample.threads.unwrap_or(0) >= 1,
             "linux should report >= 1 thread"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_probe_reports_swap_bytes() {
+        let sample = ProcessMemoryProbe::new().sample().unwrap();
+        assert!(
+            sample.swap_bytes.is_some(),
+            "linux should always expose VmSwap, even if the value is 0"
         );
     }
 }

--- a/xearthlayer/src/metrics/memory_probe.rs
+++ b/xearthlayer/src/metrics/memory_probe.rs
@@ -1,0 +1,166 @@
+//! Process memory sampling.
+//!
+//! Provides a mockable abstraction over reading the current process's memory
+//! footprint. The production implementation is backed by the `memory-stats`
+//! crate, which supports Linux, macOS and Windows; on Unix its only dependency
+//! is `libc`, already in this crate's tree.
+
+/// A point-in-time sample of the process's memory footprint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MemorySample {
+    /// Resident set size in bytes (physical memory currently held).
+    pub rss_bytes: u64,
+    /// Virtual memory size in bytes (address space reserved).
+    pub vm_bytes: u64,
+    /// OS thread count. `None` on platforms where it is not read.
+    pub threads: Option<u64>,
+}
+
+/// Reads the current process's memory footprint.
+///
+/// Implemented as a trait so the metrics daemon can be tested without reading
+/// real process memory.
+pub trait MemoryProbe: Send + Sync {
+    /// Returns the current sample, or `None` if the platform cannot supply one.
+    fn sample(&self) -> Option<MemorySample>;
+}
+
+/// Production probe backed by the `memory-stats` crate.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ProcessMemoryProbe;
+
+impl ProcessMemoryProbe {
+    /// Creates a new probe.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Reads the OS thread count.
+    ///
+    /// Linux-only and best-effort: `memory-stats` does not expose thread count,
+    /// and hand-rolling mach FFI for macOS is not worth the risk on a blocking
+    /// CI platform. Thread count is tracked because tokio's blocking pool
+    /// (default 512 threads) is implicated in issue #209.
+    #[cfg(target_os = "linux")]
+    fn thread_count() -> Option<u64> {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        status
+            .lines()
+            .find_map(|line| line.strip_prefix("Threads:"))
+            .and_then(|value| value.trim().parse().ok())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn thread_count() -> Option<u64> {
+        None
+    }
+}
+
+impl MemoryProbe for ProcessMemoryProbe {
+    fn sample(&self) -> Option<MemorySample> {
+        let stats = memory_stats::memory_stats()?;
+        Some(MemorySample {
+            rss_bytes: stats.physical_mem as u64,
+            vm_bytes: stats.virtual_mem as u64,
+            threads: Self::thread_count(),
+        })
+    }
+}
+
+/// Logs glibc allocator overrides when any are set.
+///
+/// These change how freed memory is returned to the OS, so a trace gathered
+/// with them set is not comparable to one gathered without. Recording them
+/// prevents silently comparing incomparable runs.
+pub fn log_allocator_environment() {
+    let overrides: Vec<String> = [
+        "MALLOC_ARENA_MAX",
+        "MALLOC_MMAP_THRESHOLD_",
+        "MALLOC_TRIM_THRESHOLD_",
+    ]
+    .iter()
+    .filter_map(|key| {
+        std::env::var(key)
+            .ok()
+            .map(|value| format!("{}={}", key, value))
+    })
+    .collect();
+
+    if !overrides.is_empty() {
+        tracing::info!(
+            allocator_env = %overrides.join(" "),
+            "Allocator environment overrides active"
+        );
+    }
+}
+
+/// Test double returning fixed values.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StaticMemoryProbe {
+    sample: Option<MemorySample>,
+}
+
+#[cfg(test)]
+impl StaticMemoryProbe {
+    /// Creates a probe returning the given byte counts and 42 threads.
+    pub(crate) fn new(rss_bytes: u64, vm_bytes: u64) -> Self {
+        Self {
+            sample: Some(MemorySample {
+                rss_bytes,
+                vm_bytes,
+                threads: Some(42),
+            }),
+        }
+    }
+
+    /// Creates a probe that always fails to sample.
+    pub(crate) fn unavailable() -> Self {
+        Self { sample: None }
+    }
+}
+
+#[cfg(test)]
+impl MemoryProbe for StaticMemoryProbe {
+    fn sample(&self) -> Option<MemorySample> {
+        self.sample
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_probe_reports_nonzero_memory() {
+        let probe = ProcessMemoryProbe::new();
+        let sample = probe
+            .sample()
+            .expect("probe must work on supported platforms");
+        assert!(sample.rss_bytes > 0, "rss_bytes should be positive");
+        assert!(sample.vm_bytes > 0, "vm_bytes should be positive");
+    }
+
+    #[test]
+    fn static_probe_returns_configured_values() {
+        let probe = StaticMemoryProbe::new(1024, 2048);
+        let sample = probe.sample().unwrap();
+        assert_eq!(sample.rss_bytes, 1024);
+        assert_eq!(sample.vm_bytes, 2048);
+    }
+
+    #[test]
+    fn unavailable_probe_returns_none() {
+        assert!(StaticMemoryProbe::unavailable().sample().is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_probe_reports_thread_count() {
+        let sample = ProcessMemoryProbe::new().sample().unwrap();
+        assert!(
+            sample.threads.unwrap_or(0) >= 1,
+            "linux should report >= 1 thread"
+        );
+    }
+}

--- a/xearthlayer/src/metrics/memory_probe.rs
+++ b/xearthlayer/src/metrics/memory_probe.rs
@@ -29,6 +29,14 @@ pub trait MemoryProbe: Send + Sync {
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ProcessMemoryProbe;
 
+/// Serializes the first call to `memory_stats()` to work around a race in memory-stats 1.2.0.
+///
+/// memory-stats uses an atomic CAS to guard init on Linux. A concurrent loser thread may read
+/// the uninitialized state before the winner has written it, causing PAGE_SIZE to remain 0 and
+/// both physical_mem and virtual_mem to come out as 0. Calling once here ensures the static
+/// init completes before any concurrent use in the test suite or daemon.
+static MEMORY_STATS_INIT: std::sync::Once = std::sync::Once::new();
+
 impl ProcessMemoryProbe {
     /// Creates a new probe.
     pub fn new() -> Self {
@@ -58,6 +66,12 @@ impl ProcessMemoryProbe {
 
 impl MemoryProbe for ProcessMemoryProbe {
     fn sample(&self) -> Option<MemorySample> {
+        // Serialize the first call to memory_stats to ensure upstream initialization completes
+        // before concurrent use (see MEMORY_STATS_INIT doc comment).
+        MEMORY_STATS_INIT.call_once(|| {
+            let _ = memory_stats::memory_stats();
+        });
+
         let stats = memory_stats::memory_stats()?;
         Some(MemorySample {
             rss_bytes: stats.physical_mem as u64,

--- a/xearthlayer/src/metrics/mod.rs
+++ b/xearthlayer/src/metrics/mod.rs
@@ -9,6 +9,7 @@
 mod client;
 mod daemon;
 mod event;
+mod memory_probe;
 mod optional;
 mod reporter;
 mod snapshot;
@@ -18,6 +19,7 @@ mod system;
 pub use client::MetricsClient;
 pub use daemon::{MetricsDaemon, MetricsStateSnapshot, SharedMetricsState};
 pub use event::MetricEvent;
+pub use memory_probe::{log_allocator_environment, MemoryProbe, MemorySample, ProcessMemoryProbe};
 pub use optional::OptionalMetrics;
 pub use reporter::{MetricsReporter, TuiReporter};
 pub use snapshot::TelemetrySnapshot;

--- a/xearthlayer/src/metrics/optional.rs
+++ b/xearthlayer/src/metrics/optional.rs
@@ -23,6 +23,8 @@ pub trait OptionalMetrics {
     fn memory_cache_hit(&self, is_fuse: bool);
     fn memory_cache_miss(&self, is_fuse: bool);
     fn memory_cache_size(&self, bytes: u64);
+    fn mem_cache_write_started(&self);
+    fn mem_cache_write_completed(&self);
     fn job_submitted(&self, is_fuse: bool);
     fn job_started(&self);
     fn job_completed(&self, success: bool, duration_us: u64);
@@ -149,6 +151,20 @@ impl OptionalMetrics for Option<MetricsClient> {
     }
 
     #[inline]
+    fn mem_cache_write_started(&self) {
+        if let Some(client) = self {
+            client.mem_cache_write_started();
+        }
+    }
+
+    #[inline]
+    fn mem_cache_write_completed(&self) {
+        if let Some(client) = self {
+            client.mem_cache_write_completed();
+        }
+    }
+
+    #[inline]
     fn job_submitted(&self, is_fuse: bool) {
         if let Some(client) = self {
             client.job_submitted(is_fuse);
@@ -234,6 +250,8 @@ mod tests {
         optional.download_started();
         optional.download_completed(100, 50);
         optional.job_submitted(true);
+        optional.mem_cache_write_started();
+        optional.mem_cache_write_completed();
     }
 
     #[test]
@@ -244,5 +262,7 @@ mod tests {
         optional.download_started();
         optional.download_completed(100, 50);
         optional.job_submitted(true);
+        optional.mem_cache_write_started();
+        optional.mem_cache_write_completed();
     }
 }

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -191,6 +191,11 @@ pub struct AggregatedState {
     pub fuse_memory_cache_misses: u64,
     /// Current memory cache size in bytes.
     pub memory_cache_size_bytes: u64,
+    /// Fire-and-forget memory cache writes currently in flight (the spawn in
+    /// `BuildAndCacheDdsTask` that calls `MemoryCache::put`). Mirrors
+    /// `disk_writes_active` but for the memory-cache tier, which previously had
+    /// no in-flight gauge at all — see issue #209.
+    pub mem_cache_writes_active: u64,
 
     // =========================================================================
     // Job Metrics
@@ -283,6 +288,7 @@ impl AggregatedState {
             fuse_memory_cache_hits: 0,
             fuse_memory_cache_misses: 0,
             memory_cache_size_bytes: 0,
+            mem_cache_writes_active: 0,
             jobs_submitted: 0,
             fuse_jobs_submitted: 0,
             jobs_completed: 0,
@@ -332,6 +338,7 @@ impl AggregatedState {
         self.fuse_memory_cache_hits = 0;
         self.fuse_memory_cache_misses = 0;
         self.memory_cache_size_bytes = 0;
+        self.mem_cache_writes_active = 0;
         self.jobs_submitted = 0;
         self.fuse_jobs_submitted = 0;
         self.jobs_completed = 0;

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -154,6 +154,8 @@ pub struct AggregatedState {
     pub disk_bytes_evicted: u64,
     /// Current chunk disk cache size in bytes (absolute value from LRU index).
     pub chunk_disk_cache_size_bytes: u64,
+    /// Current number of entries in the chunk disk cache LRU index.
+    pub chunk_index_entries: u64,
 
     // =========================================================================
     // DDS Disk Cache Metrics
@@ -267,6 +269,7 @@ impl AggregatedState {
             initial_disk_cache_bytes: 0,
             disk_bytes_evicted: 0,
             chunk_disk_cache_size_bytes: 0,
+            chunk_index_entries: 0,
             dds_disk_cache_hits: 0,
             dds_disk_cache_misses: 0,
             fuse_dds_disk_cache_hits: 0,

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -140,7 +140,9 @@ pub struct AggregatedState {
     pub chunk_disk_cache_hits: u64,
     /// Chunk disk cache misses.
     pub chunk_disk_cache_misses: u64,
-    /// Active disk writes (chunks only — DDS writes don't emit write events).
+    /// Active disk writes across both tiers: chunk disk cache writes and
+    /// DDS disk cache writes both emit `DiskWriteStarted`/`DiskWriteCompleted`
+    /// and are counted here.
     pub disk_writes_active: u64,
     /// Total bytes written to chunk disk cache.
     pub chunk_disk_bytes_written: u64,

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -785,7 +785,7 @@ impl AdaptivePrefetchCoordinator {
         let (lat, lon) = position;
 
         if let Some(ref metadata) = plan.metadata {
-            tracing::info!(
+            tracing::debug!(
                 strategy = plan.strategy,
                 tiles = plan.tile_count(),
                 skipped_cached = plan.skipped_cached,
@@ -800,7 +800,7 @@ impl AdaptivePrefetchCoordinator {
                 "Prefetch plan calculated"
             );
         } else {
-            tracing::info!(
+            tracing::debug!(
                 strategy = plan.strategy,
                 tiles = plan.tile_count(),
                 estimated_ms = plan.estimated_completion_ms,

--- a/xearthlayer/src/tasks/build_and_cache_dds.rs
+++ b/xearthlayer/src/tasks/build_and_cache_dds.rs
@@ -29,7 +29,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::Instrument;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 /// Tile dimensions
 const TILE_SIZE: u32 = 4096;
@@ -322,7 +322,7 @@ where
                     );
                 }
 
-                info!(
+                debug!(
                     job_id = %job_id,
                     tile = ?self.tile,
                     size_bytes = dds_size,

--- a/xearthlayer/src/tasks/build_and_cache_dds.rs
+++ b/xearthlayer/src/tasks/build_and_cache_dds.rs
@@ -268,13 +268,24 @@ where
                     // Step 4: Spawn fire-and-forget memory cache write
                     // This avoids blocking the job completion on cache write,
                     // and avoids race conditions with eventual consistency caches.
+                    //
+                    // Instrumented with mem_cache_write_started/completed (mirroring
+                    // the DDS-disk spawn below) so this backlog is visible as
+                    // mem_cache_writes_active — previously this spawn emitted no
+                    // start/complete pair at all, only a size gauge that only moves
+                    // after `cache.put()` completes. See issue #209.
                     let cache = Arc::clone(&self.memory_cache);
                     let tile = self.tile;
                     let dds_data_for_cache = dds_data.clone();
+                    let metrics_for_mem = metrics.clone();
                     tokio::spawn(async move {
+                        metrics_for_mem.mem_cache_write_started();
+
                         cache
                             .put(tile.row, tile.col, tile.zoom, dds_data_for_cache)
                             .await;
+
+                        metrics_for_mem.mem_cache_write_completed();
 
                         debug!(
                             tile = ?tile,
@@ -664,5 +675,62 @@ mod tests {
             .expect("DDS disk cache put must fire within 1s for complete tile")
             .expect("DDS disk cache channel closed unexpectedly");
         assert_eq!(disk_put, (100, 200, 15));
+    }
+
+    // ------------------------------------------------------------------
+    // mem_cache_writes_active instrumentation (#209 fix wave)
+    //
+    // Regression guard for the diagnosis hole: before this fix, the
+    // memory-cache spawn emitted no start/complete metrics pair at all, so a
+    // backlog concentrated there was invisible to `mem_cache_writes_active`
+    // and would misread as allocator retention. This asserts the production
+    // spawn actually emits the pair, not just that the daemon can count it.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn complete_tile_reports_mem_cache_write_started_and_completed() {
+        use crate::metrics::MetricEvent;
+        use crate::metrics::MetricsClient;
+
+        let mut chunks = ChunkResults::new();
+        for row in 0..16u8 {
+            for col in 0..16u8 {
+                chunks.add_success(row, col, vec![]);
+            }
+        }
+        assert!(chunks.is_complete());
+
+        let (task, _mem_rx, _disk_rx, ctx) = make_task_with_chunks(chunks);
+
+        let (metrics_tx, mut metrics_rx) = unbounded_channel();
+        let mut ctx = ctx.with_metrics(MetricsClient::new(metrics_tx));
+
+        let result = task.execute(&mut ctx).await;
+        assert!(matches!(result, TaskResult::SuccessWithOutput(_)));
+
+        // The memory-cache spawn and the DDS-disk spawn run concurrently and
+        // share this channel, so interleave with other event types (encode,
+        // disk write, ...) is expected. Filter to just the mem-cache pair;
+        // sends from a single spawned task preserve their own call order.
+        let mut mem_write_events = Vec::new();
+        let deadline = Duration::from_secs(2);
+        while mem_write_events.len() < 2 {
+            match tokio::time::timeout(deadline, metrics_rx.recv()).await {
+                Ok(Some(MetricEvent::MemCacheWriteStarted)) => {
+                    mem_write_events.push("started");
+                }
+                Ok(Some(MetricEvent::MemCacheWriteCompleted)) => {
+                    mem_write_events.push("completed");
+                }
+                Ok(Some(_)) => {} // other events (encode/assembly/disk) are irrelevant here
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        assert_eq!(
+            mem_write_events,
+            vec!["started", "completed"],
+            "memory cache spawn must emit MemCacheWriteStarted then MemCacheWriteCompleted"
+        );
     }
 }

--- a/xearthlayer/src/tasks/download_chunks.rs
+++ b/xearthlayer/src/tasks/download_chunks.rs
@@ -28,7 +28,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::task::JoinSet;
-use tracing::{debug, info, trace, warn, Instrument};
+use tracing::{debug, trace, warn, Instrument};
 
 /// Task that downloads all chunks for a tile.
 ///
@@ -358,7 +358,7 @@ where
                 let duration_us = download_start.elapsed().as_micros() as u64;
                 let bytes = data.len() as u64;
 
-                info!(
+                debug!(
                     provider = provider.name(),
                     global_row = global_row,
                     global_col = global_col,


### PR DESCRIPTION
## Summary

Adds the instrument needed to diagnose the OOM kill in #209, and cuts the log verbosity that would otherwise bury it.

A 12-hour flight ended with the kernel OOM-killing the process at 64 GB of anonymous memory against a configured 4 GB memory cache. There was no application error — the last log line is the instant of the kill. Three candidate causes remain live and undiscriminated. This branch makes the next long flight produce a trace that tells them apart, without anyone needing to set environment variables or fly a controlled route.

The core idea: a once-per-minute `Memory sample` INFO line carrying process memory alongside the cache, GC and load state needed to interpret it. `disk_writes_active` and `mem_cache_writes_active` correlated against `rss_mb` and `swap_mb` are what discriminate the candidates.

```
2026-08-06 06:20:33Z  INFO Memory sample uptime_s=60 rss_mb=873 vm_mb=1459 swap_mb=0
  threads=71 tiles_done=0 encodes_active=0 chunks_ok=0 chunks_failed=0 mem_cache_mb=0
  dds_disk_mb=158268 chunk_disk_mb=55301 gc_evicted_mb=0 chunk_index_entries=3803083
  disk_writes_active=0 mem_cache_writes_active=0
```

## Changes

- **`MemoryProbe` trait + `ProcessMemoryProbe`** (`metrics/memory_probe.rs`) backed by the `memory-stats` crate — the only new dependency. Injected into `MetricsDaemon`, so the daemon stays testable without reading real process memory.
- **16-field `Memory sample` line** emitted on a fixed 60-second tick. Deliberately not configurable: traces get pooled across users and machines, and a fixed cadence removes one variable.
- **Two new metrics.** `chunk_index_entries` exposes chunk LRU index size (~12 M entries during the OOM flight, one of the candidate causes). `mem_cache_writes_active` closes a diagnostic hole — see below.
- **Allocator-environment line at startup**, recording `MALLOC_*` overrides when set, so a trace taken with them active is never silently compared against one without.
- **Six high-volume `info!` sites demoted to `debug!`.** `Chunk download success` alone was 3,803,083 lines — 98.6% of a 501 MB log from a 1h29m flight. A 12-hour flight drops from roughly 4 GB to roughly 50 MB, small enough to attach to an issue.
- **`docs/dev/memory-telemetry.md`** — field reference, a decision table for interpreting a trace, and a confounder section. Cross-referenced with `memory-profiling.md`, which cannot capture an OOM kill because heaptrack loses all data on `kill -9`.

### Two bugs found and fixed along the way

- **Upstream race in `memory-stats` 1.2.0.** Its Linux path guards one-time init with a CAS; the thread that *loses* skips init entirely and reads `SMAPS_EXIST` before the winner stores it, falling through to the STATM path with `PAGE_SIZE` still `0`. Result: a silent `MemoryStats { 0, 0 }`. In a memory trace that reads as "the process used no memory" — precisely the investigation this exists to serve. Closed with a `std::sync::Once` warm-up; verified over 20 consecutive runs after failing 2 in 6 before.
- **False doc comment** on `disk_writes_active` claiming DDS writes don't emit write events. They do (`build_and_cache_dds.rs:294`/`:307`). That field is the primary discriminator, and the comment would have led a reader to dismiss the leading candidate.

### Scope note

The final review found the originally-designed 14 fields could point at the *wrong* cause, so two were added:

- **`swap_mb`** — 54.7 GB of the 64 GB in #209 was swapped out, so an RSS-only trace would have shown a flat ~9 GB and read as healthy. `/proc/self/status` was already being opened for `Threads:` and carries `VmSwap:` a few lines away.
- **`mem_cache_writes_active`** — the memory-cache `tokio::spawn` in `build_and_cache_dds.rs` emitted no start/complete pair, so a backlog concentrated there presented as "rss climbing, gauges flat" and would have been read as allocator retention rather than a write backlog.

## Related Issues

Related: #209

## Test Plan

- [x] `make pre-commit` passes (fmt + clippy + tests) — 2420 lib tests, 78 CLI, 63 doctests, 0 failures
- [x] Field-assertion test verified by **mutation**: swapping a field's source (`mem_cache_mb` → `dds_disk_cache_size_bytes`) makes it fail; restoring makes it pass. Every numeric field is seeded with a pairwise-distinct value, asserted distinct at runtime, so a swap between any two cannot pass silently
- [x] MB truncation asserted with non-whole-MB byte counts, so raw bytes leaking under an `_mb` name fails
- [x] `memory-stats` race fix verified over 20 consecutive runs (was 2 failures in 6)
- [x] Live smoke check on real hardware with a FUSE mount: allocator line plus `Memory sample` lines 60 s apart, all fields populated
- [x] Log demotion verified at source level — none of the six messages remain at `info!`; `Chunk download error`/`failed` deliberately left at `warn!`

Reviewers can verify the live behaviour with:

```bash
cargo build --release
MALLOC_ARENA_MAX=2 ./target/release/xearthlayer run
# after ~70s:
grep -E "Allocator environment|Memory sample" ~/.xearthlayer/xearthlayer.log
```

## Checklist

- [x] Code follows the project's SOLID principles and patterns
- [x] Tests added or updated for new/changed behavior
- [x] Documentation updated if applicable (CLAUDE.md, docs/, config reference)
- [x] No new warnings from `cargo clippy`

## Known follow-up (not addressed here)

`metrics/daemon.rs` adds every `DiskWriteCompleted { bytes }` into `state.chunk_disk_bytes_written`, including ~11 MB DDS writes, so DDS bytes inflate a chunk-tier counter that feeds the TUI throughput display. Pre-existing, deliberately left untouched — changing it would alter TUI numbers and belongs in its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
