### PR TITLE
fix(publisher): drive coverage map colours from region_metadata.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,7 @@ xearthlayer publish version --region <code> --bump <type>  # Manage versions
 xearthlayer publish release --region <code> --metadata-url <url>  # Release
 xearthlayer publish status                  # Show release status
 xearthlayer publish validate                # Validate repository
-xearthlayer publish coverage [--dark] [--geojson] [-o <file>]  # Generate coverage map
+xearthlayer publish coverage [--dark] [--geojson] [-o <file>] [--metadata <path>]  # Generate coverage map
 xearthlayer publish dedupe --region <code> [--priority <mode>] [--tile <lat,lon>] [--dry-run]  # Remove overlapping ZL tiles
 xearthlayer publish gaps --region <code> [--tile <lat,lon>] [--format <fmt>] [-o <file>]  # Analyze coverage gaps
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199f851bd3cb5004c09474252c7f74e7c047441ed0979bf3688a7106a13da952"
+dependencies = [
+ "num-traits",
+ "phf",
+ "serde",
+ "uncased",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2412,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uncased",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+ "uncased",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,6 +3321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3822,6 +3885,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -4747,6 +4819,7 @@ dependencies = [
  "block_compression",
  "bytes",
  "chrono",
+ "csscolorparser",
  "dashmap",
  "dirs",
  "filetime",

--- a/docs/dev/github-releases-publishing.md
+++ b/docs/dev/github-releases-publishing.md
@@ -530,6 +530,7 @@ xearthlayer publish coverage --geojson --output coverage.geojson
 | `--height` | Image height in pixels (PNG only, default: 600) |
 | `--dark` | Use dark theme with CartoDB tiles (PNG only) |
 | `--geojson` | Generate GeoJSON instead of PNG |
+| `--metadata` | Path to region_metadata.json (default: `<repo>/region_metadata.json`) |
 
 ## Website Sync Integration
 
@@ -572,7 +573,9 @@ When you push library index updates to the regional-scenery repository, the publ
 
 ### Region Metadata File
 
-The `region_metadata.json` file in the regional-scenery repo provides region names, coverage descriptions, and colors for the website:
+The `region_metadata.json` file in the regional-scenery repo is a **required input to `xearthlayer publish coverage`**, not just a website artefact — it supplies the region names, coverage descriptions, and colors used both by the coverage map generator and the website:
+
+`publish coverage` reads it from the repository root by default (`<repo>/region_metadata.json`), overridable with `--metadata <path>`. The `color` field for each region accepts either a CSS colour name (e.g. `"orange"`) or a hex string (e.g. `"#ffaa00"`). An unresolvable colour or a missing metadata file is a **hard error**: the command exits non-zero and writes no map. This is deliberate — a silently grey region is how a wrong map shipped once already (issue #200). Dark mode colours are derived automatically by blending toward white, so there is no separate dark palette to maintain.
 
 ```json
 {

--- a/xearthlayer-cli/src/commands/publish/args.rs
+++ b/xearthlayer-cli/src/commands/publish/args.rs
@@ -284,6 +284,10 @@ pub enum PublishCommands {
         #[arg(long)]
         geojson: bool,
 
+        /// Path to region_metadata.json (default: <repo>/region_metadata.json)
+        #[arg(long)]
+        metadata: Option<PathBuf>,
+
         /// Repository path (default: current directory)
         #[arg(default_value = ".")]
         repo: PathBuf,
@@ -461,6 +465,7 @@ pub struct CoverageArgs {
     pub height: u32,
     pub dark: bool,
     pub geojson: bool,
+    pub metadata: Option<PathBuf>,
     pub repo: PathBuf,
 }
 

--- a/xearthlayer-cli/src/commands/publish/handlers.rs
+++ b/xearthlayer-cli/src/commands/publish/handlers.rs
@@ -730,6 +730,10 @@ impl CommandHandler for CoverageHandler {
     fn execute(args: Self::Args, ctx: &CommandContext<'_>) -> Result<(), CliError> {
         let repo = ctx.publisher.open_repository(&args.repo)?;
         let packages_dir = repo.root().join("packages");
+        let metadata_path = args
+            .metadata
+            .clone()
+            .unwrap_or_else(|| repo.root().join("region_metadata.json"));
 
         let format_type = if args.geojson { "GeoJSON" } else { "PNG" };
         ctx.output
@@ -738,11 +742,12 @@ impl CommandHandler for CoverageHandler {
 
         let result = if args.geojson {
             ctx.publisher
-                .generate_coverage_geojson(&packages_dir, &args.output)?
+                .generate_coverage_geojson(&packages_dir, &args.output, &metadata_path)?
         } else {
             ctx.publisher.generate_coverage_map(
                 &packages_dir,
                 &args.output,
+                &metadata_path,
                 args.width,
                 args.height,
                 args.dark,

--- a/xearthlayer-cli/src/commands/publish/mod.rs
+++ b/xearthlayer-cli/src/commands/publish/mod.rs
@@ -197,6 +197,7 @@ pub fn run(command: PublishCommands) -> Result<(), CliError> {
             height,
             dark,
             geojson,
+            metadata,
             repo,
         } => CoverageHandler::execute(
             CoverageArgs {
@@ -205,6 +206,7 @@ pub fn run(command: PublishCommands) -> Result<(), CliError> {
                 height,
                 dark,
                 geojson,
+                metadata,
                 repo,
             },
             &ctx,

--- a/xearthlayer-cli/src/commands/publish/services.rs
+++ b/xearthlayer-cli/src/commands/publish/services.rs
@@ -17,8 +17,8 @@ use xearthlayer::publisher::dedupe::{
 };
 use xearthlayer::publisher::{
     coverage::{CoverageConfig, CoverageMapGenerator},
-    BuildResult, ProcessSummary, RegionSuggestion, ReleaseResult, ReleaseStatus, RepoConfig,
-    SceneryScanResult, UrlConfigResult, VersionBump,
+    BuildResult, ProcessSummary, RegionMetadata, RegionSuggestion, ReleaseResult, ReleaseStatus,
+    RepoConfig, SceneryScanResult, UrlConfigResult, VersionBump,
 };
 
 // ============================================================================
@@ -292,15 +292,22 @@ impl PublisherService for DefaultPublisherService {
         &self,
         packages_dir: &Path,
         output_path: &Path,
+        metadata_path: &Path,
         width: u32,
         height: u32,
         dark: bool,
     ) -> Result<CoverageResult, CliError> {
-        let mut config = if dark {
+        let metadata =
+            RegionMetadata::load(metadata_path).map_err(|e| CliError::Publish(format!("{}", e)))?;
+
+        let base = if dark {
             CoverageConfig::dark()
         } else {
             CoverageConfig::default()
         };
+        let mut config = base
+            .with_regions(&metadata)
+            .map_err(|e| CliError::Publish(format!("{}", e)))?;
         config.width = width;
         config.height = height;
 
@@ -330,8 +337,13 @@ impl PublisherService for DefaultPublisherService {
         &self,
         packages_dir: &Path,
         output_path: &Path,
+        metadata_path: &Path,
     ) -> Result<CoverageResult, CliError> {
-        let config = CoverageConfig::default();
+        let metadata =
+            RegionMetadata::load(metadata_path).map_err(|e| CliError::Publish(format!("{}", e)))?;
+        let config = CoverageConfig::default()
+            .with_regions(&metadata)
+            .map_err(|e| CliError::Publish(format!("{}", e)))?;
         let generator = CoverageMapGenerator::new(config);
 
         // Scan packages

--- a/xearthlayer-cli/src/commands/publish/tests.rs
+++ b/xearthlayer-cli/src/commands/publish/tests.rs
@@ -420,6 +420,7 @@ impl PublisherService for MockPublisherService {
         &self,
         _packages_dir: &Path,
         _output_path: &Path,
+        _metadata_path: &Path,
         _width: u32,
         _height: u32,
         _dark: bool,
@@ -434,6 +435,7 @@ impl PublisherService for MockPublisherService {
         &self,
         _packages_dir: &Path,
         _output_path: &Path,
+        _metadata_path: &Path,
     ) -> Result<CoverageResult, CliError> {
         Ok(CoverageResult {
             total_tiles: 100,

--- a/xearthlayer-cli/src/commands/publish/tests.rs
+++ b/xearthlayer-cli/src/commands/publish/tests.rs
@@ -208,6 +208,7 @@ impl MockPublisherServiceBuilder {
             release_status: self.release_status.unwrap_or(ReleaseStatus::NotBuilt),
             url_config_result: self.url_config_result,
             release_result: self.release_result,
+            captured_coverage_metadata_path: RwLock::new(None),
         }
     }
 }
@@ -225,6 +226,15 @@ pub struct MockPublisherService {
     release_status: ReleaseStatus,
     url_config_result: Option<Result<UrlConfigResult, String>>,
     release_result: Option<Result<ReleaseResult, String>>,
+    captured_coverage_metadata_path: RwLock<Option<PathBuf>>,
+}
+
+impl MockPublisherService {
+    /// Returns the `metadata_path` most recently passed to
+    /// `generate_coverage_map` or `generate_coverage_geojson`, if any.
+    pub fn captured_coverage_metadata_path(&self) -> Option<PathBuf> {
+        self.captured_coverage_metadata_path.read().unwrap().clone()
+    }
 }
 
 impl PublisherService for MockPublisherService {
@@ -420,11 +430,12 @@ impl PublisherService for MockPublisherService {
         &self,
         _packages_dir: &Path,
         _output_path: &Path,
-        _metadata_path: &Path,
+        metadata_path: &Path,
         _width: u32,
         _height: u32,
         _dark: bool,
     ) -> Result<CoverageResult, CliError> {
+        *self.captured_coverage_metadata_path.write().unwrap() = Some(metadata_path.to_path_buf());
         Ok(CoverageResult {
             total_tiles: 100,
             tiles_by_region: [("na".to_string(), 100)].into_iter().collect(),
@@ -435,8 +446,9 @@ impl PublisherService for MockPublisherService {
         &self,
         _packages_dir: &Path,
         _output_path: &Path,
-        _metadata_path: &Path,
+        metadata_path: &Path,
     ) -> Result<CoverageResult, CliError> {
+        *self.captured_coverage_metadata_path.write().unwrap() = Some(metadata_path.to_path_buf());
         Ok(CoverageResult {
             total_tiles: 100,
             tiles_by_region: [("na".to_string(), 100)].into_iter().collect(),
@@ -1239,5 +1251,104 @@ mod validate_tests {
         assert!(result.is_ok());
         assert!(output.contains("Validating repository"));
         assert!(output.contains("Repository is valid"));
+    }
+}
+
+// ============================================================================
+// Coverage Handler Tests
+// ============================================================================
+
+#[cfg(test)]
+mod coverage_tests {
+    use super::*;
+
+    fn base_coverage_args(metadata: Option<PathBuf>, geojson: bool) -> CoverageArgs {
+        CoverageArgs {
+            output: PathBuf::from("coverage.png"),
+            width: 1200,
+            height: 600,
+            dark: false,
+            geojson,
+            metadata,
+            repo: PathBuf::from("/test/repo"),
+        }
+    }
+
+    #[test]
+    fn test_coverage_png_uses_default_metadata_path_when_not_specified() {
+        let output = MockOutput::new();
+        let publisher = MockPublisherServiceBuilder::new()
+            .with_open_success(PathBuf::from("/test/repo"))
+            .build();
+        let ctx = CommandContext::new(&output, &publisher);
+
+        let args = base_coverage_args(None, false);
+
+        let result = CoverageHandler::execute(args, &ctx);
+
+        assert!(result.is_ok());
+        assert_eq!(
+            publisher.captured_coverage_metadata_path(),
+            Some(PathBuf::from("/test/repo/region_metadata.json"))
+        );
+    }
+
+    #[test]
+    fn test_coverage_png_passes_through_explicit_metadata_path() {
+        let output = MockOutput::new();
+        let publisher = MockPublisherServiceBuilder::new()
+            .with_open_success(PathBuf::from("/test/repo"))
+            .build();
+        let ctx = CommandContext::new(&output, &publisher);
+
+        let custom_path = PathBuf::from("/custom/location/region_metadata.json");
+        let args = base_coverage_args(Some(custom_path.clone()), false);
+
+        let result = CoverageHandler::execute(args, &ctx);
+
+        assert!(result.is_ok());
+        assert_eq!(
+            publisher.captured_coverage_metadata_path(),
+            Some(custom_path)
+        );
+    }
+
+    #[test]
+    fn test_coverage_geojson_uses_default_metadata_path_when_not_specified() {
+        let output = MockOutput::new();
+        let publisher = MockPublisherServiceBuilder::new()
+            .with_open_success(PathBuf::from("/test/repo"))
+            .build();
+        let ctx = CommandContext::new(&output, &publisher);
+
+        let args = base_coverage_args(None, true);
+
+        let result = CoverageHandler::execute(args, &ctx);
+
+        assert!(result.is_ok());
+        assert_eq!(
+            publisher.captured_coverage_metadata_path(),
+            Some(PathBuf::from("/test/repo/region_metadata.json"))
+        );
+    }
+
+    #[test]
+    fn test_coverage_geojson_passes_through_explicit_metadata_path() {
+        let output = MockOutput::new();
+        let publisher = MockPublisherServiceBuilder::new()
+            .with_open_success(PathBuf::from("/test/repo"))
+            .build();
+        let ctx = CommandContext::new(&output, &publisher);
+
+        let custom_path = PathBuf::from("/custom/location/region_metadata.json");
+        let args = base_coverage_args(Some(custom_path.clone()), true);
+
+        let result = CoverageHandler::execute(args, &ctx);
+
+        assert!(result.is_ok());
+        assert_eq!(
+            publisher.captured_coverage_metadata_path(),
+            Some(custom_path)
+        );
     }
 }

--- a/xearthlayer-cli/src/commands/publish/traits.rs
+++ b/xearthlayer-cli/src/commands/publish/traits.rs
@@ -231,6 +231,7 @@ pub trait PublisherService: Send + Sync {
         &self,
         packages_dir: &Path,
         output_path: &Path,
+        metadata_path: &Path,
         width: u32,
         height: u32,
         dark: bool,
@@ -241,6 +242,7 @@ pub trait PublisherService: Send + Sync {
         &self,
         packages_dir: &Path,
         output_path: &Path,
+        metadata_path: &Path,
     ) -> Result<CoverageResult, CliError>;
 
     /// Deduplicate overlapping zoom level tiles in a package.

--- a/xearthlayer/Cargo.toml
+++ b/xearthlayer/Cargo.toml
@@ -52,6 +52,7 @@ nix = { version = "0.31", default-features = false, features = ["fs"] }
 memory-stats = "1.2"
 tracing-chrome = { version = "0.7", optional = true }
 axum = { version = "0.7", optional = true }
+csscolorparser = "0.8"
 
 [features]
 profiling = ["tracing-chrome"]

--- a/xearthlayer/src/publisher/coverage.rs
+++ b/xearthlayer/src/publisher/coverage.rs
@@ -67,32 +67,11 @@ pub struct CoverageConfig {
 
 impl Default for CoverageConfig {
     fn default() -> Self {
-        let mut region_colors = HashMap::new();
-        // Blue for NA (matches GeoJSON)
-        region_colors.insert("na".to_string(), (51, 136, 255, 180));
-        // Orange for EU (matches GeoJSON)
-        region_colors.insert("eu".to_string(), (255, 136, 0, 180));
-        // Tangerine for EU2 (Eastern Europe / Western Russia) — brighter than EU
-        region_colors.insert("eu2".to_string(), (255, 170, 0, 180));
-        // Green for SA
-        region_colors.insert("sa".to_string(), (0, 200, 83, 180));
-        // Purple for OC
-        region_colors.insert("oc".to_string(), (156, 39, 176, 180));
-        // Red for AS3 (Asia Part 3)
-        region_colors.insert("as3".to_string(), (255, 80, 80, 180));
-        // Green for AS (legacy/future Asia regions)
-        region_colors.insert("as".to_string(), (0, 200, 83, 180));
-        // Cyan for AF1 (North Africa)
-        region_colors.insert("af1".to_string(), (0, 188, 212, 180));
-        // Yellowish-green for AF/AF2 (Southern Africa)
-        region_colors.insert("af".to_string(), (180, 200, 80, 180));
-        region_colors.insert("af2".to_string(), (180, 200, 80, 180));
-
         Self {
             width: 1200,
             height: 600,
             padding: (20, 20),
-            region_colors,
+            region_colors: HashMap::new(),
             default_color: (100, 100, 100, 180),
             border_color: (0, 0, 0, 255),
             border_width: 0.5,
@@ -104,29 +83,11 @@ impl Default for CoverageConfig {
 impl CoverageConfig {
     /// Create a dark mode configuration with adjusted colors for visibility.
     pub fn dark() -> Self {
-        let mut region_colors = HashMap::new();
-        // Brighter colors for dark background
-        region_colors.insert("na".to_string(), (100, 180, 255, 200));
-        region_colors.insert("eu".to_string(), (255, 180, 100, 200));
-        // Tangerine for EU2 (dark mode) — brighter than EU
-        region_colors.insert("eu2".to_string(), (255, 200, 80, 200));
-        region_colors.insert("sa".to_string(), (100, 255, 150, 200));
-        region_colors.insert("oc".to_string(), (200, 100, 255, 200));
-        // Red for AS3 (Asia Part 3)
-        region_colors.insert("as3".to_string(), (255, 100, 100, 200));
-        // Green for AS (legacy/future Asia regions)
-        region_colors.insert("as".to_string(), (100, 255, 150, 200));
-        // Cyan for AF1 (North Africa - brighter for dark background)
-        region_colors.insert("af1".to_string(), (0, 220, 240, 200));
-        // Yellowish-green for AF/AF2 (Southern Africa - brighter for dark background)
-        region_colors.insert("af".to_string(), (210, 230, 120, 200));
-        region_colors.insert("af2".to_string(), (210, 230, 120, 200));
-
         Self {
             width: 1200,
             height: 600,
             padding: (20, 20),
-            region_colors,
+            region_colors: HashMap::new(),
             default_color: (150, 150, 150, 200),
             border_color: (80, 80, 80, 255),
             border_width: 0.3,
@@ -753,8 +714,9 @@ mod tests {
 
         assert_eq!(config.width, 1200);
         assert_eq!(config.height, 600);
-        assert!(config.region_colors.contains_key("na"));
-        assert!(config.region_colors.contains_key("eu"));
+        // Colours are no longer hardcoded; region_colors is populated by
+        // `with_regions` from `region_metadata.json`, not by `default()`.
+        assert!(config.region_colors.is_empty());
     }
 
     #[test]

--- a/xearthlayer/src/publisher/coverage.rs
+++ b/xearthlayer/src/publisher/coverage.rs
@@ -21,6 +21,7 @@ use staticmap::tools::Tool;
 use staticmap::{lat_to_y, lon_to_x, Bounds, StaticMapBuilder};
 use tiny_skia::{Color, FillRule, Paint, PathBuilder, PixmapMut, Shader, Stroke, Transform};
 
+use super::region_colors::{brighten, resolve, RegionMetadata};
 use super::{PublishError, PublishResult};
 
 /// Map style/theme for the base layer.
@@ -131,6 +132,28 @@ impl CoverageConfig {
             border_width: 0.3,
             style: MapStyle::Dark,
         }
+    }
+
+    /// Populates `region_colors` from region metadata.
+    ///
+    /// Keys are lowercased because metadata uses uppercase codes ("AS1") while
+    /// package directories on disk use lowercase ("as1"). Dark configs brighten
+    /// each colour and use alpha 200; light configs use alpha 180.
+    ///
+    /// Whether to brighten is decided by `self.style`, so a caller cannot pair
+    /// a dark config with light colours.
+    pub fn with_regions(mut self, metadata: &RegionMetadata) -> PublishResult<Self> {
+        let is_dark = self.style == MapStyle::Dark;
+        let alpha = if is_dark { 200 } else { 180 };
+
+        let mut colors = HashMap::new();
+        for (code, entry) in &metadata.regions {
+            let rgb = resolve(code, &entry.color)?;
+            let rgb = if is_dark { brighten(rgb) } else { rgb };
+            colors.insert(code.to_lowercase(), (rgb.0, rgb.1, rgb.2, alpha));
+        }
+        self.region_colors = colors;
+        Ok(self)
     }
 }
 
@@ -665,6 +688,52 @@ impl CoverageMapGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn metadata_fixture() -> crate::publisher::RegionMetadata {
+        serde_json::from_str(
+            r#"{"regions":{
+                "NA":{"color":"blue"},
+                "AS1":{"color":"firebrick"}
+            }}"#,
+        )
+        .unwrap()
+    }
+
+    // Metadata keys are uppercase ("AS1"); package region codes on disk are
+    // lowercase ("as1"). Without normalisation every lookup would miss.
+    #[test]
+    fn with_regions_lowercases_keys() {
+        let config = CoverageConfig::default()
+            .with_regions(&metadata_fixture())
+            .unwrap();
+        assert!(config.region_colors.contains_key("na"));
+        assert!(config.region_colors.contains_key("as1"));
+        assert!(!config.region_colors.contains_key("NA"));
+    }
+
+    #[test]
+    fn light_config_uses_metadata_colour_with_alpha_180() {
+        let config = CoverageConfig::default()
+            .with_regions(&metadata_fixture())
+            .unwrap();
+        assert_eq!(config.region_colors["na"], (0, 0, 255, 180));
+    }
+
+    #[test]
+    fn dark_config_brightens_and_uses_alpha_200() {
+        let config = CoverageConfig::dark()
+            .with_regions(&metadata_fixture())
+            .unwrap();
+        assert_eq!(config.region_colors["na"], (89, 89, 255, 200));
+    }
+
+    #[test]
+    fn with_regions_propagates_unknown_colour_error() {
+        let md: crate::publisher::RegionMetadata =
+            serde_json::from_str(r#"{"regions":{"EU2":{"color":"tangerine"}}}"#).unwrap();
+        let err = CoverageConfig::default().with_regions(&md).unwrap_err();
+        assert!(format!("{}", err).contains("EU2"));
+    }
 
     #[test]
     fn test_filled_rect_extent() {

--- a/xearthlayer/src/publisher/error.rs
+++ b/xearthlayer/src/publisher/error.rs
@@ -67,6 +67,15 @@ pub enum PublishError {
 
     /// Release validation failed.
     ReleaseValidation(String),
+
+    /// Region metadata file not found.
+    RegionMetadataNotFound(PathBuf),
+
+    /// Region metadata file could not be parsed.
+    InvalidRegionMetadata { path: PathBuf, message: String },
+
+    /// A region's colour could not be resolved to RGB.
+    UnknownRegionColor { region: String, color: String },
 }
 
 impl fmt::Display for PublishError {
@@ -140,6 +149,23 @@ impl fmt::Display for PublishError {
             }
             PublishError::ReleaseValidation(msg) => {
                 write!(f, "release validation failed: {}", msg)
+            }
+            PublishError::RegionMetadataNotFound(path) => {
+                write!(
+                    f,
+                    "region_metadata.json not found at {}. Pass --metadata to override.",
+                    path.display()
+                )
+            }
+            PublishError::InvalidRegionMetadata { path, message } => {
+                write!(f, "failed to parse {}: {}", path.display(), message)
+            }
+            PublishError::UnknownRegionColor { region, color } => {
+                write!(
+                    f,
+                    "region \"{}\" has unknown color \"{}\". Use a CSS color name or hex (#rrggbb).",
+                    region, color
+                )
             }
         }
     }

--- a/xearthlayer/src/publisher/mod.rs
+++ b/xearthlayer/src/publisher/mod.rs
@@ -48,6 +48,7 @@ mod library;
 mod metadata;
 mod processor;
 mod region;
+mod region_colors;
 mod release;
 mod repository;
 mod urls;
@@ -72,6 +73,7 @@ pub use processor::{
     SceneryScanResult, TileInfo, TileWarning,
 };
 pub use region::{analyze_tiles, suggest_region, RegionSuggestion, SuggestedRegion};
+pub use region_colors::{brighten, resolve, RegionEntry, RegionMetadata};
 pub use release::{
     build_package, configure_urls, get_release_status, release_package, validate_repository,
     BuildResult, ReleaseResult, ReleaseStatus, UrlConfigResult,

--- a/xearthlayer/src/publisher/region_colors.rs
+++ b/xearthlayer/src/publisher/region_colors.rs
@@ -26,20 +26,15 @@ pub struct RegionMetadata {
 
 /// One region's metadata entry.
 ///
-/// Only `color` is required — it is the only field the coverage map uses.
-/// `name` and `coverage` exist for the website legend and are optional here so
-/// the map does not fail on a region that omits them. Unknown fields are
-/// ignored, so the website can add keys without breaking map generation.
+/// Only `color` is modelled — it is the only field the coverage map uses. The
+/// real file also carries `name` and `coverage` for the website legend, which
+/// reads the JSON directly and never goes through this type. Unknown fields are
+/// ignored (no `deny_unknown_fields`), so those keys parse harmlessly and the
+/// website can add more without breaking map generation.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RegionEntry {
     /// CSS colour name or hex string (e.g. "crimson", "#ffaa00").
     pub color: String,
-    /// Human-readable region name (website legend only).
-    #[serde(default)]
-    pub name: Option<String>,
-    /// Human-readable coverage description (website legend only).
-    #[serde(default)]
-    pub coverage: Option<String>,
 }
 
 impl RegionMetadata {
@@ -181,6 +176,17 @@ mod tests {
                 color
             );
         }
+    }
+
+    // name/coverage exist in the real file for the website legend but are not
+    // fields on RegionEntry. Serde ignores them, so the map is unaffected.
+    #[test]
+    fn website_only_fields_are_ignored() {
+        let f = write_temp(
+            r#"{"regions":{"NA":{"name":"North America","coverage":"US","color":"blue"}}}"#,
+        );
+        let md = RegionMetadata::load(f.path()).unwrap();
+        assert_eq!(md.regions.get("NA").unwrap().color, "blue");
     }
 
     #[test]

--- a/xearthlayer/src/publisher/region_colors.rs
+++ b/xearthlayer/src/publisher/region_colors.rs
@@ -1,0 +1,197 @@
+//! Region colour resolution for coverage maps.
+//!
+//! Colours come from `region_metadata.json` in the package repository root —
+//! the same file the website legend reads — so adding a region requires no
+//! Rust change. See issue #200.
+//!
+//! An unresolvable colour is a hard error rather than a grey fallback: a
+//! silently grey region is exactly how AS2 v0.1.0 shipped wrong.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use super::{PublishError, PublishResult};
+
+/// Fraction blended toward white to derive dark-mode colours.
+const DARK_BLEND: f32 = 0.35;
+
+/// Parsed `region_metadata.json`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegionMetadata {
+    /// Region code (e.g. "NA", "AS1") to its entry.
+    pub regions: HashMap<String, RegionEntry>,
+}
+
+/// One region's metadata entry.
+///
+/// Only `color` is required — it is the only field the coverage map uses.
+/// `name` and `coverage` exist for the website legend and are optional here so
+/// the map does not fail on a region that omits them. Unknown fields are
+/// ignored, so the website can add keys without breaking map generation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegionEntry {
+    /// CSS colour name or hex string (e.g. "crimson", "#ffaa00").
+    pub color: String,
+    /// Human-readable region name (website legend only).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Human-readable coverage description (website legend only).
+    #[serde(default)]
+    pub coverage: Option<String>,
+}
+
+impl RegionMetadata {
+    /// Reads and parses the metadata file.
+    pub fn load(path: &Path) -> PublishResult<Self> {
+        if !path.exists() {
+            return Err(PublishError::RegionMetadataNotFound(path.to_path_buf()));
+        }
+        let contents =
+            std::fs::read_to_string(path).map_err(|source| PublishError::ReadFailed {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        serde_json::from_str(&contents).map_err(|e| PublishError::InvalidRegionMetadata {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })
+    }
+}
+
+/// Resolves a CSS colour name or hex string to RGB.
+///
+/// `region` is used only so the error can name the offending entry.
+pub fn resolve(region: &str, color: &str) -> PublishResult<(u8, u8, u8)> {
+    let parsed =
+        color
+            .parse::<csscolorparser::Color>()
+            .map_err(|_| PublishError::UnknownRegionColor {
+                region: region.to_string(),
+                color: color.to_string(),
+            })?;
+    let [r, g, b, _a] = parsed.to_rgba8();
+    Ok((r, g, b))
+}
+
+/// Derives the dark-mode variant by blending toward white.
+///
+/// Uniform and predictable: already-bright colours barely move rather than
+/// clipping, and saturated primaries lighten instead of turning fluorescent.
+pub fn brighten(rgb: (u8, u8, u8)) -> (u8, u8, u8) {
+    let blend = |c: u8| (c as f32 + (255.0 - c as f32) * DARK_BLEND).round() as u8;
+    (blend(rgb.0), blend(rgb.1), blend(rgb.2))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_temp(contents: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn loads_valid_metadata() {
+        let f = write_temp(
+            r#"{"regions":{"NA":{"name":"North America","coverage":"US","color":"blue"}}}"#,
+        );
+        let md = RegionMetadata::load(f.path()).unwrap();
+        assert_eq!(md.regions.get("NA").unwrap().color, "blue");
+    }
+
+    // Only `color` is required. The map never reads name/coverage; requiring
+    // them would fail generation for a region that merely omits a description.
+    #[test]
+    fn color_is_the_only_required_field() {
+        let f = write_temp(r#"{"regions":{"XX":{"color":"red"}}}"#);
+        let md = RegionMetadata::load(f.path()).unwrap();
+        assert_eq!(md.regions.get("XX").unwrap().color, "red");
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored() {
+        let f = write_temp(r#"{"regions":{"XX":{"color":"red","future_key":42}}}"#);
+        assert!(RegionMetadata::load(f.path()).is_ok());
+    }
+
+    #[test]
+    fn missing_file_is_an_error() {
+        let err = RegionMetadata::load(Path::new("/nonexistent/region_metadata.json"));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        let f = write_temp("{ not json");
+        assert!(RegionMetadata::load(f.path()).is_err());
+    }
+
+    #[test]
+    fn resolves_css_names() {
+        assert_eq!(resolve("NA", "blue").unwrap(), (0, 0, 255));
+        assert_eq!(resolve("EU", "orange").unwrap(), (255, 165, 0));
+        assert_eq!(resolve("AS2", "crimson").unwrap(), (220, 20, 60));
+    }
+
+    #[test]
+    fn resolves_hex() {
+        assert_eq!(resolve("EU2", "#ffaa00").unwrap(), (255, 170, 0));
+    }
+
+    // The error must name the region, or a release engineer cannot tell which
+    // metadata entry to fix.
+    #[test]
+    fn unknown_color_errors_and_names_the_region() {
+        let err = resolve("EU2", "tangerine").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("EU2"), "error should name the region: {}", msg);
+        assert!(
+            msg.contains("tangerine"),
+            "error should name the color: {}",
+            msg
+        );
+    }
+
+    // Proves the ten CSS names actually used by the live repo all resolve.
+    // EU2 is deliberately absent: its "tangerine" is not a CSS colour and is
+    // being moved to hex in the regional-scenery repo.
+    #[test]
+    fn every_live_region_colour_resolves() {
+        for (region, color) in [
+            ("NA", "blue"),
+            ("EU", "orange"),
+            ("SA", "green"),
+            ("OC", "purple"),
+            ("AS1", "firebrick"),
+            ("AS2", "crimson"),
+            ("AS3", "red"),
+            ("AS4", "palevioletred"),
+            ("AF1", "cyan"),
+            ("AF2", "yellowgreen"),
+        ] {
+            assert!(
+                resolve(region, color).is_ok(),
+                "{} colour {} should resolve",
+                region,
+                color
+            );
+        }
+    }
+
+    #[test]
+    fn brighten_blends_toward_white_by_35_percent() {
+        assert_eq!(brighten((0, 0, 255)), (89, 89, 255));
+        // 165 + (255-165)*0.35 == 196.5 exactly in f32; Rust's f32::round()
+        // is round-half-away-from-zero, so this rounds to 197, not 196.
+        assert_eq!(brighten((255, 165, 0)), (255, 197, 89));
+        assert_eq!(brighten((0, 128, 0)), (89, 172, 89));
+        assert_eq!(brighten((128, 0, 128)), (172, 89, 172));
+        assert_eq!(brighten((220, 20, 60)), (232, 102, 128));
+        assert_eq!(brighten((0, 255, 255)), (89, 255, 255));
+    }
+}

--- a/xearthlayer/src/publisher/repository.rs
+++ b/xearthlayer/src/publisher/repository.rs
@@ -34,6 +34,18 @@ const STAGING_DIR: &str = "staging";
 /// Library index filename.
 const LIBRARY_FILE: &str = "xearthlayer_package_library.txt";
 
+/// Region colour metadata consumed by `publish coverage` and the website legend.
+const REGION_METADATA_FILE: &str = "region_metadata.json";
+
+/// Stub written by `init`. The empty `regions` map is intentional — coverage
+/// map generation succeeds and renders everything grey, which is visibly
+/// incomplete, rather than failing on a fresh repository.
+const REGION_METADATA_STUB: &str = r#"{
+  "_comment": "Region colours for the coverage map and website legend. 'color' accepts a CSS colour name (e.g. crimson) or hex (e.g. #ffaa00).",
+  "regions": {}
+}
+"#;
+
 /// A package publisher repository.
 ///
 /// Manages the structure and state of a local package repository used to
@@ -59,6 +71,7 @@ impl Repository {
     /// - `dist/` directory for built archives
     /// - `staging/` directory for work in progress
     /// - Empty `xearthlayer_package_library.txt`
+    /// - `region_metadata.json` stub with an empty region list
     ///
     /// # Errors
     ///
@@ -113,6 +126,15 @@ impl Repository {
         fs::write(&library_path, library_content).map_err(|e| PublishError::WriteFailed {
             path: library_path,
             source: e,
+        })?;
+
+        // Write region metadata stub
+        let region_metadata_path = root.join(REGION_METADATA_FILE);
+        fs::write(&region_metadata_path, REGION_METADATA_STUB).map_err(|e| {
+            PublishError::WriteFailed {
+                path: region_metadata_path,
+                source: e,
+            }
         })?;
 
         Ok(Self {
@@ -559,5 +581,28 @@ mod tests {
         let (_temp, repo) = temp_repo();
         let debug = format!("{:?}", repo);
         assert!(debug.contains("Repository"));
+    }
+
+    #[test]
+    fn init_creates_region_metadata_stub() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let path = repo.root().join("region_metadata.json");
+        assert!(path.exists(), "init should create region_metadata.json");
+    }
+
+    // The stub must be loadable by the coverage map, not merely present.
+    // An empty regions map is intentional: `publish coverage` then succeeds
+    // and renders every region grey, which is obviously incomplete.
+    #[test]
+    fn init_stub_parses_as_region_metadata_with_no_regions() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let metadata =
+            crate::publisher::RegionMetadata::load(&repo.root().join("region_metadata.json"))
+                .expect("stub must parse as RegionMetadata");
+        assert!(metadata.regions.is_empty());
     }
 }


### PR DESCRIPTION
Fixes #200

> **Note on auto-close:** GitHub only acts on a closing keyword when a PR merges into the *default* branch (`main`). This PR targets `develop/0.4.7`, so the keyword above will not fire on merge here — `Fixes #200` is also in the final commit's message, which closes the issue automatically when `develop/0.4.7` reaches `main`.

## Summary

`publish coverage` hardcoded region→colour tables in `coverage.rs` while `region_metadata.json` — sitting in the package repository root, beside the packages the command already scans — was the source of truth for the website legend. Adding a region meant editing both, in two repositories, and the mismatch only surfaced after a map was regenerated and published. AS2 v0.1.0 shipped a grey region for exactly this reason.

Colours now come from `region_metadata.json`. **Adding a region requires one JSON entry and no Rust change.**

## The two sources had already diverged

Exploration found the situation was worse than the issue described: **not one hardcoded colour matched its CSS name.**

| Region | metadata | CSS value | hardcoded value |
|---|---|---|---|
| NA | `blue` | (0,0,255) | (51,136,255) |
| EU | `orange` | (255,165,0) | (255,136,0) |
| SA | `green` | (0,128,0) | (0,200,83) |
| OC | `purple` | (128,0,128) | (156,39,176) |
| AS3 | `red` | (255,0,0) | (255,80,80) |
| AF1 | `cyan` | (0,255,255) | (0,188,212) |
| AF2 | `yellowgreen` | (154,205,50) | (180,200,80) |

The hardcoded values were hand-tuned map colours; the metadata names were legend labels. Two palettes that had never agreed. Three live regions — AS1, AS2, AS4 — were missing from the Rust table entirely and rendered grey; two entries in it (`as`, `af`) matched no package at all.

**So this PR repaints the map.** That is the intended outcome — the map and the website legend now show the same colour per region — but anyone diffing before/after coverage images will see a substantially different picture.

## Changes

- **New `publisher::region_colors`** — `RegionMetadata::load`, `resolve` (CSS names *and* hex), `brighten`. Single new dependency: `csscolorparser = "0.8"`.
- **`CoverageConfig::with_regions`** populates the colour table from metadata, lowercasing keys (metadata uses `AS1`, package directories use `as1`) and deriving dark mode by blending 35% toward white — so there is no second palette to maintain.
- **`--metadata <path>`** on `publish coverage`, defaulting to `<repo>/region_metadata.json`. Both the PNG and GeoJSON paths load it, so the two outputs cannot disagree.
- **Unresolvable colour or missing file is a hard error** — non-zero exit, no map written, and the message names the offending region. Silent grey is the failure this issue exists to eliminate.
- **`publish init` now scaffolds a `region_metadata.json` stub** with an empty region list, so a fresh repository can generate a coverage map.

Built as three commits ordered so no intermediate is broken: an additive module, an additive `with_regions`, then the atomic switch that wires the CLI and deletes the hardcoded tables together.

## Companion change required

`region_metadata.json` in `samsoir/xearthlayer-regional-scenery` needs `EU2` changed from `"tangerine"` to `"#ffaa00"`. `"tangerine"` is not a CSS colour name and cannot be resolved; `#ffaa00` is the value EU2 has always rendered as, so this is not a colour change — it makes the existing colour expressible. **Until that lands, `publish coverage` fails on EU2 by design.**

## Test Plan

- [x] `make pre-commit` passes — fmt, clippy `-D warnings`, full suite, 63 doctests
- [x] **Hard-failure path demonstrated live** against the real metadata file: exit 1, `region "EU2" has unknown color "tangerine"`, on both the PNG and GeoJSON paths
- [x] **Success path demonstrated live** with the companion change applied: exit 0, 820 KB PNG, all **11 regions** rendering — including AS1, AS2 and AS4, previously grey
- [x] Default metadata path (no `--metadata` flag) unit-tested for both output formats — this is the path release engineers actually use, and it was previously untested
- [x] `publish init` verified to produce a stub that parses as `RegionMetadata`
- [x] `brighten` pinned against computed values; `resolve` covers CSS names, hex, and the unknown-name error naming its region
- [x] All ten live CSS colour names verified to resolve

Reviewers can check the end state with:

```bash
xearthlayer publish coverage -o /tmp/coverage.png <package-repo>
grep -rn 'region_colors.insert' xearthlayer/src/publisher/coverage.rs   # expect: nothing
```

## Checklist

- [x] Code follows the project's SOLID principles and patterns
- [x] Tests added or updated for new/changed behavior
- [x] Documentation updated — `docs/dev/github-releases-publishing.md` gains the `--metadata` row and a rewritten "Region Metadata File" section covering the required-input status, hex support, hard-error behaviour and automatic dark mode; `CLAUDE.md` gains the flag
- [x] No new warnings from `cargo clippy`

## Known minors, deliberately deferred

- A package whose region has **no** metadata entry still renders `default_color` grey with no warning. Left as-is: an undefined region is glaring on a map, so a warning would add noise for a failure that announces itself.
- The library error message names the CLI flag `--metadata` (layering leak, good UX).
- `RegionMetadata::load` uses `exists()`, so an unreadable file reports "not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
