### PR TITLE
fix(cache): attribute disk write bytes per tier and consolidate DiskTier

### DIFF
--- a/xearthlayer-cli/src/ui/dashboard/mod.rs
+++ b/xearthlayer-cli/src/ui/dashboard/mod.rs
@@ -191,7 +191,7 @@ impl Dashboard {
 
         // Update disk history (both reads and writes for I/O tracking)
         self.disk_history.update(
-            snapshot.chunk_disk_bytes_written,
+            snapshot.chunk_disk_bytes_written + snapshot.dds_disk_bytes_written,
             snapshot.chunk_disk_bytes_read + snapshot.dds_disk_bytes_read,
             sample_interval,
         );

--- a/xearthlayer-cli/src/ui/widgets/input_output.rs
+++ b/xearthlayer-cli/src/ui/widgets/input_output.rs
@@ -232,7 +232,8 @@ impl Widget for InputOutputWidget<'_> {
             };
 
         // Total disk I/O this session
-        let total_disk_writes = self.snapshot.chunk_disk_bytes_written;
+        let total_disk_writes =
+            self.snapshot.chunk_disk_bytes_written + self.snapshot.dds_disk_bytes_written;
         let total_disk_reads =
             self.snapshot.chunk_disk_bytes_read + self.snapshot.dds_disk_bytes_read;
 

--- a/xearthlayer/src/cache/config.rs
+++ b/xearthlayer/src/cache/config.rs
@@ -183,7 +183,7 @@ impl DiskProviderConfig {
                 gc_interval: *gc_interval,
                 provider_name: provider_name.clone(),
                 metrics_client: None,
-                tier: DiskTier::Chunk,
+                tier: config.tier,
             }),
             ProviderConfig::Memory { .. } => None,
         }
@@ -295,5 +295,19 @@ mod tests {
         )
         .as_dds_tier();
         assert_eq!(dds.tier, DiskTier::Dds);
+    }
+
+    #[test]
+    fn from_service_config_propagates_dds_tier() {
+        let config = ServiceCacheConfig::disk(
+            1_000_000,
+            PathBuf::from("/tmp/xel-tier-test"),
+            Duration::from_secs(60),
+            "bing".to_string(),
+        )
+        .as_dds_tier();
+
+        let disk_config = DiskProviderConfig::from_service_config(&config).unwrap();
+        assert_eq!(disk_config.tier, DiskTier::Dds);
     }
 }

--- a/xearthlayer/src/cache/config.rs
+++ b/xearthlayer/src/cache/config.rs
@@ -7,6 +7,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::cache::DiskTier;
 use crate::config::DEFAULT_MEMORY_CACHE_SIZE;
 use crate::metrics::MetricsClient;
 
@@ -23,8 +24,8 @@ pub struct ServiceCacheConfig {
     /// For disk caches, this enables GC eviction reporting.
     pub metrics_client: Option<MetricsClient>,
 
-    /// Whether this is a DDS tile cache tier (affects metric event routing).
-    pub is_dds_tier: bool,
+    /// Which disk cache tier this config describes.
+    pub tier: DiskTier,
 }
 
 /// Provider-specific configuration.
@@ -70,7 +71,7 @@ impl ServiceCacheConfig {
             max_size_bytes,
             provider: ProviderConfig::Memory { ttl },
             metrics_client: None,
-            is_dds_tier: false,
+            tier: DiskTier::Chunk,
         }
     }
 
@@ -107,7 +108,7 @@ impl ServiceCacheConfig {
                 provider_name,
             },
             metrics_client: None,
-            is_dds_tier: false,
+            tier: DiskTier::Chunk,
         }
     }
 
@@ -116,7 +117,7 @@ impl ServiceCacheConfig {
     /// DDS tier providers emit `dds_disk_cache_size` metrics instead of
     /// `disk_cache_size`, allowing the TUI to correctly aggregate both tiers.
     pub fn as_dds_tier(mut self) -> Self {
-        self.is_dds_tier = true;
+        self.tier = DiskTier::Dds;
         self
     }
 
@@ -157,8 +158,8 @@ pub struct DiskProviderConfig {
     /// Optional metrics client for reporting GC eviction stats.
     pub metrics_client: Option<MetricsClient>,
 
-    /// Whether this is a DDS tile cache tier (affects which metric event is emitted).
-    pub is_dds_tier: bool,
+    /// Which disk cache tier this config describes.
+    pub tier: DiskTier,
 }
 
 impl DiskProviderConfig {
@@ -182,7 +183,7 @@ impl DiskProviderConfig {
                 gc_interval: *gc_interval,
                 provider_name: provider_name.clone(),
                 metrics_client: None,
-                is_dds_tier: false,
+                tier: DiskTier::Chunk,
             }),
             ProviderConfig::Memory { .. } => None,
         }
@@ -274,5 +275,25 @@ mod tests {
         let config = ServiceCacheConfig::memory(1_000_000, None);
         let disk_config = DiskProviderConfig::from_service_config(&config);
         assert!(disk_config.is_none());
+    }
+
+    #[test]
+    fn disk_config_defaults_to_chunk_tier_and_builder_sets_dds() {
+        let config = ServiceCacheConfig::disk(
+            1_000_000,
+            PathBuf::from("/tmp/xel-tier-test"),
+            Duration::from_secs(60),
+            "bing".to_string(),
+        );
+        assert_eq!(config.tier, DiskTier::Chunk);
+
+        let dds = ServiceCacheConfig::disk(
+            1_000_000,
+            PathBuf::from("/tmp/xel-tier-test"),
+            Duration::from_secs(60),
+            "bing".to_string(),
+        )
+        .as_dds_tier();
+        assert_eq!(dds.tier, DiskTier::Dds);
     }
 }

--- a/xearthlayer/src/cache/mod.rs
+++ b/xearthlayer/src/cache/mod.rs
@@ -79,7 +79,7 @@ pub use clients::{ChunkCacheClient, TileCacheClient};
 // Legacy exports (backward compatibility)
 pub use memory::MemoryCache;
 pub use stats::{CacheStatistics, CacheStats};
