### PR TITLE
fix(config): accept decimal sizes and round the memory recommendation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ The wizard auto-detects your X-Plane installation, system hardware (CPU, memory,
 
 1. **X-Plane Custom Scenery** — auto-detected from your X-Plane install, with fallback to manual entry.
 2. **Package Location** — where regional scenery packages live on disk.
-3. **Cache Configuration** — cache directory, disk cache size (defaults to 25% of free space, floored to 10 GB), DDS-to-chunk disk ratio, memory cache size (defaults to RAM ÷ 12, clamped to 500 MB – RAM ÷ 4), and disk I/O profile (NVMe / SSD / HDD / auto).
+3. **Cache Configuration** — cache directory, disk cache size (defaults to 25% of free space, floored to 10 GB), DDS-to-chunk disk ratio, memory cache size (defaults to RAM ÷ 12, rounded to the nearest whole GB, clamped to 500 MB – RAM ÷ 4), and disk I/O profile (NVMe / SSD / HDD / auto).
 4. **DDS Encoding** — picks ISPC (CPU) by default, or offers to offload encoding to a secondary GPU when **two or more GPU adapters** are detected. The wizard warns against picking the GPU X-Plane renders on. Single-GPU systems skip the choice and stay on ISPC.
 
 GPU enumeration can take 10–30 seconds on multi-adapter systems while drivers are probed; a spinner shows progress.
@@ -126,8 +126,8 @@ Controls tile caching behavior.
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `directory` | path | `~/.cache/xearthlayer` | Directory for storing cached tiles. Supports `~` expansion. |
-| `memory_size` | size | `512MB` | Maximum RAM for in-memory cache. Supports KB, MB, GB suffixes. Memory cache is a staging buffer; DDS disk cache is the retention layer. |
-| `disk_size` | size | `20GB` | Maximum disk space for persistent cache (shared between DDS tiles and raw chunks). Supports KB, MB, GB suffixes. |
+| `memory_size` | size | `512MB` | Maximum RAM for in-memory cache. Supports KB, MB, GB suffixes, decimal values (e.g. `2.6GB`), and a bare `B` suffix. Memory cache is a staging buffer; DDS disk cache is the retention layer. |
+| `disk_size` | size | `20GB` | Maximum disk space for persistent cache (shared between DDS tiles and raw chunks). Supports KB, MB, GB suffixes, decimal values (e.g. `2.6GB`), and a bare `B` suffix. |
 | `dds_disk_ratio` | float | `0.6` | Fraction of `disk_size` allocated to DDS tile cache (0.0-1.0). Remainder goes to raw chunk cache. |
 | `disk_io_profile` | string | `auto` | Disk I/O concurrency profile based on storage type (see below) |
 

--- a/xearthlayer-cli/src/commands/setup/wizard.rs
+++ b/xearthlayer-cli/src/commands/setup/wizard.rs
@@ -493,7 +493,7 @@ fn prompt_memory_cache_size(
     println!();
     println!("{}", style("Memory cache size:").bold());
     println!(
-        "  ℹ  System RAM: {} MB — default is RAM ÷ 12 ({} MB)",
+        "  ℹ  System RAM: {} MB — default is RAM ÷ 12, rounded to the nearest GB ({} MB)",
         total_mb, recommended_mb
     );
     println!(

--- a/xearthlayer/src/config/size.rs
+++ b/xearthlayer/src/config/size.rs
@@ -29,6 +29,8 @@ impl SizeParseError {
 ///
 /// Supports:
 /// - Bare numbers (treated as bytes)
+/// - Decimal values (e.g. "2.6GB")
+/// - B suffix (bytes, e.g. "512B" — what `format_size` emits under 1 KB)
 /// - KB/K suffix (1024 bytes)
 /// - MB/M suffix (1024² bytes)
 /// - GB/G suffix (1024³ bytes)
@@ -45,6 +47,7 @@ impl SizeParseError {
 /// assert_eq!(parse_size("1 KB").unwrap(), 1024);
 /// assert_eq!(parse_size("2GB").unwrap(), 2 * 1024 * 1024 * 1024);
 /// assert_eq!(parse_size("500mb").unwrap(), 500 * 1024 * 1024);
+/// assert_eq!(parse_size("1.5GB").unwrap(), 1536 * 1024 * 1024);
 /// ```
 pub fn parse_size(s: &str) -> Result<usize, SizeParseError> {
     let s = s.trim();
@@ -69,16 +72,34 @@ pub fn parse_size(s: &str) -> Result<usize, SizeParseError> {
         let suffix_len = if s_upper.ends_with("KB") { 2 } else { 1 };
         let num_part = s[..s.len() - suffix_len].trim();
         (num_part, 1024_usize)
+    } else if s_upper.ends_with('B') {
+        // Explicit bytes suffix, e.g. "512 B" — this is what `format_size`
+        // emits for values under 1 KB, so it must round-trip (see #218).
+        let num_part = s[..s.len() - 1].trim();
+        (num_part, 1_usize)
     } else {
         // No suffix, treat as bytes
         (s, 1_usize)
     };
 
-    // Parse the numeric part
-    let num: usize = num_str.parse().map_err(|_| SizeParseError::new(s))?;
+    // Parse the numeric part. Decimals are accepted so that any value
+    // `format_size` can emit reads back through here — see issue #218.
+    let num: f64 = num_str.parse().map_err(|_| SizeParseError::new(s))?;
 
-    num.checked_mul(multiplier)
-        .ok_or_else(|| SizeParseError::new(s))
+    // These guards are load-bearing. Rust's float -> int `as` casts saturate
+    // rather than trapping, so without them "-1GB" would silently yield 0 and
+    // "infGB" would yield usize::MAX — replacing a loud failure with a quiet
+    // wrong answer.
+    if !num.is_finite() || num < 0.0 {
+        return Err(SizeParseError::new(s));
+    }
+
+    let bytes = (num * multiplier as f64).round();
+    if bytes > usize::MAX as f64 {
+        return Err(SizeParseError::new(s));
+    }
+
+    Ok(bytes as usize)
 }
 
 /// Format a byte count as a human-readable string.
@@ -205,7 +226,65 @@ mod tests {
         assert!(parse_size("abc").is_err());
         assert!(parse_size("2TB").is_err()); // Not supported
         assert!(parse_size("-1GB").is_err());
-        assert!(parse_size("1.5GB").is_err()); // Decimals not supported
+    }
+
+    #[test]
+    fn test_parse_decimals() {
+        // The value from issue #218 — a 32 GB machine's RAM/12.
+        assert_eq!(parse_size("2.6 GB").unwrap(), 2_791_728_742);
+        assert_eq!(parse_size("1.5GB").unwrap(), 1536 * 1024 * 1024);
+        assert_eq!(parse_size("1.5MB").unwrap(), 1536 * 1024);
+        assert_eq!(parse_size("2.5KB").unwrap(), 2560);
+    }
+
+    // Rust's float->int `as` casts saturate rather than trapping, so each of
+    // these would silently produce a number instead of an error without
+    // explicit guards: "-1GB" -> 0, "infGB" -> usize::MAX, overflow -> usize::MAX.
+    #[test]
+    fn test_parse_rejects_non_finite_and_negative() {
+        assert!(parse_size("-1GB").is_err());
+        assert!(parse_size("-0.5GB").is_err());
+        assert!(parse_size("infGB").is_err());
+        assert!(parse_size("NaNGB").is_err());
+    }
+
+    #[test]
+    fn test_parse_rejects_overflow() {
+        // Far beyond usize::MAX once multiplied by the GB unit.
+        assert!(parse_size("999999999999GB").is_err());
+    }
+
+    // format_size and parse_size are inverses and must round-trip. This is the
+    // property whose absence caused issue #218.
+    #[test]
+    fn test_size_round_trip() {
+        for bytes in [
+            512_usize,
+            2048,
+            1536 * 1024,
+            500 * 1024 * 1024,
+            1024 * 1024 * 1024,
+            1536 * 1024 * 1024,
+            2_791_728_742,
+            50 * 1024 * 1024 * 1024,
+        ] {
+            let rendered = format_size(bytes);
+            // The primary assertion is simply that it parses at all — that is
+            // the property whose absence caused #218.
+            let parsed = parse_size(&rendered).unwrap_or_else(|e| {
+                panic!("{bytes} rendered as {rendered:?} failed to parse: {e}")
+            });
+            // format_size keeps one decimal place, so the round trip is lossy
+            // by design for values that are not exact unit multiples. 10% is
+            // deliberately generous: a value just above 1.0 of its unit can
+            // lose almost 5%, and a tighter bound would make this flaky at
+            // that boundary without testing anything more useful.
+            let tolerance = (bytes as f64 * 0.10).max(1.0) as usize;
+            assert!(
+                parsed.abs_diff(bytes) <= tolerance,
+                "{bytes} -> {rendered:?} -> {parsed} exceeds tolerance {tolerance}"
+            );
+        }
     }
 
     #[test]

--- a/xearthlayer/src/config/size.rs
+++ b/xearthlayer/src/config/size.rs
@@ -95,6 +95,11 @@ pub fn parse_size(s: &str) -> Result<usize, SizeParseError> {
     }
 
     let bytes = (num * multiplier as f64).round();
+    // Deliberately `>`, not `>=`: `usize::MAX as f64` rounds up to 2^64 (a
+    // value usize can't hold), and `format_size(usize::MAX)` emits
+    // "17179869184 GB", which parses back to exactly 2^64 here. Tightening
+    // this to `>=` would reject the formatter's own output and break the
+    // round-trip property at the top of the range.
     if bytes > usize::MAX as f64 {
         return Err(SizeParseError::new(s));
     }
@@ -257,7 +262,7 @@ mod tests {
     // format_size and parse_size are inverses and must round-trip. This is the
     // property whose absence caused issue #218.
     #[test]
-    fn test_size_round_trip() {
+    fn test_format_parse_round_trip() {
         for bytes in [
             512_usize,
             2048,
@@ -302,7 +307,10 @@ mod tests {
 
     #[test]
     fn test_size_roundtrip() {
-        // Note: roundtrip only works for exact multiples due to space in format
+        // Note: parse_size accepts decimals (see #218), so parsing is no
+        // longer the limiting factor here. format_size still rounds to one
+        // decimal place, so this test sticks to exact multiples where the
+        // string representation itself round-trips unchanged.
         let test_cases = vec![
             ("1KB", "1 KB"),
             ("500MB", "500 MB"),

--- a/xearthlayer/src/system/hardware.rs
+++ b/xearthlayer/src/system/hardware.rs
@@ -137,9 +137,10 @@ impl SystemInfo {
 
     /// Get recommended memory cache size in bytes.
     ///
-    /// Computed as `RAM / 12`, clamped to a 500 MB floor and a `RAM / 4`
-    /// ceiling. The cache is intentionally a small request absorber, not a
-    /// working set holder; the on-disk DDS cache holds the working set.
+    /// Computed as `RAM / 12`, rounded to the nearest whole GB, then clamped
+    /// to a 500 MB floor and a `RAM / 4` ceiling. The cache is intentionally
+    /// a small request absorber, not a working set holder; the on-disk DDS
+    /// cache holds the working set.
     pub fn recommended_memory_cache(&self) -> usize {
         recommended_memory_cache(self.total_memory)
     }

--- a/xearthlayer/src/system/hardware.rs
+++ b/xearthlayer/src/system/hardware.rs
@@ -282,8 +282,8 @@ mod tests {
     fn test_system_info_recommendations() {
         // 16GB system with SSD, 230GB available disk
         let info = SystemInfo::new_with_disk(8, 16 * GB, StorageType::Ssd, 230 * GB as u64);
-        // 16GB / 12 = ~1.33GB, well above 500MB floor and well below 4GB ceiling
-        assert_eq!(info.recommended_memory_cache(), 16 * GB / 12);
+        // 16GB / 12 = ~1.33GB, rounded to the nearest whole GB
+        assert_eq!(info.recommended_memory_cache(), GB);
         assert_eq!(info.recommended_disk_cache(), 50 * GB);
         assert_eq!(info.recommended_disk_io_profile(), "auto");
     }
@@ -298,8 +298,8 @@ mod tests {
     fn test_system_info_display_formatting() {
         let info = SystemInfo::new(8, 16 * GB, StorageType::Ssd);
         assert_eq!(info.memory_display(), "16 GB");
-        // 16GB / 12 = 1.333... GB → format_size renders as "1.3 GB"
-        assert_eq!(info.recommended_memory_cache_display(), "1.3 GB");
+        // 16GB / 12 = 1.333... GB, rounded to a whole GB for a tidy config value
+        assert_eq!(info.recommended_memory_cache_display(), "1 GB");
         assert_eq!(info.storage_display(), "SATA SSD");
     }
 

--- a/xearthlayer/src/system/recommendations.rs
+++ b/xearthlayer/src/system/recommendations.rs
@@ -78,22 +78,28 @@ impl RecommendedSettings {
 /// | System RAM | Recommended cache |
 /// |------------|------------------|
 /// | 4 GB       | 500 MB (floor)   |
-/// | 8 GB       | ~683 MB          |
-/// | 16 GB      | ~1.3 GB          |
-/// | 32 GB      | ~2.7 GB          |
-/// | 64 GB      | ~5.3 GB          |
-/// | 128 GB     | ~10.7 GB         |
+/// | 8 GB       | 1 GB             |
+/// | 16 GB      | 1 GB             |
+/// | 32 GB      | 3 GB             |
+/// | 64 GB      | 5 GB             |
+/// | 128 GB     | 11 GB            |
 ///
 /// ```
 /// use xearthlayer::system::recommended_memory_cache;
 ///
 /// let cache = recommended_memory_cache(16 * 1024 * 1024 * 1024); // 16 GB RAM
-/// assert!(cache >= 1_300_000_000 && cache <= 1_500_000_000); // ~1.3 GB
+/// assert_eq!(cache, 1024 * 1024 * 1024); // 1 GB, rounded to a whole GB
 /// ```
 pub fn recommended_memory_cache(total_memory: usize) -> usize {
     let raw = total_memory / 12;
+    // Round to the nearest whole GB so the wizard writes a tidy config value,
+    // matching recommended_disk_cache which already uses a round step. Nearest
+    // rather than floor: flooring would drop an 8 GB machine from ~683 MB to
+    // the 500 MB minimum, whereas rounding lifts it to a clean 1 GB. Values
+    // that round to zero are caught by the MIN clamp below.
+    let rounded = ((raw as f64 / GB as f64).round() as usize) * GB;
     let ceiling = total_memory / 4;
-    raw.clamp(MIN_MEMORY_CACHE_BYTES, ceiling.max(MIN_MEMORY_CACHE_BYTES))
+    rounded.clamp(MIN_MEMORY_CACHE_BYTES, ceiling.max(MIN_MEMORY_CACHE_BYTES))
 }
 
 /// Calculate recommended disk cache size from available disk space.
@@ -156,16 +162,26 @@ mod tests {
         assert_eq!(recommended_memory_cache(1 * GB), MIN_MEMORY_CACHE_BYTES);
     }
 
+    // Issue #218: the wizard wrote "2.6 GB" on a 32 GB machine and the app
+    // rejected it. Recommendations are now whole GB above the floor, matching
+    // recommended_disk_cache's existing round-step behaviour.
     #[test]
-    fn memory_cache_uses_ram_div_12_in_normal_range() {
-        // 16GB / 12 = 1.333... GB
-        assert_eq!(recommended_memory_cache(16 * GB), 16 * GB / 12);
-        // 32GB / 12 = 2.666... GB
-        assert_eq!(recommended_memory_cache(32 * GB), 32 * GB / 12);
-        // 64GB / 12 = 5.333... GB
-        assert_eq!(recommended_memory_cache(64 * GB), 64 * GB / 12);
-        // 128GB / 12 = 10.666... GB
-        assert_eq!(recommended_memory_cache(128 * GB), 128 * GB / 12);
+    fn memory_cache_rounds_ram_div_12_to_whole_gb() {
+        let cases = [
+            (4 * GB, MIN_MEMORY_CACHE_BYTES), // rounds to 0, caught by the floor
+            (8 * GB, GB),
+            (16 * GB, GB),
+            (32 * GB, 3 * GB),
+            (64 * GB, 5 * GB),
+            (128 * GB, 11 * GB),
+        ];
+        for (ram, expected) in cases {
+            assert_eq!(
+                recommended_memory_cache(ram),
+                expected,
+                "RAM {ram} should recommend {expected}"
+            );
+        }
     }
 
     #[test]
@@ -216,7 +232,8 @@ mod tests {
     fn recommended_settings_combines_inputs() {
         let settings =
             RecommendedSettings::for_system(32 * GB, 230 * GB as u64, DiskIoProfile::Nvme);
-        assert_eq!(settings.memory_cache, 32 * GB / 12);
+        // 32GB / 12 = 2.666... GB, rounded to a whole 3 GB.
+        assert_eq!(settings.memory_cache, 3 * GB);
         assert_eq!(settings.disk_cache, 50 * GB);
         assert_eq!(settings.disk_io_profile, DiskIoProfile::Nvme);
         assert_eq!(settings.disk_io_profile_str(), "nvme");

--- a/xearthlayer/src/system/recommendations.rs
+++ b/xearthlayer/src/system/recommendations.rs
@@ -71,7 +71,8 @@ impl RecommendedSettings {
 ///
 /// The memory cache is intentionally a small request absorber, not a working
 /// set holder — the on-disk DDS cache is the working set. The formula is
-/// `RAM / 12`, clamped to `[MIN_MEMORY_CACHE_BYTES, RAM / 4]`.
+/// `RAM / 12`, rounded to the nearest whole GB, then clamped to
+/// `[MIN_MEMORY_CACHE_BYTES, RAM / 4]`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Fixes #218

> **Note on auto-close:** GitHub only acts on a closing keyword when a PR merges into the *default* branch (`main`). This PR targets `develop/0.4.7`, so the keyword above will not fire on merge here — `Fixes #218` is also in the final commit's message, which closes the issue automatically when `develop/0.4.7` reaches `main`.

## Summary

@x16-dev reported that the setup wizard wrote `memory_size = 2.6 GB` into `config.ini` on a 32 GB machine, and the application then refused to start. Workaround was hand-editing it to a whole number.

The wizard turned out not to be the culprit. **`format_size` and `parse_size` are inverse functions living in the same file that do not round-trip:**

- `format_size` emits one decimal place for non-exact multiples — its own doctest asserts `format_size(1536 * 1024 * 1024) == "1.5 GB"`.
- `parse_size` did `num_str.parse::<usize>()`, rejecting any decimal outright.

So the application could not read back a config it had written. `recommended_memory_cache` returns exact bytes (`RAM / 12`); the fraction appeared only at write time. A 32 GB machine reports ~31.2 GiB of RAM, so `RAM / 12` lands on 2.6 GiB — reliably fractional, which is why this reproduced consistently for the reporter and not for everyone.

This affected more than the wizard: `config get cache.memory_size` piped into `config set` could not round-trip its own output either.

## Changes

**`parse_size` accepts decimals** (`config/size.rs`) — the load-bearing fix. Any value `format_size` can emit now reads back, including hand-edited ones.

Three guards are load-bearing and deliberate. Rust's float→int `as` casts *saturate* rather than trapping, so a naive `f64` rewrite would turn `"-1GB"` into `Ok(0)`, `"infGB"` into `Ok(usize::MAX)`, and an overflow into a saturated value where `checked_mul` previously errored — trading one loud failure for three silent ones. The parser rejects non-finite and negative values explicitly and bounds-checks before the cast.

A bare-`B` suffix branch was also needed: `format_size` emits `"512 B"` for sub-KB values, a second instance of the same round-trip failure that the new property test exposed. It is matched *after* GB/MB/KB, since `"2GB"` also ends in `B`.

**`recommended_memory_cache` rounds to the nearest whole GB** (`system/recommendations.rs`) — polish, not the fix. It mirrors `recommended_disk_cache`, which already floors to a round step "so the value is round and predictable in the wizard".

| System RAM | Before | After |
|---|---|---|
| 4 GB | 500 MB (floor) | 500 MB (floor) |
| 8 GB | ~683 MB | 1 GB |
| 16 GB | ~1.3 GB | 1 GB |
| 32 GB | ~2.7 GB | 3 GB |
| 64 GB | ~5.3 GB | 5 GB |
| 128 GB | ~10.7 GB | 11 GB |

*Nearest*, not floor: flooring would drop an 8 GB machine to the 500 MB minimum, whereas rounding lifts it to a clean 1 GB, still well under the `RAM/4` ceiling.

**Documentation corrected** — the wizard's own `"RAM ÷ 12"` hint (the screen the reporter was looking at, which showed both numbers and so was visibly not division once rounded), `docs/configuration.md`, and two doc comments that contradicted the tables directly beside them.

## Related Issues

Fixes #218

## Test Plan

- [x] `make pre-commit` passes — fmt, clippy `-D warnings`, full suite, doctests
- [x] **Round-trip property test** — `parse_size(&format_size(n))` recovers `n` across exact GB, fractional GB, fractional MB and sub-KB values. This is the property whose absence caused the bug
- [x] Three rejection cases covered: negative, non-finite, overflow — each must error rather than saturate
- [x] `parse_size("2TB")` still errors; the long-standing test is unchanged
- [x] `format_size` output unchanged — only the parser widened
- [x] Recommendation table above covered by a table-driven test with hand-computed expected values
- [x] Two pre-existing tests (`memory_cache_floored_at_500mb_for_tiny_systems`, `memory_cache_capped_at_quarter_ram`) pass untouched — the latter is the ceiling coverage
- [x] **End to end on this machine** (91.9 GB RAM): `recommended_memory_cache_display()` returns `"8 GB"` — a whole number, no decimal point

## Checklist

- [x] Code follows the project's SOLID principles and patterns
- [x] Tests added or updated for new/changed behavior
- [x] Documentation updated if applicable
- [x] No new warnings from `cargo clippy`

## Notes for the reviewer

**The overflow guard's `>` is correct and must not be tightened to `>=`.** `usize::MAX as f64` rounds *up* to 2^64, and `format_size(usize::MAX)` emits `"17179869184 GB"` which multiplies back to exactly 2^64 — so `>=` would reject the formatter's own output and break the round-trip property at the top of the range. There is a comment at the site saying so.

**Six sites encoded the old unrounded contract**, including a doctest that runs in `make pre-commit` and an existing test whose *name* stated the formula. All updated; the two tests that should survive were verified untouched.

**Behaviour change worth noting:** `"10B"` now parses where it previously errored. Intentional — it is what `format_size` emits for sub-KB values.

**Out of scope, noted:** `publisher/config.rs` contains a second, independent `parse_size` returning `u64` with divergent semantics. Not reachable from `format_size` and not touched here, but a consolidation candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