-pub use types::{CacheError, CacheKey, DiskCacheConfig, MemoryCacheConfig};
+pub use types::{CacheError, CacheKey, DiskCacheConfig, DiskTier, MemoryCacheConfig};
 
 // Re-export path utilities for convenience
 pub use path::{

--- a/xearthlayer/src/cache/providers/disk.rs
+++ b/xearthlayer/src/cache/providers/disk.rs
@@ -37,6 +37,7 @@ use tracing::{debug, info, warn};
 use crate::cache::config::DiskProviderConfig;
 use crate::cache::lru_index::LruIndex;
 use crate::cache::traits::{BoxFuture, Cache, GcResult, ServiceCacheError};
+use crate::cache::DiskTier;
 use crate::metrics::MetricsClient;
 
 /// On-disk cache provider with LRU index tracking.
@@ -67,9 +68,9 @@ pub struct DiskCacheProvider {
     /// Optional metrics client for reporting cache size updates.
     metrics_client: Option<MetricsClient>,
 
-    /// Whether this provider serves the DDS tile tier (vs chunk tier).
+    /// Which disk cache tier this provider serves.
     /// Controls which metric event is emitted for size updates.
-    is_dds_tier: bool,
+    tier: DiskTier,
 }
 
 impl DiskCacheProvider {
@@ -106,7 +107,7 @@ impl DiskCacheProvider {
             lru_index,
             shutdown,
             metrics_client: config.metrics_client,
-            is_dds_tier: config.is_dds_tier,
+            tier: config.tier,
         });
 
         // Populate LRU index from disk
@@ -114,7 +115,7 @@ impl DiskCacheProvider {
             Ok(stats) => {
                 info!(
                     dir = %config.directory.display(),
-                    tier = if config.is_dds_tier { "dds" } else { "chunks" },
+                    tier = %config.tier,
                     files = stats.files_indexed,
                     skipped = stats.skipped_unparseable,
                     size_mb = stats.total_bytes / 1_000_000,
@@ -160,7 +161,7 @@ impl DiskCacheProvider {
             lru_index,
             shutdown,
             metrics_client: config.metrics_client,
-            is_dds_tier: config.is_dds_tier,
+            tier: config.tier,
         });
 
         info!(
@@ -244,7 +245,7 @@ impl DiskCacheProvider {
     /// When set, size updates emit `dds_disk_cache_size` metrics instead of
     /// `disk_cache_size`, allowing the TUI to correctly aggregate both tiers.
     pub fn set_dds_tier(&mut self) {
-        self.is_dds_tier = true;
+        self.tier = DiskTier::Dds;
     }
 
     /// Report current cache size to metrics, using the appropriate event
@@ -252,11 +253,12 @@ impl DiskCacheProvider {
     fn report_size_to_metrics(&self) {
         let size = self.lru_index.total_size();
         if let Some(ref client) = self.metrics_client {
-            if self.is_dds_tier {
-                client.dds_disk_cache_size(size);
-            } else {
-                client.disk_cache_size(size);
-                client.chunk_index_entries(self.lru_index.entry_count());
+            match self.tier {
+                DiskTier::Dds => client.dds_disk_cache_size(size),
+                DiskTier::Chunk => {
+                    client.disk_cache_size(size);
+                    client.chunk_index_entries(self.lru_index.entry_count());
+                }
             }
         }
     }
@@ -281,7 +283,7 @@ impl Cache for DiskCacheProvider {
                 key = %key_owned,
                 size,
                 path = %path.display(),
-                tier = if self.is_dds_tier { "dds" } else { "chunks" },
+                tier = %self.tier,
                 "Disk cache write starting"
             );
 
@@ -307,10 +309,13 @@ impl Cache for DiskCacheProvider {
             // Report authoritative cache size to metrics
             self.report_size_to_metrics();
 
-            if self.is_dds_tier {
-                debug!(key = %key_owned, size, path = %path.display(), "DDS disk cache write complete");
-            } else {
-                debug!(key = %key_owned, size, "Cache set");
+            match self.tier {
+                DiskTier::Dds => {
+                    debug!(key = %key_owned, size, path = %path.display(), "DDS disk cache write complete");
+                }
+                DiskTier::Chunk => {
+                    debug!(key = %key_owned, size, "Cache set");
+                }
             }
             Ok(())
         })
@@ -319,7 +324,7 @@ impl Cache for DiskCacheProvider {
     fn get(&self, key: &str) -> BoxFuture<'_, Result<Option<Vec<u8>>, ServiceCacheError>> {
         let path = self.key_path(key);
         let key_owned = key.to_string();
-        let is_dds = self.is_dds_tier;
+        let tier = self.tier;
 
         Box::pin(async move {
             match tokio::fs::read(&path).await {
@@ -330,7 +335,7 @@ impl Cache for DiskCacheProvider {
                         key = %key_owned,
                         size = data.len(),
                         path = %path.display(),
-                        tier = if is_dds { "dds" } else { "chunks" },
+                        tier = %tier,
                         "Disk cache hit"
                     );
                     Ok(Some(data))
@@ -344,7 +349,7 @@ impl Cache for DiskCacheProvider {
                     debug!(
                         key = %key_owned,
                         path = %path.display(),
-                        tier = if is_dds { "dds" } else { "chunks" },
+                        tier = %tier,
                         was_in_index,
                         "Disk cache miss — file not found"
                     );
@@ -354,7 +359,7 @@ impl Cache for DiskCacheProvider {
                     warn!(
                         key = %key_owned,
                         path = %path.display(),
-                        tier = if is_dds { "dds" } else { "chunks" },
+                        tier = %tier,
                         error = %e,
                         "Disk cache read error"
                     );
@@ -401,11 +406,11 @@ impl Cache for DiskCacheProvider {
         // produce at most a skipped plan entry that X-Plane later
         // requests via FUSE and properly generates.
         let in_index = self.lru_index.contains(key);
-        let is_dds = self.is_dds_tier;
+        let tier = self.tier;
         debug!(
             key = %key,
             in_index,
-            tier = if is_dds { "dds" } else { "chunks" },
+            tier = %tier,
             "Disk cache contains (index-only)"
         );
         Box::pin(async move { Ok(in_index) })
@@ -464,7 +469,7 @@ mod tests {
             gc_interval: Duration::from_secs(3600), // Not used anymore
             provider_name: "test".to_string(),
             metrics_client: None,
-            is_dds_tier: false,
+            tier: DiskTier::Chunk,
         };
 
         let provider = DiskCacheProvider::start(config).await.unwrap();
@@ -665,7 +670,7 @@ mod tests {
             gc_interval: Duration::from_secs(3600),
             provider_name: "test".to_string(),
             metrics_client: None,
-            is_dds_tier: false,
+            tier: DiskTier::Chunk,
         };
 
         // start() internally calls populate_from_disk()
@@ -706,7 +711,7 @@ mod tests {
                 gc_interval: Duration::from_secs(3600),
                 provider_name: "test".to_string(),
                 metrics_client: None,
-                is_dds_tier: false,
+                tier: DiskTier::Chunk,
             };
             let provider = DiskCacheProvider::start(config).await.unwrap();
 
@@ -722,7 +727,7 @@ mod tests {
                 gc_interval: Duration::from_secs(3600),
                 provider_name: "test".to_string(),
                 metrics_client: None,
-                is_dds_tier: false,
+                tier: DiskTier::Chunk,
             };
             let provider = DiskCacheProvider::start(config).await.unwrap();
 

--- a/xearthlayer/src/cache/providers/disk.rs
+++ b/xearthlayer/src/cache/providers/disk.rs
@@ -240,14 +240,6 @@ impl DiskCacheProvider {
         (max as f64 * 0.80) as u64
     }
 
-    /// Mark this provider as serving the DDS tile cache tier.
-    ///
-    /// When set, size updates emit `dds_disk_cache_size` metrics instead of
-    /// `disk_cache_size`, allowing the TUI to correctly aggregate both tiers.
-    pub fn set_dds_tier(&mut self) {
-        self.tier = DiskTier::Dds;
-    }
-
     /// Report current cache size to metrics, using the appropriate event
     /// based on whether this is the DDS or chunk tier.
     fn report_size_to_metrics(&self) {

--- a/xearthlayer/src/cache/service.rs
+++ b/xearthlayer/src/cache/service.rs
@@ -118,7 +118,7 @@ impl CacheService {
                     gc_interval,
                     provider_name: provider_name.clone(),
                     metrics_client: config.metrics_client,
-                    is_dds_tier: config.is_dds_tier,
+                    tier: config.tier,
                 };
 
                 let provider = DiskCacheProvider::start(disk_config).await?;

--- a/xearthlayer/src/cache/types.rs
+++ b/xearthlayer/src/cache/types.rs
@@ -2,6 +2,7 @@
 
 use crate::coord::TileCoord;
 use crate::dds::DdsFormat;
+use std::fmt;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -96,6 +97,39 @@ impl Default for DiskCacheConfig {
     }
 }
 
+/// Which disk cache tier a write belongs to.
+///
+/// Chunk-tier writes are small and frequent (~14 KB, thousands per second);
+/// DDS-tier writes are large and rare (11.17 MB, a few per second). Attributing
+/// bytes to a tier keeps `chunk_disk_bytes_written` honest — see issue #216.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiskTier {
+    /// The chunk disk cache.
+    Chunk,
+    /// The DDS tile disk cache.
+    Dds,
+}
+
+impl DiskTier {
+    /// Stable label for log fields.
+    ///
+    /// These exact strings already appear in disk cache log output; changing
+    /// them would break existing log greps. Note the asymmetry — the chunk
+    /// label is plural, the DDS label is not.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Chunk => "chunks",
+            Self::Dds => "dds",
+        }
+    }
+}
+
+impl fmt::Display for DiskTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,5 +218,16 @@ mod tests {
         assert_eq!(config.daemon_interval_secs, 60);
         assert!(config.max_age_days.is_none());
         assert!(config.cache_dir.ends_with("xearthlayer"));
+    }
+
+    // These exact strings already appear in disk cache log output. Changing
+    // them — including "normalising" the plural — would break existing log
+    // greps and dashboard filters.
+    #[test]
+    fn disk_tier_labels_are_stable() {
+        assert_eq!(DiskTier::Chunk.as_str(), "chunks");
+        assert_eq!(DiskTier::Dds.as_str(), "dds");
+        assert_eq!(format!("{}", DiskTier::Chunk), "chunks");
+        assert_eq!(format!("{}", DiskTier::Dds), "dds");
     }
 }

--- a/xearthlayer/src/executor/traits.rs
+++ b/xearthlayer/src/executor/traits.rs
@@ -31,6 +31,7 @@
 //! └─────────────────────────────────────────────────────────────┘
 //! ```
 
+use crate::cache::DiskTier;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -200,6 +201,10 @@ pub trait MemoryCache: Send + Sync + 'static {
 /// Disk cache stores individual JPEG chunks for persistence across sessions.
 /// Operations are async since they involve disk I/O.
 pub trait DiskCache: Send + Sync + 'static {
+    /// The cache tier this trait writes to. Derived rather than declared at
+    /// call sites so a wrong tier cannot be typed by hand — see issue #216.
+    const TIER: DiskTier = DiskTier::Chunk;
+
     /// Gets a chunk from the cache.
     ///
     /// # Arguments
@@ -241,6 +246,10 @@ pub trait DiskCache: Send + Sync + 'static {
 /// Uses the same tile-level key space as [`MemoryCache`] but backed by disk
 /// storage with LRU eviction.
 pub trait DdsDiskCache: Send + Sync + 'static {
+    /// The cache tier this trait writes to. Derived rather than declared at
+    /// call sites so a wrong tier cannot be typed by hand — see issue #216.
+    const TIER: DiskTier = DiskTier::Dds;
+
     /// Gets a DDS tile from the disk cache.
     ///
     /// Returns `Some(data)` if the tile is cached on disk, `None` otherwise.
@@ -602,5 +611,16 @@ mod tests {
         // Use futures::executor for a simple sync test
         let result = futures::executor::block_on(future);
         assert_eq!(result.unwrap(), 42);
+    }
+
+    use crate::cache::{DdsDiskCacheBridge, DiskCacheBridge};
+
+    // Pins the tier to the trait rather than to a hand-typed argument at each
+    // call site. Asserted against the bridges actually wired in production,
+    // not stubs.
+    #[test]
+    fn cache_traits_carry_their_own_tier() {
+        assert_eq!(<DiskCacheBridge as DiskCache>::TIER, DiskTier::Chunk);
+        assert_eq!(<DdsDiskCacheBridge as DdsDiskCache>::TIER, DiskTier::Dds);
     }
 }

--- a/xearthlayer/src/manager/mounts.rs
+++ b/xearthlayer/src/manager/mounts.rs
@@ -731,6 +731,7 @@ impl MountManager {
             chunk_disk_cache_hit_rate: 0.0,
             chunk_disk_cache_size_bytes: 0,
             chunk_disk_bytes_written: 0,
+            dds_disk_bytes_written: 0,
             chunk_disk_bytes_read: 0,
             encodes_completed: 0,
             encodes_active: 0,
@@ -802,6 +803,9 @@ impl MountManager {
             total.chunk_disk_bytes_written = total
                 .chunk_disk_bytes_written
                 .max(snapshot.chunk_disk_bytes_written);
+            total.dds_disk_bytes_written = total
+                .dds_disk_bytes_written
+                .max(snapshot.dds_disk_bytes_written);
             total.dds_disk_bytes_read = total.dds_disk_bytes_read.max(snapshot.dds_disk_bytes_read);
             total.chunk_disk_bytes_read = total
                 .chunk_disk_bytes_read

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -150,15 +150,10 @@ impl MetricsClient {
     /// # Arguments
     ///
     /// * `bytes` - Number of bytes written
-    /// * `duration_us` - Time taken in microseconds
     /// * `tier` - Which cache tier the bytes belong to
     #[inline]
-    pub fn disk_write_completed(&self, bytes: u64, duration_us: u64, tier: DiskTier) {
-        self.send(MetricEvent::DiskWriteCompleted {
-            bytes,
-            duration_us,
-            tier,
-        });
+    pub fn disk_write_completed(&self, bytes: u64, tier: DiskTier) {
+        self.send(MetricEvent::DiskWriteCompleted { bytes, tier });
     }
 
     /// Sets the initial disk cache size (scanned on startup).
@@ -423,7 +418,7 @@ mod tests {
 
         client.chunk_disk_cache_hit(2048);
         client.chunk_disk_cache_miss();
-        client.disk_write_completed(2048, 1000, DiskTier::Chunk);
+        client.disk_write_completed(2048, DiskTier::Chunk);
         client.disk_cache_size(9_000_000_000);
         client.memory_cache_hit(true);
         client.memory_cache_miss(false);
@@ -441,7 +436,6 @@ mod tests {
             rx.recv().await,
             Some(MetricEvent::DiskWriteCompleted {
                 bytes: 2048,
-                duration_us: 1000,
                 tier: DiskTier::Chunk
             })
         ));

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -21,7 +21,7 @@
 //! client.chunk_disk_cache_hit(30_000);
 //! ```
 
-use super::event::MetricEvent;
+use super::event::{DiskTier, MetricEvent};
 use tokio::sync::mpsc;
 
 /// Client for emitting metric events to the metrics daemon.
@@ -151,9 +151,14 @@ impl MetricsClient {
     ///
     /// * `bytes` - Number of bytes written
     /// * `duration_us` - Time taken in microseconds
+    /// * `tier` - Which cache tier the bytes belong to
     #[inline]
-    pub fn disk_write_completed(&self, bytes: u64, duration_us: u64) {
-        self.send(MetricEvent::DiskWriteCompleted { bytes, duration_us });
+    pub fn disk_write_completed(&self, bytes: u64, duration_us: u64, tier: DiskTier) {
+        self.send(MetricEvent::DiskWriteCompleted {
+            bytes,
+            duration_us,
+            tier,
+        });
     }
 
     /// Sets the initial disk cache size (scanned on startup).
@@ -418,7 +423,7 @@ mod tests {
 
         client.chunk_disk_cache_hit(2048);
         client.chunk_disk_cache_miss();
-        client.disk_write_completed(2048, 1000);
+        client.disk_write_completed(2048, 1000, DiskTier::Chunk);
         client.disk_cache_size(9_000_000_000);
         client.memory_cache_hit(true);
         client.memory_cache_miss(false);
@@ -436,7 +441,8 @@ mod tests {
             rx.recv().await,
             Some(MetricEvent::DiskWriteCompleted {
                 bytes: 2048,
-                duration_us: 1000
+                duration_us: 1000,
+                tier: DiskTier::Chunk
             })
         ));
         assert!(matches!(

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -21,7 +21,8 @@
 //! client.chunk_disk_cache_hit(30_000);
 //! ```
 
-use super::event::{DiskTier, MetricEvent};
+use super::event::MetricEvent;
+use crate::cache::DiskTier;
 use tokio::sync::mpsc;
 
 /// Client for emitting metric events to the metrics daemon.

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -13,9 +13,10 @@
 //! state through a shared `RwLock` handle that the daemon updates after
 //! processing events. This ensures reporters never block event processing.
 
-use super::event::{DiskTier, MetricEvent};
+use super::event::MetricEvent;
 use super::memory_probe::{MemoryProbe, ProcessMemoryProbe};
 use super::state::{AggregatedState, TimeSeriesHistory, DEFAULT_HISTORY_CAPACITY};
+use crate::cache::DiskTier;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -13,7 +13,7 @@
 //! state through a shared `RwLock` handle that the daemon updates after
 //! processing events. This ensures reporters never block event processing.
 
-use super::event::MetricEvent;
+use super::event::{DiskTier, MetricEvent};
 use super::memory_probe::{MemoryProbe, ProcessMemoryProbe};
 use super::state::{AggregatedState, TimeSeriesHistory, DEFAULT_HISTORY_CAPACITY};
 use std::sync::{Arc, RwLock};
@@ -207,9 +207,16 @@ impl MetricsDaemon {
             MetricEvent::DiskWriteStarted => {
                 self.state.disk_writes_active += 1;
             }
-            MetricEvent::DiskWriteCompleted { bytes, duration_us } => {
+            MetricEvent::DiskWriteCompleted {
+                bytes,
+                duration_us,
+                tier,
+            } => {
                 self.state.disk_writes_active = self.state.disk_writes_active.saturating_sub(1);
-                self.state.chunk_disk_bytes_written += bytes;
+                match tier {
+                    DiskTier::Chunk => self.state.chunk_disk_bytes_written += bytes,
+                    DiskTier::Dds => self.state.dds_disk_bytes_written += bytes,
+                }
                 self.state.disk_write_time_us += duration_us;
             }
             MetricEvent::DiskCacheInitialSize { bytes } => {
@@ -1020,6 +1027,65 @@ mod tests {
         assert!(
             find_memory_sample(&events).is_none(),
             "no \"Memory sample\" event may be emitted when rss_bytes is zero"
+        );
+    }
+
+    #[test]
+    fn chunk_tier_write_credits_only_the_chunk_counter() {
+        let (mut daemon, _tx) = create_daemon();
+
+        daemon.process_event(MetricEvent::DiskWriteCompleted {
+            bytes: 1_000,
+            duration_us: 50,
+            tier: DiskTier::Chunk,
+        });
+
+        assert_eq!(daemon.state.chunk_disk_bytes_written, 1_000);
+        assert_eq!(daemon.state.dds_disk_bytes_written, 0);
+    }
+
+    #[test]
+    fn dds_tier_write_credits_only_the_dds_counter() {
+        let (mut daemon, _tx) = create_daemon();
+
+        daemon.process_event(MetricEvent::DiskWriteCompleted {
+            bytes: 11_174_016,
+            duration_us: 50,
+            tier: DiskTier::Dds,
+        });
+
+        assert_eq!(daemon.state.dds_disk_bytes_written, 11_174_016);
+        assert_eq!(daemon.state.chunk_disk_bytes_written, 0);
+    }
+
+    // Guards the cross-tier invariant the #209 memory telemetry depends on:
+    // disk_writes_active must count in-flight writes from BOTH tiers.
+    #[test]
+    fn both_tiers_decrement_the_shared_in_flight_gauge() {
+        let (mut daemon, _tx) = create_daemon();
+
+        daemon.process_event(MetricEvent::DiskWriteStarted);
+        daemon.process_event(MetricEvent::DiskWriteStarted);
+        assert_eq!(daemon.state.disk_writes_active, 2);
+
+        daemon.process_event(MetricEvent::DiskWriteCompleted {
+            bytes: 1,
+            duration_us: 1,
+            tier: DiskTier::Chunk,
+        });
+        assert_eq!(
+            daemon.state.disk_writes_active, 1,
+            "chunk completion must decrement"
+        );
+
+        daemon.process_event(MetricEvent::DiskWriteCompleted {
+            bytes: 1,
+            duration_us: 1,
+            tier: DiskTier::Dds,
+        });
+        assert_eq!(
+            daemon.state.disk_writes_active, 0,
+            "dds completion must decrement too"
         );
     }
 

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -843,10 +843,8 @@ mod tests {
         };
         let subscriber = tracing_subscriber::registry().with(layer);
         tracing::subscriber::with_default(subscriber, f);
-        std::sync::Arc::try_unwrap(events)
-            .expect("no other references to the capture buffer should remain")
-            .into_inner()
-            .unwrap()
+        let captured = events.lock().unwrap().clone();
+        captured
     }
 
     /// Finds the first captured event whose message is "Memory sample".

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -66,9 +66,6 @@ pub struct MetricsDaemon {
     /// Last bytes downloaded (for rate calculation).
     last_bytes_downloaded: u64,
 
-    /// Last disk bytes written (for rate calculation).
-    last_disk_bytes_written: u64,
-
     /// Last jobs completed (for rate calculation).
     last_jobs_completed: u64,
 
@@ -111,7 +108,6 @@ impl MetricsDaemon {
             shared_state,
             last_sample: Instant::now(),
             last_bytes_downloaded: 0,
-            last_disk_bytes_written: 0,
             last_jobs_completed: 0,
             last_fuse_completed: 0,
             memory_probe,
@@ -207,17 +203,12 @@ impl MetricsDaemon {
             MetricEvent::DiskWriteStarted => {
                 self.state.disk_writes_active += 1;
             }
-            MetricEvent::DiskWriteCompleted {
-                bytes,
-                duration_us,
-                tier,
-            } => {
+            MetricEvent::DiskWriteCompleted { bytes, tier } => {
                 self.state.disk_writes_active = self.state.disk_writes_active.saturating_sub(1);
                 match tier {
                     DiskTier::Chunk => self.state.chunk_disk_bytes_written += bytes,
                     DiskTier::Dds => self.state.dds_disk_bytes_written += bytes,
                 }
-                self.state.disk_write_time_us += duration_us;
             }
             MetricEvent::DiskCacheInitialSize { bytes } => {
                 self.state.initial_disk_cache_bytes = bytes;
@@ -414,17 +405,6 @@ impl MetricsDaemon {
             }
 
             self.last_bytes_downloaded = self.state.bytes_downloaded;
-
-            // Disk throughput (bytes/sec)
-            let total_disk_written = self
-                .state
-                .chunk_disk_bytes_written
-                .saturating_add(self.state.dds_disk_bytes_written);
-            let disk_delta = total_disk_written.saturating_sub(self.last_disk_bytes_written);
-            self.history
-                .disk_throughput
-                .push(disk_delta as f64 / elapsed);
-            self.last_disk_bytes_written = total_disk_written;
 
             // Job rate (jobs/sec)
             let jobs_delta = self
@@ -721,7 +701,6 @@ mod tests {
         daemon.sample_time_series();
 
         assert_eq!(daemon.history.network_throughput.len(), 1);
-        assert_eq!(daemon.history.disk_throughput.len(), 1);
         assert_eq!(daemon.history.job_rate.len(), 1);
 
         // Verify rates are non-zero
@@ -1036,7 +1015,6 @@ mod tests {
 
         daemon.process_event(MetricEvent::DiskWriteCompleted {
             bytes: 1_000,
-            duration_us: 50,
             tier: DiskTier::Chunk,
         });
 
@@ -1050,7 +1028,6 @@ mod tests {
 
         daemon.process_event(MetricEvent::DiskWriteCompleted {
             bytes: 11_174_016,
-            duration_us: 50,
             tier: DiskTier::Dds,
         });
 
@@ -1070,7 +1047,6 @@ mod tests {
 
         daemon.process_event(MetricEvent::DiskWriteCompleted {
             bytes: 1,
-            duration_us: 1,
             tier: DiskTier::Chunk,
         });
         assert_eq!(
@@ -1080,7 +1056,6 @@ mod tests {
 
         daemon.process_event(MetricEvent::DiskWriteCompleted {
             bytes: 1,
-            duration_us: 1,
             tier: DiskTier::Dds,
         });
         assert_eq!(

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -409,14 +409,15 @@ impl MetricsDaemon {
             self.last_bytes_downloaded = self.state.bytes_downloaded;
 
             // Disk throughput (bytes/sec)
-            let disk_delta = self
+            let total_disk_written = self
                 .state
                 .chunk_disk_bytes_written
-                .saturating_sub(self.last_disk_bytes_written);
+                .saturating_add(self.state.dds_disk_bytes_written);
+            let disk_delta = total_disk_written.saturating_sub(self.last_disk_bytes_written);
             self.history
                 .disk_throughput
                 .push(disk_delta as f64 / elapsed);
-            self.last_disk_bytes_written = self.state.chunk_disk_bytes_written;
+            self.last_disk_bytes_written = total_disk_written;
 
             // Job rate (jobs/sec)
             let jobs_delta = self

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -89,8 +89,6 @@ pub enum MetricEvent {
     DiskWriteCompleted {
         /// Number of bytes written.
         bytes: u64,
-        /// Time taken in microseconds.
-        duration_us: u64,
         /// Which cache tier the bytes belong to.
         tier: DiskTier,
     },

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -14,18 +14,7 @@
 //! - Job events: per-job (one per tile request)
 //! - FUSE events: per-request
 
-/// Which disk cache tier a write belongs to.
-///
-/// Chunk-tier writes are small and frequent (~14 KB, thousands per second);
-/// DDS-tier writes are large and rare (11.17 MB, a few per second). Attributing
-/// bytes to a tier keeps `chunk_disk_bytes_written` honest — see issue #216.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DiskTier {
-    /// The chunk disk cache.
-    Chunk,
-    /// The DDS tile disk cache.
-    Dds,
-}
+use crate::cache::DiskTier;
 
 /// Events emitted by pipeline components to the metrics daemon.
 ///

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -14,6 +14,19 @@
 //! - Job events: per-job (one per tile request)
 //! - FUSE events: per-request
 
+/// Which disk cache tier a write belongs to.
+///
+/// Chunk-tier writes are small and frequent (~14 KB, thousands per second);
+/// DDS-tier writes are large and rare (11.17 MB, a few per second). Attributing
+/// bytes to a tier keeps `chunk_disk_bytes_written` honest — see issue #216.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiskTier {
+    /// The chunk disk cache.
+    Chunk,
+    /// The DDS tile disk cache.
+    Dds,
+}
+
 /// Events emitted by pipeline components to the metrics daemon.
 ///
 /// Each event represents an atomic occurrence that updates metrics state.
@@ -78,6 +91,8 @@ pub enum MetricEvent {
         bytes: u64,
         /// Time taken in microseconds.
         duration_us: u64,
+        /// Which cache tier the bytes belong to.
+        tier: DiskTier,
     },
 
     /// Set the initial disk cache size (scanned on startup).

--- a/xearthlayer/src/metrics/mod.rs
+++ b/xearthlayer/src/metrics/mod.rs
@@ -18,7 +18,7 @@ mod system;
 
 pub use client::MetricsClient;
 pub use daemon::{MetricsDaemon, MetricsStateSnapshot, SharedMetricsState};
-pub use event::{DiskTier, MetricEvent};
+pub use event::MetricEvent;
 pub use memory_probe::{log_allocator_environment, MemoryProbe, MemorySample, ProcessMemoryProbe};
 pub use optional::OptionalMetrics;
 pub use reporter::{MetricsReporter, TuiReporter};

--- a/xearthlayer/src/metrics/mod.rs
+++ b/xearthlayer/src/metrics/mod.rs
@@ -18,7 +18,7 @@ mod system;
 
 pub use client::MetricsClient;
 pub use daemon::{MetricsDaemon, MetricsStateSnapshot, SharedMetricsState};
-pub use event::MetricEvent;
+pub use event::{DiskTier, MetricEvent};
 pub use memory_probe::{log_allocator_environment, MemoryProbe, MemorySample, ProcessMemoryProbe};
 pub use optional::OptionalMetrics;
 pub use reporter::{MetricsReporter, TuiReporter};

--- a/xearthlayer/src/metrics/optional.rs
+++ b/xearthlayer/src/metrics/optional.rs
@@ -1,6 +1,7 @@
 //! OptionalMetrics — extension trait for `Option<MetricsClient>`.
 
 use super::client::MetricsClient;
+use super::event::DiskTier;
 
 /// Extension trait for optional metrics client usage.
 ///
@@ -16,7 +17,7 @@ pub trait OptionalMetrics {
     fn dds_disk_cache_hit(&self, bytes: u64, is_fuse: bool);
     fn dds_disk_cache_miss(&self, is_fuse: bool);
     fn disk_write_started(&self);
-    fn disk_write_completed(&self, bytes: u64, duration_us: u64);
+    fn disk_write_completed(&self, bytes: u64, duration_us: u64, tier: DiskTier);
     fn disk_cache_initial_size(&self, bytes: u64);
     fn disk_cache_size(&self, bytes: u64);
     fn dds_disk_cache_size(&self, bytes: u64);
@@ -102,9 +103,9 @@ impl OptionalMetrics for Option<MetricsClient> {
     }
 
     #[inline]
-    fn disk_write_completed(&self, bytes: u64, duration_us: u64) {
+    fn disk_write_completed(&self, bytes: u64, duration_us: u64, tier: DiskTier) {
         if let Some(client) = self {
-            client.disk_write_completed(bytes, duration_us);
+            client.disk_write_completed(bytes, duration_us, tier);
         }
     }
 

--- a/xearthlayer/src/metrics/optional.rs
+++ b/xearthlayer/src/metrics/optional.rs
@@ -17,7 +17,7 @@ pub trait OptionalMetrics {
     fn dds_disk_cache_hit(&self, bytes: u64, is_fuse: bool);
     fn dds_disk_cache_miss(&self, is_fuse: bool);
     fn disk_write_started(&self);
-    fn disk_write_completed(&self, bytes: u64, duration_us: u64, tier: DiskTier);
+    fn disk_write_completed(&self, bytes: u64, tier: DiskTier);
     fn disk_cache_initial_size(&self, bytes: u64);
     fn disk_cache_size(&self, bytes: u64);
     fn dds_disk_cache_size(&self, bytes: u64);
@@ -103,9 +103,9 @@ impl OptionalMetrics for Option<MetricsClient> {
     }
 
     #[inline]
-    fn disk_write_completed(&self, bytes: u64, duration_us: u64, tier: DiskTier) {
+    fn disk_write_completed(&self, bytes: u64, tier: DiskTier) {
         if let Some(client) = self {
-            client.disk_write_completed(bytes, duration_us, tier);
+            client.disk_write_completed(bytes, tier);
         }
     }
 

--- a/xearthlayer/src/metrics/optional.rs
+++ b/xearthlayer/src/metrics/optional.rs
@@ -1,7 +1,7 @@
 //! OptionalMetrics — extension trait for `Option<MetricsClient>`.
 
 use super::client::MetricsClient;
-use super::event::DiskTier;
+use crate::cache::DiskTier;
 
 /// Extension trait for optional metrics client usage.
 ///

--- a/xearthlayer/src/metrics/reporter.rs
+++ b/xearthlayer/src/metrics/reporter.rs
@@ -180,6 +180,7 @@ impl MetricsReporter for TuiReporter {
             chunk_disk_cache_hit_rate: chunk_disk_hit_rate,
             chunk_disk_cache_size_bytes: state.chunk_disk_cache_size_bytes,
             chunk_disk_bytes_written: state.chunk_disk_bytes_written,
+            dds_disk_bytes_written: state.dds_disk_bytes_written,
             chunk_disk_bytes_read: state.chunk_disk_bytes_read,
 
             // Encode metrics
@@ -426,5 +427,21 @@ mod tests {
             snapshot.chunk_disk_cache_size_bytes, 5_000_000_000,
             "Reporter should use chunk_disk_cache_size_bytes directly, not initial+written-evicted"
         );
+    }
+
+    #[test]
+    fn reporter_carries_dds_disk_bytes_written() {
+        let mut state = AggregatedState::new();
+        let history = TimeSeriesHistory::default();
+        let reporter = TuiReporter::new();
+
+        // Distinct values so a swapped mapping cannot pass.
+        state.chunk_disk_bytes_written = 111;
+        state.dds_disk_bytes_written = 222;
+
+        let snapshot = reporter.report(&state, &history);
+
+        assert_eq!(snapshot.chunk_disk_bytes_written, 111);
+        assert_eq!(snapshot.dds_disk_bytes_written, 222);
     }
 }

--- a/xearthlayer/src/metrics/snapshot.rs
+++ b/xearthlayer/src/metrics/snapshot.rs
@@ -103,6 +103,8 @@ pub struct TelemetrySnapshot {
     pub chunk_disk_cache_size_bytes: u64,
     /// Chunk disk bytes written this session
     pub chunk_disk_bytes_written: u64,
+    /// DDS disk bytes written this session
+    pub dds_disk_bytes_written: u64,
     /// Chunk disk bytes read this session (from cache hits)
     pub chunk_disk_bytes_read: u64,
 
@@ -175,6 +177,7 @@ impl Default for TelemetrySnapshot {
             chunk_disk_cache_hit_rate: 0.0,
             chunk_disk_cache_size_bytes: 0,
             chunk_disk_bytes_written: 0,
+            dds_disk_bytes_written: 0,
             chunk_disk_bytes_read: 0,
             encodes_completed: 0,
             encodes_active: 0,
@@ -425,6 +428,7 @@ mod tests {
             chunk_disk_cache_hit_rate: 5000.0 / 23040.0,
             chunk_disk_cache_size_bytes: 5_000_000_000,
             chunk_disk_bytes_written: 500_000_000,
+            dds_disk_bytes_written: 0,
             chunk_disk_bytes_read: 750_000_000,
             encodes_completed: 90,
             encodes_active: 2,

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -146,6 +146,8 @@ pub struct AggregatedState {
     pub disk_writes_active: u64,
     /// Total bytes written to chunk disk cache.
     pub chunk_disk_bytes_written: u64,
+    /// Total bytes written to DDS disk cache.
+    pub dds_disk_bytes_written: u64,
     /// Total bytes read from chunk disk cache (cache hits).
     pub chunk_disk_bytes_read: u64,
     /// Total disk write time in microseconds.
@@ -271,6 +273,7 @@ impl AggregatedState {
             chunk_disk_cache_misses: 0,
             disk_writes_active: 0,
             chunk_disk_bytes_written: 0,
+            dds_disk_bytes_written: 0,
             chunk_disk_bytes_read: 0,
             disk_write_time_us: 0,
             initial_disk_cache_bytes: 0,
@@ -326,6 +329,7 @@ impl AggregatedState {
         self.chunk_disk_cache_misses = 0;
         self.disk_writes_active = 0;
         self.chunk_disk_bytes_written = 0;
+        self.dds_disk_bytes_written = 0;
         self.chunk_disk_bytes_read = 0;
         self.disk_write_time_us = 0;
         self.dds_disk_cache_hits = 0;

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -150,8 +150,6 @@ pub struct AggregatedState {
     pub dds_disk_bytes_written: u64,
     /// Total bytes read from chunk disk cache (cache hits).
     pub chunk_disk_bytes_read: u64,
-    /// Total disk write time in microseconds.
-    pub disk_write_time_us: u64,
     /// Initial disk cache size (scanned on startup, not reset).
     pub initial_disk_cache_bytes: u64,
     /// Total bytes evicted from disk cache by the GC daemon.
@@ -275,7 +273,6 @@ impl AggregatedState {
             chunk_disk_bytes_written: 0,
             dds_disk_bytes_written: 0,
             chunk_disk_bytes_read: 0,
-            disk_write_time_us: 0,
             initial_disk_cache_bytes: 0,
             disk_bytes_evicted: 0,
             chunk_disk_cache_size_bytes: 0,
@@ -331,7 +328,6 @@ impl AggregatedState {
         self.chunk_disk_bytes_written = 0;
         self.dds_disk_bytes_written = 0;
         self.chunk_disk_bytes_read = 0;
-        self.disk_write_time_us = 0;
         self.dds_disk_cache_hits = 0;
         self.dds_disk_cache_misses = 0;
         self.fuse_dds_disk_cache_hits = 0;
@@ -376,8 +372,6 @@ pub const DEFAULT_HISTORY_CAPACITY: usize = 60;
 pub struct TimeSeriesHistory {
     /// Network throughput samples (bytes/sec).
     pub network_throughput: RingBuffer<f64>,
-    /// Disk throughput samples (bytes/sec).
-    pub disk_throughput: RingBuffer<f64>,
     /// Job completion rate samples (jobs/sec).
     pub job_rate: RingBuffer<f64>,
     /// FUSE request rate samples (requests/sec).
@@ -389,7 +383,6 @@ impl TimeSeriesHistory {
     pub fn new(capacity: usize) -> Self {
         Self {
             network_throughput: RingBuffer::new(capacity),
-            disk_throughput: RingBuffer::new(capacity),
             job_rate: RingBuffer::new(capacity),
             fuse_rate: RingBuffer::new(capacity),
         }
@@ -398,7 +391,6 @@ impl TimeSeriesHistory {
     /// Clears all time series data.
     pub fn clear(&mut self) {
         self.network_throughput.clear();
-        self.disk_throughput.clear();
         self.job_rate.clear();
         self.fuse_rate.clear();
     }
@@ -493,14 +485,11 @@ mod tests {
 
         history.network_throughput.push(1000.0);
         history.network_throughput.push(2000.0);
-        history.disk_throughput.push(500.0);
 
         assert_eq!(history.network_throughput.len(), 2);
         assert_eq!(history.network_throughput.last(), Some(2000.0));
-        assert_eq!(history.disk_throughput.len(), 1);
 
         history.clear();
         assert!(history.network_throughput.is_empty());
-        assert!(history.disk_throughput.is_empty());
     }
 }

--- a/xearthlayer/src/tasks/build_and_cache_dds.rs
+++ b/xearthlayer/src/tasks/build_and_cache_dds.rs
@@ -17,7 +17,6 @@
 //! Returns the DDS data via `TaskOutput` key "dds_data" (`Vec<u8>`).
 //! Cache write is fire-and-forget (spawned async task).
 
-use crate::cache::DiskTier;
 use crate::coord::TileCoord;
 use crate::executor::{
     BlockingExecutor, ChunkResults, DdsDiskCache, MemoryCache, ResourceType, Task, TaskContext,
@@ -314,7 +313,7 @@ where
                             )
                             .await;
 
-                        metrics_for_dds.disk_write_completed(dds_bytes, DiskTier::Dds);
+                        metrics_for_dds.disk_write_completed(dds_bytes, DD::TIER);
 
                         debug!(
                             tile = ?tile_for_disk,

--- a/xearthlayer/src/tasks/build_and_cache_dds.rs
+++ b/xearthlayer/src/tasks/build_and_cache_dds.rs
@@ -22,7 +22,7 @@ use crate::executor::{
     BlockingExecutor, ChunkResults, DdsDiskCache, MemoryCache, ResourceType, Task, TaskContext,
     TaskError, TaskOutput, TaskResult, TextureEncoderAsync,
 };
-use crate::metrics::OptionalMetrics;
+use crate::metrics::{DiskTier, OptionalMetrics};
 use image::{Rgba, RgbaImage};
 use std::future::Future;
 use std::pin::Pin;
@@ -315,7 +315,7 @@ where
                             .await;
 
                         let duration_us = write_start.elapsed().as_micros() as u64;
-                        metrics_for_dds.disk_write_completed(dds_bytes, duration_us);
+                        metrics_for_dds.disk_write_completed(dds_bytes, duration_us, DiskTier::Dds);
 
                         debug!(
                             tile = ?tile_for_disk,

--- a/xearthlayer/src/tasks/build_and_cache_dds.rs
+++ b/xearthlayer/src/tasks/build_and_cache_dds.rs
@@ -303,7 +303,6 @@ where
                     let metrics_for_dds = metrics.clone();
                     tokio::spawn(async move {
                         metrics_for_dds.disk_write_started();
-                        let write_start = Instant::now();
 
                         dds_disk
                             .put(
@@ -314,8 +313,7 @@ where
                             )
                             .await;
 
-                        let duration_us = write_start.elapsed().as_micros() as u64;
-                        metrics_for_dds.disk_write_completed(dds_bytes, duration_us, DiskTier::Dds);
+                        metrics_for_dds.disk_write_completed(dds_bytes, DiskTier::Dds);
 
                         debug!(
                             tile = ?tile_for_disk,

--- a/xearthlayer/src/tasks/build_and_cache_dds.rs
+++ b/xearthlayer/src/tasks/build_and_cache_dds.rs
@@ -17,12 +17,13 @@
 //! Returns the DDS data via `TaskOutput` key "dds_data" (`Vec<u8>`).
 //! Cache write is fire-and-forget (spawned async task).
 
+use crate::cache::DiskTier;
 use crate::coord::TileCoord;
 use crate::executor::{
     BlockingExecutor, ChunkResults, DdsDiskCache, MemoryCache, ResourceType, Task, TaskContext,
     TaskError, TaskOutput, TaskResult, TextureEncoderAsync,
 };
-use crate::metrics::{DiskTier, OptionalMetrics};
+use crate::metrics::OptionalMetrics;
 use image::{Rgba, RgbaImage};
 use std::future::Future;
 use std::pin::Pin;

--- a/xearthlayer/src/tasks/download_chunks.rs
+++ b/xearthlayer/src/tasks/download_chunks.rs
@@ -447,7 +447,7 @@ where
 /// Spawns a fire-and-forget task to write chunk data to disk cache.
 ///
 /// Emits `disk_write_started` when beginning and `disk_write_completed`
-/// with byte count and duration when finished.
+/// with byte count when finished.
 fn spawn_cache_write<D>(
     disk_cache: Arc<D>,
     tile: TileCoord,
@@ -462,15 +462,13 @@ fn spawn_cache_write<D>(
     tokio::spawn(async move {
         // Track disk write started
         metrics.disk_write_started();
-        let start = Instant::now();
 
         let _ = disk_cache
             .put(tile.row, tile.col, tile.zoom, chunk_row, chunk_col, data)
             .await;
 
         // Track disk write completed
-        let duration_us = start.elapsed().as_micros() as u64;
-        metrics.disk_write_completed(bytes, duration_us, DiskTier::Chunk);
+        metrics.disk_write_completed(bytes, DiskTier::Chunk);
     });
 }
 

--- a/xearthlayer/src/tasks/download_chunks.rs
+++ b/xearthlayer/src/tasks/download_chunks.rs
@@ -17,7 +17,6 @@
 //!
 //! Produces `TaskOutput` with key "chunks" containing `ChunkResults`.
 
-use crate::cache::DiskTier;
 use crate::coord::TileCoord;
 use crate::executor::{
     ChunkProvider, ChunkResults, DiskCache, DownloadConfig, ResourceType, Task, TaskContext,
@@ -469,7 +468,7 @@ fn spawn_cache_write<D>(
             .await;
 
         // Track disk write completed
-        metrics.disk_write_completed(bytes, DiskTier::Chunk);
+        metrics.disk_write_completed(bytes, D::TIER);
     });
 }
 

--- a/xearthlayer/src/tasks/download_chunks.rs
+++ b/xearthlayer/src/tasks/download_chunks.rs
@@ -17,12 +17,13 @@
 //!
 //! Produces `TaskOutput` with key "chunks" containing `ChunkResults`.
 
+use crate::cache::DiskTier;
 use crate::coord::TileCoord;
 use crate::executor::{
     ChunkProvider, ChunkResults, DiskCache, DownloadConfig, ResourceType, Task, TaskContext,
     TaskOutput, TaskResult,
 };
-use crate::metrics::{DiskTier, MetricsClient, OptionalMetrics};
+use crate::metrics::{MetricsClient, OptionalMetrics};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/xearthlayer/src/tasks/download_chunks.rs
+++ b/xearthlayer/src/tasks/download_chunks.rs
@@ -22,7 +22,7 @@ use crate::executor::{
     ChunkProvider, ChunkResults, DiskCache, DownloadConfig, ResourceType, Task, TaskContext,
     TaskOutput, TaskResult,
 };
-use crate::metrics::{MetricsClient, OptionalMetrics};
+use crate::metrics::{DiskTier, MetricsClient, OptionalMetrics};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -470,7 +470,7 @@ fn spawn_cache_write<D>(
 
         // Track disk write completed
         let duration_us = start.elapsed().as_micros() as u64;
-        metrics.disk_write_completed(bytes, duration_us);
+        metrics.disk_write_completed(bytes, duration_us, DiskTier::Chunk);
     });
 }
 


### PR DESCRIPTION
## Summary

Fixes #216, and consolidates the cache-tier concept while in the area.

`chunk_disk_bytes_written` accumulated bytes from **both** cache tiers despite its name. Chunk writes (~14 KB each, thousands per second) and DDS tile writes (11.17 MB each, a few per second) emitted the same untiered event, and the daemon added all of it into the chunk-named counter. At the rates measured during the #209 flight, roughly **79% of that counter was DDS bytes**.

**No displayed value was wrong, and none changes here.** The TUI's intent everywhere is total disk I/O — reads already summed both tiers explicitly, and writes got both tiers by accident through the conflated field. So this is a data-model correctness fix, and the primary acceptance criterion was that the TUI render byte-for-byte identically before and after. It does.

## Changes

**Per-tier byte attribution (#216 proper)**

- `DiskWriteCompleted` gains a `tier` discriminator; the daemon routes bytes into `chunk_disk_bytes_written` or the new `dds_disk_bytes_written`.
- Every consumer sums both tiers, mirroring how reads were already handled.
- Built as two commits ordered so no intermediate is broken: an **additive** one that introduces the new counter (always zero) and prepares every consumer, then a **routing** one. Verified: `cargo check --all-targets` is clean at both.

**Tier consolidation**

- `DiskTier` moved from `metrics/` to `cache/types.rs` — cache tier is a cache concept — and is now the single canonical path, with `as_str()` + `Display`.
- `DiskCache::TIER` / `DdsDiskCache::TIER` associated constants mean the tier is **derived from the type** at each call site rather than typed by hand. `DiskCache` is always the chunk tier and `DdsDiskCache` always the DDS tier, so a wrong tier is now structurally impossible rather than merely unlikely.
- The pre-existing `is_dds_tier: bool` is replaced by `DiskTier` across `config.rs`, `service.rs` and `providers/disk.rs`. Exactly one representation of the concept now exists; the strings `"chunks"`/`"dds"` live only in `DiskTier::as_str()`.
- Two behavioural branches became `match` for compiler-enforced exhaustiveness.

**Dead code removed**

- `history.disk_throughput` and its sampling cursor — computed every 100 ms, never read.
- `disk_write_time_us` — accumulated, never read. It summed durations across two tiers differing ~800× in write size, so any mean derived from it would have been dominated by whichever tier is more numerous. If disk-write latency is wanted later it needs to be per-tier and shaped for display; that's a different metric, not this one revived.
- Consequently `duration_us` on the event, its two signatures, and the `Instant` timing at both writers.

**One unrelated fix found along the way**

`capture_events` in the metrics test support (added in #215) ended with `Arc::try_unwrap(...).expect(...)`, which succeeds only at refcount 1. `tracing` holds the subscriber in an `Arc`-based `Dispatch` with no guarantee every clone is dropped by the time `with_default` returns, so under full-suite parallelism the count was sometimes 2 and it panicked — **failing roughly 1 run in 3**. It's a teardown failure, so the message pointed at buffer ownership rather than anything to do with memory samples. Now lock-and-clone; verified over 19 consecutive full-suite runs.

## Related Issues

Fixes #216

## Test Plan

- [x] `make pre-commit` passes (fmt + clippy `-D warnings` + tests) — ~2437 tests, 63 doctests, 0 failures
- [x] **TUI output unchanged** — every consumer sums both tiers, so the displayed write total is identical
- [x] **Log output unchanged** — six `tier=` sites now render via `Display`; `"chunks"` (plural) and `"dds"` (singular) preserved exactly, pinned by a test asserting both literals
- [x] **Byte conservation verified end to end** — two emit sites, one routing sink, four consumers all summing both tiers
- [x] **No broken intermediate commit** — `cargo check --all-targets` clean at both `c110f86` and `8ca22fe`
- [x] Tier/trait pairing verified by tracing implementors to their backing stores, not by name-matching
- [x] Flaky test fix verified over 19 consecutive full-suite runs (was ~1-in-3 failing)

Reviewers can confirm the log labels are unchanged with:

```bash
grep -rn '"dds"\|"chunks"' xearthlayer/src/cache/providers/disk.rs   # expect: nothing
grep -n 'tier = %' xearthlayer/src/cache/providers/disk.rs           # expect: 6 sites
```

## Checklist

- [x] Code follows the project's SOLID principles and patterns
- [x] Tests added or updated for new/changed behavior
- [x] Documentation updated if applicable — no doc changes needed; `docs/dev/memory-telemetry.md` references `disk_writes_active`, whose semantics are unchanged, and never the byte counters
- [x] No new warnings from `cargo clippy`

## Notes for the reviewer

**`disk_writes_active` is deliberately cross-tier and was not touched.** It counts in-flight writes from both tiers, which is load-bearing for the memory telemetry added in #209 — that gauge is what detects a DDS write backlog. Its increment stays in exactly one place and its decrement in one place, outside the `match tier`, guarded by a dedicated test.

**`mounts.rs` aggregation.** The new field mirrors the existing `.max()` shape rather than using `+`. That aggregation is pre-existing and unusual, but mirroring keeps the two fields from diverging; changing it was out of scope.

**Three known Minors deferred** from the final review, none blocking: `ServiceCacheConfig::memory()` assigns a disk tier to a cache with no disk (the bool hid this, the enum makes it visible — `Option<DiskTier>` would make the illegal state unrepresentable), and two redundant `let tier = self.tier;` locals in `providers/disk.rs`.

**One architectural note.** Moving `DiskTier` into `cache/` means `metrics/` now imports `cache/` where previously the dependency ran one way only. It's legal within the crate and defensible — the domain should own its types — but it is a real change worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
