### PR TITLE
fix(prefetch): one region tile-set definition for submit, promote and rescue (#176)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
     - `PrefetchStateObserver` - FUSE-side divergence detector; demotes a `Prefetched`/`NoCoverage` region back to *absent* when FUSE has to generate a tile on demand there, rate-limited to one demotion per region per 120s window
     - Submits jobs to shared job executor daemon via `DdsClient` trait
     - Mode selection: Aggressive (>30 tiles/sec), Opportunistic (10-30), or Disabled
-    - **Four-tier filtering**: Local tracking → Memory cache → Patched region exclusion (via `GeoIndex`) → Disk existence (via `OrthoUnionIndex`)
+    - **Four-tier filtering**: Memory cache → Patched region exclusion (via `GeoIndex`) → Installed package disk (via `OrthoUnionIndex`) → XEL DDS disk cache (the write-only `cached_tiles` local-tracking shadow tier was deleted in #176 after it was confirmed to never be read)
     - **Two-phase region commit**: Regions marked `InProgress` in GeoIndex during prefetch, promoted to `Prefetched` on completion
     - **Stale telemetry safe mode**: pauses tile submissions when telemetry stale >5s; on resume, reads `on_ground` from AircraftState to reset PhaseDetector before next cycle
     - See `docs/dev/adaptive-prefetch-design.md` for design details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
     - `SimState` - Direct sim state detection via X-Plane Web API (paused, on_ground, scenery_loading, replay)
     - `TransitionThrottle` - Grace period + ramp-up after Ground-to-Cruise transition
     - `LoopState` - Per-cycle runner state including `telemetry_paused` flag for stale telemetry safe mode
+    - `PrefetchStateObserver` - FUSE-side divergence detector; demotes a `Prefetched`/`NoCoverage` region back to *absent* when FUSE has to generate a tile on demand there, rate-limited to one demotion per region per 120s window
     - Submits jobs to shared job executor daemon via `DdsClient` trait
     - Mode selection: Aggressive (>30 tiles/sec), Opportunistic (10-30), or Disabled
     - **Four-tier filtering**: Local tracking → Memory cache → Patched region exclusion (via `GeoIndex`) → Disk existence (via `OrthoUnionIndex`)

--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -673,7 +673,7 @@ For each BoundaryCrossing:
        knows nothing about yields no tiles and is marked NoCoverage
 
     5. Apply four-tier filter:
-       Local tracking → Memory cache → Patch exclusion → Disk existence
+       Memory cache → Patch exclusion → Installed package disk → XEL DDS disk cache
 
     6. Order tiles:
        Primary: urgency rank (depth 0 before depth 1 before depth 2)

--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -248,7 +248,18 @@ Each DSF region in the XEL Window has one of four states:
 This follows a **two-phase commit** pattern:
 1. **Reserve**: Region marked `InProgress` when tiles are submitted (prevents duplicate bulk submissions)
 2. **Confirm**: Region marked `Prefetched` when tiles are confirmed in cache
-3. **Timeout**: If `InProgress` exceeds `stale_region_timeout`, reverts to *absent* for re-evaluation
+3. **Timeout**: If `InProgress` exceeds `stale_region_timeout`, `evaluate_stale_regions`
+   consults `BoundaryStrategy::region_disk_state` — the same completeness predicate the
+   fast path uses — and picks one of four outcomes:
+   - Disk shows every tile present → promote straight to `Prefetched` (the rescue path;
+     see [Region Tile-Set SSOT](#region-tile-set-ssot) below)
+   - Disk shows tiles missing, under `MAX_REGION_ATTEMPTS` (3) → reverts to *absent* for
+     re-evaluation next cycle, incrementing the region's strike count
+   - Disk shows tiles missing, at `MAX_REGION_ATTEMPTS` → retired to `NoCoverage`
+     **permanently for the session** — this is the event flight-test criterion 4 keys on
+   - No authoritative source to consult (no `DdsDiskCacheChecker` and/or no
+     `SceneryIndex`) → left `InProgress` untouched; this does **not** count as a retry,
+     since "cannot tell" must not be treated the same as "checked and it is absent"
 
 A region can reach step 1 without submitting anything. When the filter
 pipeline removes a region's *entire* planned tile set as already cached, there
@@ -272,6 +283,48 @@ whether a region is complete. Earlier code reconstructed the tile set from a
 45nm radius query per path, which returns a circle overlapping neighbouring
 regions rather than the region itself — the source of several promotion bugs
 fixed under #176.
+
+`BoundaryStrategy::region_disk_state` (`xearthlayer/src/prefetch/adaptive/boundary_strategy.rs`)
+is the single completeness predicate built on top of that tile set, consumed
+by both the fast path (`promote_completed_regions`) and the rescue path
+(`evaluate_stale_regions`). It returns one of four states — `Complete`,
+`Incomplete`, `NoTiles`, or `Unknown` — rather than a `bool`, because the
+answer feeds a decision whose terminal outcome is permanent exclusion
+(`NoCoverage`): "we cannot tell" (`Unknown` — no `DdsDiskCacheChecker` and/or
+no `SceneryIndex` wired) must stay distinguishable from "we checked and it is
+absent" (`Incomplete`/`NoTiles`), or a region could be retired to `NoCoverage`
+on a cycle where it was never actually checked.
+
+**Coverage is a disjunction.** A tile counts as covered if it is present in
+the XEL DDS disk cache (`DdsDiskCacheChecker`) **or** ships inside an
+installed scenery package (`OrthoUnionIndex::dds_tile_exists`) — prefetch
+deliberately never downloads tiles the disk filter (stage 3 of the four-tier
+filter) already excluded as package-shipped, so promotion must recognise
+that same evidence or a region covered entirely by package imagery could
+never be confirmed and would ratchet to `NoCoverage` over land. The two
+lookups use different coordinate systems: the XEL DDS cache is keyed by
+**tile** coordinates (`tile.row, tile.col, tile.zoom`), while
+`OrthoUnionIndex::dds_tile_exists` is keyed by **chunk** coordinates
+(`tile.chunk_origin()`) — mixing them up silently returns "not covered" for
+every tile (the #172 keying bug).
+
+**Strike counts survive the retry branch, not the promote branch.** A
+region's `region_attempts` strike count is cleared on promotion (both the
+fast path and the rescue path) but deliberately left untouched on the retry
+branch of `evaluate_stale_regions`. This looks backwards until you notice
+what the retry branch does: it *removes* the region's `PrefetchedRegion`
+entry from the `GeoIndex` so the region is eligible for re-prefetch — and
+that removal is exactly what makes `region_attempts` (a separate
+`HashMap<DsfRegion, u8>` on the coordinator, not stored in the `GeoIndex`)
+the only thing that still remembers the region failed last time. Clearing it
+on retry, by naive symmetry with the promote branch, would make
+`MAX_REGION_ATTEMPTS` unreachable: every retry would restart the count at
+zero and a region that never succeeds would retry forever instead of
+eventually being retired to `NoCoverage`. Promotion clears it for the
+opposite reason — a promoted region's failure history belongs to the episode
+that failed, not to the region, so a region that recovers and is later
+demoted by `PrefetchStateObserver` should not be retired to `NoCoverage`
+after a single fresh failure.
 
 ### Demotion: Closing the Loop on Wrong Claims
 
@@ -315,8 +368,17 @@ wire it up and these become totals since the last reset:
 
 ```
 INFO Prefetch sample uptime_s=... regions_in_progress=... regions_prefetched=...
-     regions_nocoverage=... state_diverged=... regions_demoted=...
+     regions_nocoverage=... promotions_normal=... promotions_rescue=...
+     state_diverged=... regions_demoted=...
 ```
+
+`promotions_normal` counts fast-path promotions (`promote_completed_regions`,
+per-cycle region maintenance); `promotions_rescue` counts stale-region
+rescue promotions (`evaluate_stale_regions`, the `RegionDiskState::Complete`
+arm above). A healthy flight should show `promotions_normal` dominating; a
+high `promotions_rescue` ratio means the fast path is stalling and the
+rescue path is carrying the work — see [Region Tile-Set
+SSOT](#region-tile-set-ssot).
 
 `state_diverged` and `regions_demoted` are expected to stay at (or near) zero
 on a healthy flight; a climbing `state_diverged` with a flat `regions_demoted`
@@ -1009,8 +1071,11 @@ SimState (X-Plane Web API)
 
 If some tiles in a submitted region fail:
 - Region stays `InProgress`
-- After `stale_region_timeout` (120s), reverts to *absent*
-- Next evaluation cycle: target diff finds the region, re-submits
+- After `stale_region_timeout` (120s), `region_disk_state` reports `Incomplete` — see
+  [Region States](#region-states-geoindex-prefetchedregion-layer) above — so the region
+  reverts to *absent* for retry, up to `MAX_REGION_ATTEMPTS` (3) times before being
+  retired to `NoCoverage`
+- Next evaluation cycle (while retries remain): target diff finds the region, re-submits
 - Four-tier filter handles individual tile dedup (only failed tiles re-submitted)
 
 ---

--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -416,7 +416,6 @@ Regions previously retained but now outside → evicted from GeoIndex
 
 When a region leaves the retained area, the coordinator also evicts:
 - Its `PrefetchedRegion` entry (making it eligible for re-prefetch if the aircraft returns)
-- Any `cached_tiles` entries for tiles in that region (allowing fresh memory cache queries)
 
 `InProgress` regions are never evicted — they represent actively running prefetch jobs.
 
@@ -770,15 +769,21 @@ If backpressure reduces batch size, the most urgent axis is served first.
 
 ### Interface
 
+> **Stale**, like the algorithm block above: `BoundaryStrategy` does not
+> implement `AdaptivePrefetchStrategy` — it exposes static functions
+> (`promote_completed_regions`, `evict_non_retained`, `region_disk_state`)
+> instead. The trait itself still exists (`xearthlayer/src/prefetch/adaptive/strategy.rs`);
+> its current `calculate_prefetch` signature, for reference:
+
 ```rust
-impl AdaptivePrefetchStrategy for BoundaryStrategy {
+pub trait AdaptivePrefetchStrategy: Send + Sync {
     fn calculate_prefetch(
         &self,
         position: (f64, f64),
-        predictions: &[BoundaryCrossing],
-        xel_window: &XelWindow,
-        cached_tiles: &HashSet<TileCoord>,
-    ) -> Option<PrefetchPlan>;
+        track: f64,
+        calibration: &PerformanceCalibration,
+        already_cached: &HashSet<TileCoord>,
+    ) -> PrefetchPlan;
 }
 ```
 

--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -250,6 +250,18 @@ This follows a **two-phase commit** pattern:
 2. **Confirm**: Region marked `Prefetched` when tiles are confirmed in cache
 3. **Timeout**: If `InProgress` exceeds `stale_region_timeout`, reverts to *absent* for re-evaluation
 
+A region can reach step 1 without submitting anything. When the filter
+pipeline removes a region's *entire* planned tile set as already cached, there
+is no submission for the mark-after-submit rule to hang off — and if that is
+true of every region in the plan, the plan is empty and the submit path is
+skipped outright. Such regions are marked `InProgress` at the end of
+filtering, so step 2's disk-verified check confirms them on the maintenance
+pass. Without this they stayed *absent*, re-entered the target diff every 2s
+cycle, and could never return to `Prefetched` — which under-reported
+`regions_prefetched` in the 60s sample. Patch-owned regions are excluded:
+their tiles filter out in full too, but prefetch never places them on the DDS
+disk, so `InProgress` would be a claim nothing could confirm.
+
 ### Region Tile-Set SSOT
 
 `SceneryIndex::tiles_in_region(region)` is the single definition of "which DDS
@@ -281,6 +293,13 @@ NoCoverage ──┘        (region re-enters the prefetch cycle)
 still running — and cache hits are exempt, since serving from cache is the
 system working, not a divergence.
 
+Re-entering the prefetch cycle only *repairs* two of the three causes. The
+scenery index is immutable for the life of the process, so where the cause is
+an index gap the next cycle re-derives the same empty tile set and re-marks
+the region `NoCoverage`. The loop is bounded and safe, but for that cause the
+observer flags the gap and nothing more — do not read a repeating
+`state_diverged` in one region as a repair in progress.
+
 Every divergence is counted and reported via
 `MetricsClient::prefetch_state_diverged()`, but the region is only cleared
 (and `MetricsClient::prefetch_region_demoted()` fired) at most once per region
@@ -289,8 +308,10 @@ unbounded demote → re-prefetch → evict loop would churn on a long flight; th
 rate limit exists so the diagnostic doesn't become the noise it's meant to
 surface.
 
-The daemon aggregates both counters as cumulative totals since process start
-and logs them on the same 60s cadence as the memory sample:
+The daemon aggregates both counters and logs them on the same 60s cadence as
+the memory sample. They are cumulative totals since process start, because
+`AggregatedState::reset()` — which does zero them — has no production caller;
+wire it up and these become totals since the last reset:
 
 ```
 INFO Prefetch sample uptime_s=... regions_in_progress=... regions_prefetched=...
@@ -605,7 +626,15 @@ pub enum BoundaryAxis {
 }
 ```
 
-### Algorithm
+### Algorithm (historical — superseded)
+
+> **This block describes the boundary-monitor design and no longer matches the
+> code.** `BoundaryCrossing` and its monitors were deleted in PR #102, which
+> replaced them with the sliding `PrefetchBox` described above; step 4a's
+> SceneTracker history is a write-only field; and step 4c's geometric fallback
+> was removed in #176 — see *Region Tile-Set SSOT*, which is now the only
+> definition of a region's tile set. It is kept for the reasoning about
+> asymmetric load depth in step 1, which the measurements still support.
 
 ```
 Input:  Vec<BoundaryCrossing> from SceneryWindow (sorted by urgency)
@@ -640,9 +669,8 @@ For each BoundaryCrossing:
        Absent → include
 
     4. For each remaining DSF region, get DDS tiles:
-       a. SceneTracker history (most accurate — matches X-Plane's zoom/coverage)
-       b. SceneryIndex query (for unseen regions)
-       c. Fallback 4×4 grid at zoom 14 (last resort)
+       SceneryIndex::tiles_in_region — the only source; a region the index
+       knows nothing about yields no tiles and is marked NoCoverage
 
     5. Apply four-tier filter:
        Local tracking → Memory cache → Patch exclusion → Disk existence

--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -862,18 +862,17 @@ The existing `TransitionThrottle` ramps prefetch from 25% to 100% over 30 second
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                        Prefetch Filter Chain                            │
 │                                                                         │
-│  1. LOCAL TRACKING (HashSet) - O(1)                                     │
-│     Skip tiles submitted this session                                   │
+│  1. MEMORY CACHE (async) - moka LRU query                              │
+│     Skip tiles already generated (DaemonMemoryCache)                    │
 │                                                                         │
-│  2. MEMORY CACHE (async) - moka LRU query                              │
-│     Skip tiles already generated                                        │
-│                                                                         │
-│  3. PATCHED REGION EXCLUSION (GeoIndex PatchCoverage)                   │
+│  2. PATCHED REGION EXCLUSION (GeoIndex PatchCoverage)                   │
 │     Skip tiles in DSF regions owned by scenery patches                  │
 │                                                                         │
-│  4. DISK EXISTENCE (filesystem probe) - slow                            │
-│     Skip tiles from installed packages and XEL cache                    │
-│     Checks: ZL, BI, GO2, GO filename patterns                          │
+│  3. INSTALLED PACKAGE DISK (OrthoUnionIndex) - filesystem probe         │
+│     Skip tiles that already ship as real .dds files in a package        │
+│                                                                         │
+│  4. XEL DDS DISK CACHE (DdsDiskCacheChecker) - filesystem probe         │
+│     Skip tiles XEL has already downloaded and cached itself             │
 │                                                                         │
 │  Only tiles passing ALL four filters are submitted for download         │
 └─────────────────────────────────────────────────────────────────────────┘
@@ -1072,9 +1071,11 @@ SimState (X-Plane Web API)
 If some tiles in a submitted region fail:
 - Region stays `InProgress`
 - After `stale_region_timeout` (120s), `region_disk_state` reports `Incomplete` — see
-  [Region States](#region-states-geoindex-prefetchedregion-layer) above — so the region
-  reverts to *absent* for retry, up to `MAX_REGION_ATTEMPTS` (3) times before being
-  retired to `NoCoverage`
+  [Region States](#region-states-geoindex-prefetchedregion-layer) above — and the
+  region's strike count increments. While the count stays under
+  `MAX_REGION_ATTEMPTS` (3) the region reverts to *absent* for retry; the strike that
+  reaches 3 retires it to `NoCoverage` instead of granting another retry — so a region
+  gets at most 2 revert-to-absent retries before retirement, not 3
 - Next evaluation cycle (while retries remain): target diff finds the region, re-submits
 - Four-tier filter handles individual tile dedup (only failed tiles re-submitted)
 

--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -250,6 +250,59 @@ This follows a **two-phase commit** pattern:
 2. **Confirm**: Region marked `Prefetched` when tiles are confirmed in cache
 3. **Timeout**: If `InProgress` exceeds `stale_region_timeout`, reverts to *absent* for re-evaluation
 
+### Region Tile-Set SSOT
+
+`SceneryIndex::tiles_in_region(region)` is the single definition of "which DDS
+tiles belong to this DSF region": a tile belongs to the region containing its
+geographic centre (the `LOAD_CENTER` of its `.ter` file). The submit, promote,
+and rescue paths all consult this one method, so they cannot disagree about
+whether a region is complete. Earlier code reconstructed the tile set from a
+45nm radius query per path, which returns a circle overlapping neighbouring
+regions rather than the region itself — the source of several promotion bugs
+fixed under #176.
+
+### Demotion: Closing the Loop on Wrong Claims
+
+`Prefetched` and `NoCoverage` are claims, not guarantees. If FUSE has to
+*generate* a tile on demand inside a region carrying either state, the claim
+was wrong — whether from a scenery-index gap, a premature promotion, or
+eviction of the tile after promotion. `PrefetchStateObserver`
+(`xearthlayer/src/prefetch/state_observer.rs`) sits on the one FUSE code path
+every implementation shares (`DdsRequestor::on_dds_response`, defaulted to a
+no-op, overridden by `Fuse3OrthoUnionFS`) and reacts to exactly this:
+
+```
+Prefetched ──┐
+             ├──▶ on-demand FUSE generation observed ──▶ demoted to *absent*
+NoCoverage ──┘        (region re-enters the prefetch cycle)
+```
+
+`InProgress` regions are exempt — they are expected to miss while prefetch is
+still running — and cache hits are exempt, since serving from cache is the
+system working, not a divergence.
+
+Every divergence is counted and reported via
+`MetricsClient::prefetch_state_diverged()`, but the region is only cleared
+(and `MetricsClient::prefetch_region_demoted()` fired) at most once per region
+per 120s window. Eviction inside the retained window can recur, so an
+unbounded demote → re-prefetch → evict loop would churn on a long flight; the
+rate limit exists so the diagnostic doesn't become the noise it's meant to
+surface.
+
+The daemon aggregates both counters as cumulative totals since process start
+and logs them on the same 60s cadence as the memory sample:
+
+```
+INFO Prefetch sample uptime_s=... regions_in_progress=... regions_prefetched=...
+     regions_nocoverage=... state_diverged=... regions_demoted=...
+```
+
+`state_diverged` and `regions_demoted` are expected to stay at (or near) zero
+on a healthy flight; a climbing `state_diverged` with a flat `regions_demoted`
+means the rate limit is suppressing repeat divergences in the same region —
+worth investigating even though no region is currently stuck in a wrong
+state.
+
 ### Retention Inference
 
 The X-Plane Window is inferred, not observed directly. We use a buffer zone to handle uncertainty:

--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -369,8 +369,15 @@ wire it up and these become totals since the last reset:
 ```
 INFO Prefetch sample uptime_s=... regions_in_progress=... regions_prefetched=...
      regions_nocoverage=... promotions_normal=... promotions_rescue=...
-     state_diverged=... regions_demoted=...
+     state_diverged=... regions_demoted=... fuse_generations=...
 ```
+
+`fuse_generations` mirrors `fuse_jobs_submitted` (aggregated from
+`MetricEvent::JobSubmitted { is_fuse: true }`) — the only default-level
+source for criterion 5 ("on-demand FUSE generations fall during cruise").
+Per-tile FUSE request logging is `debug!`-only (#209), so without this field
+that criterion is unreadable at default log level. It is cumulative since
+process start, the same convention as the other counters on this line.
 
 `promotions_normal` counts fast-path promotions (`promote_completed_regions`,
 per-cycle region maintenance); `promotions_rescue` counts stale-region

--- a/docs/dev/geo-index-design.md
+++ b/docs/dev/geo-index-design.md
@@ -32,7 +32,12 @@ Package `.ter` files reference `.dds` textures that FUSE won't generate in patch
 
 - Persistent storage (in-memory only; rebuild on startup)
 - Sub-region granularity (1x1 DSF regions are the atomic unit)
-- Runtime modification of layers during flights (populated at startup)
+- Runtime modification of the `PatchCoverage` layer during flights (populated
+  once at startup and never rewritten). This does **not** hold for the
+  `PrefetchedRegion` layer — it has two concurrent in-flight writers, the
+  prefetch coordinator and the FUSE-side `PrefetchStateObserver`, and is
+  rewritten continuously for the life of a flight. See
+  `docs/dev/adaptive-prefetch-design.md` for its state machine.
 
 ---
 
@@ -70,7 +75,7 @@ xearthlayer/src/geo_index/
 ├── mod.rs       # Module definition, re-exports
 ├── region.rs    # DsfRegion type (1x1 coordinate)
 ├── index.rs     # GeoIndex implementation
-└── layers.rs    # GeoLayer trait, PatchCoverage
+└── layers.rs    # GeoLayer trait, PatchCoverage, RetainedRegion, PrefetchedRegion
 ```
 
 ### Data Model
@@ -84,10 +89,23 @@ GeoIndex
 │   ├── DsfRegion(+45, +012) → PatchCoverage { patch_name: "LIPX_Mesh" }
 │   └── DsfRegion(+33, -119) → PatchCoverage { patch_name: "KLAX_Ortho" }
 │
+├── Layer: RetainedRegion
+│   └── DsfRegion(+50, +007) → RetainedRegion   (unit struct — presence is the payload)
+│
+├── Layer: PrefetchedRegion
+│   ├── DsfRegion(+50, +008) → PrefetchedRegion { state: InProgress, since: ... }
+│   └── DsfRegion(+50, +009) → PrefetchedRegion { state: Prefetched, since: ... }
+│
 └── (future layers added here without modifying existing code)
 ```
 
-Each layer type (`PatchCoverage`, etc.) is an independent `DashMap<DsfRegion, T>` accessed via Rust's `TypeId` for type-safe heterogeneous storage.
+Each layer type (`PatchCoverage`, `RetainedRegion`, `PrefetchedRegion`, etc.)
+is an independent `DashMap<DsfRegion, T>` accessed via Rust's `TypeId` for
+type-safe heterogeneous storage. `PatchCoverage` and `RetainedRegion` are
+populated by a single writer (startup population, `SceneryWindow` per cycle
+respectively); `PrefetchedRegion` is written concurrently by the prefetch
+coordinator and the FUSE-side `PrefetchStateObserver` — see
+`docs/dev/adaptive-prefetch-design.md` for its state machine.
 
 ---
 
@@ -181,6 +199,36 @@ Indicates a DSF region is owned by a scenery patch:
 ```rust
 pub struct PatchCoverage {
     pub patch_name: String,  // e.g., "LIPX_Mesh"
+}
+```
+
+#### `RetainedRegion`
+
+Unit struct marking a DSF region as retained by X-Plane's scenery window
+(inferred from `SceneTracker` observations). Inserted/removed by
+`SceneryWindow` each coordinator cycle; presence in the layer is the entire
+payload:
+
+```rust
+pub struct RetainedRegion;
+```
+
+#### `PrefetchedRegion`
+
+Tracks prefetch state per DSF region: `InProgress`, `Prefetched`, or
+`NoCoverage`, plus the `Instant` the state was set (used for staleness
+checks). Regions absent from the layer are "never evaluated" — eligible for
+prefetch. Written by two concurrent sources: the prefetch coordinator
+(`AdaptivePrefetchCoordinator`, via `BoundaryStrategy`) and the FUSE-side
+`PrefetchStateObserver`, which demotes a `Prefetched`/`NoCoverage` region
+when FUSE has to generate a tile on demand there. See
+`docs/dev/adaptive-prefetch-design.md` for the full state machine
+(two-phase commit, stale-region rescue, demotion).
+
+```rust
+pub struct PrefetchedRegion {
+    state: RegionState,   // InProgress | Prefetched | NoCoverage
+    since: Instant,
 }
 ```
 
@@ -322,7 +370,8 @@ Bulk population via `populate()` provides atomicity: readers never see a partial
 | `xearthlayer/src/geo_index/mod.rs` | Module definition, re-exports |
 | `xearthlayer/src/geo_index/region.rs` | `DsfRegion` type |
 | `xearthlayer/src/geo_index/index.rs` | `GeoIndex` implementation |
-| `xearthlayer/src/geo_index/layers.rs` | `GeoLayer` trait, `PatchCoverage` |
+| `xearthlayer/src/geo_index/layers.rs` | `GeoLayer` trait, `PatchCoverage`, `RetainedRegion`, `PrefetchedRegion` |
+| `xearthlayer/src/prefetch/state_observer.rs` | `PrefetchStateObserver` — FUSE-side `PrefetchedRegion` writer (demotion) |
 | `xearthlayer/src/ortho_union/index.rs` | `resolve_lazy_filtered()` |
 | `xearthlayer/src/fuse/fuse3/ortho_union_fs.rs` | FUSE composition (`is_geo_filtered`, `resolve_lazy_geo`) |
 | `xearthlayer/src/manager/mounts.rs` | GeoIndex creation and population |

--- a/docs/dev/geo-index-design.md
+++ b/docs/dev/geo-index-design.md
@@ -33,11 +33,13 @@ Package `.ter` files reference `.dds` textures that FUSE won't generate in patch
 - Persistent storage (in-memory only; rebuild on startup)
 - Sub-region granularity (1x1 DSF regions are the atomic unit)
 - Runtime modification of the `PatchCoverage` layer during flights (populated
-  once at startup and never rewritten). This does **not** hold for the
-  `PrefetchedRegion` layer — it has two concurrent in-flight writers, the
-  prefetch coordinator and the FUSE-side `PrefetchStateObserver`, and is
-  rewritten continuously for the life of a flight. See
-  `docs/dev/adaptive-prefetch-design.md` for its state machine.
+  once at startup and never rewritten). This does **not** hold for
+  `PrefetchedRegion` or `RetainedRegion` — both are rewritten continuously for
+  the life of a flight: `RetainedRegion` by `SceneryWindow` every coordinator
+  cycle, and `PrefetchedRegion` by two concurrent in-flight writers, the
+  prefetch coordinator and the FUSE-side `PrefetchStateObserver`. See
+  `docs/dev/adaptive-prefetch-design.md` for the `PrefetchedRegion` state
+  machine.
 
 ---
 

--- a/docs/dev/memory-telemetry.md
+++ b/docs/dev/memory-telemetry.md
@@ -342,9 +342,12 @@ daemon does not emit a burst of catch-up samples.
 
 If the probe returns `None`, **or returns `Some` with `rss_bytes == 0`**, the
 daemon logs one warning (`"Memory probe unavailable; memory samples
-disabled"`), latches `memory_probe_failed`, and emits nothing further for that
-tick. The warning is not repeated, but the probe is retried every subsequent
-tick — a later tick returning a valid reading resumes normal sampling without
+disabled"`), latches `memory_probe_failed`, and emits no memory sample for
+that tick — the `Prefetch sample` line sharing the same 60s interval still
+fires unconditionally (`log_prefetch_sample` has no dependency on the memory
+probe); see `docs/dev/adaptive-prefetch-design.md` for its field format. The
+warning is not repeated, but the probe is retried every subsequent tick — a
+later tick returning a valid reading resumes normal sampling without
 re-latching anything.
 
 Because `MetricsSystem::new` is constructed unconditionally in

--- a/xearthlayer-cli/src/commands/scenery_index.rs
+++ b/xearthlayer-cli/src/commands/scenery_index.rs
@@ -85,7 +85,13 @@ fn run_update() -> Result<(), CliError> {
         io::stdout().flush().ok();
 
         match index.build_from_package(path) {
-            Ok(count) => println!("{} tiles", count),
+            Ok(stats) if stats.failed > 0 => {
+                println!(
+                    "{} tiles ({} .ter files failed to parse)",
+                    stats.parsed, stats.failed
+                )
+            }
+            Ok(stats) => println!("{} tiles", stats.parsed),
             Err(e) => println!("error: {}", e),
         }
     }
@@ -153,6 +159,21 @@ fn run_status() -> Result<(), CliError> {
             println!("  Land tiles: {}", land_tiles);
             println!("  Sea tiles: {}", status.sea_tiles);
             println!("  File size: {}", format_size(file_size));
+
+            let expected: usize = status.packages.iter().map(|p| p.terrain_file_count).sum();
+            if expected > 0 {
+                let pct = (status.total_tiles as f64 / expected as f64) * 100.0;
+                println!(
+                    "  Indexed:   {} of {} .ter files ({:.1}%)",
+                    status.total_tiles, expected, pct
+                );
+                if status.total_tiles < expected {
+                    println!(
+                        "  WARNING:   {} .ter files did not produce a tile",
+                        expected - status.total_tiles
+                    );
+                }
+            }
         }
         Err(e) => {
             println!("  Status: Invalid");

--- a/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
+++ b/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
@@ -1946,4 +1946,93 @@ mod tests {
             "real passthrough files should have default flags (no DIRECT_IO)"
         );
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // PrefetchStateObserver wiring (#176)
+    //
+    // The observer's own policy is unit-tested in `prefetch::state_observer`.
+    // What those tests cannot see is whether FUSE ever *calls* it: every one
+    // of them invokes `observe()` directly. These two exercise the real
+    // chain — `DdsRequestor::request_dds_impl` → `do_request` →
+    // `on_dds_response` → `observer.observe` → `GeoIndex` — over a real
+    // `Fuse3OrthoUnionFS` and a real `GeoIndex`, so cutting any link in it
+    // fails a test instead of silently disabling the feature.
+    //
+    // The final link (`manager::mounts` attaching the observer at mount
+    // construction) is not covered: reaching it needs a whole
+    // `XEarthLayerService` and a live FUSE mount.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Drive one full FUSE DDS request against a `Prefetched` region and
+    /// return whether that region still carries prefetch state afterwards.
+    ///
+    /// `cache_hit` is what the stand-in executor reports back, so the caller
+    /// controls the single input the observer's policy turns on.
+    async fn run_dds_request_over_prefetched_region(cache_hit: bool) -> bool {
+        use crate::geo_index::{DsfRegion, PrefetchedRegion};
+
+        let temp = TempDir::new().unwrap();
+        let index = OrthoUnionIndexBuilder::new()
+            .add_package(create_test_package(&temp, "na"))
+            .build()
+            .unwrap();
+
+        // A region prefetch claims is fully cached.
+        let tile = crate::coord::to_tile_coords(33.5, -118.5, 12).unwrap();
+        let (lat, lon) = tile.to_lat_lon();
+        let region = DsfRegion::from_lat_lon(lat, lon);
+        let geo_index = Arc::new(GeoIndex::new());
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
+
+        let (client, mut rx) = MockDdsClient::new();
+        let fs = Fuse3OrthoUnionFS::new(index, client as Arc<dyn DdsClient>, 1024)
+            .with_state_observer(Arc::new(PrefetchStateObserver::new(Arc::clone(&geo_index))));
+
+        // Stand in for the executor daemon: answer the one request FUSE makes.
+        let responder = tokio::spawn(async move {
+            let request = rx.recv().await.expect("FUSE must submit a DDS request");
+            request
+                .response_tx
+                .expect("FUSE requests carry a response channel")
+                .send(DdsResponse::new(
+                    vec![0u8; 16],
+                    cache_hit,
+                    Duration::from_millis(1),
+                    true,
+                ))
+                .ok();
+        });
+
+        let coords = crate::fuse::DdsFilename {
+            row: tile.row * 16,
+            col: tile.col * 16,
+            zoom: tile.zoom + 4,
+            map_type: "BI".to_string(),
+        };
+        let _ = fs.request_dds_impl(&coords).await;
+        responder.await.unwrap();
+
+        geo_index.get::<PrefetchedRegion>(&region).is_some()
+    }
+
+    #[tokio::test]
+    async fn test_fuse_on_demand_generation_demotes_prefetched_region() {
+        assert!(
+            !run_dds_request_over_prefetched_region(false).await,
+            "a FUSE on-demand generation inside a Prefetched region must reach \
+             the observer and demote it — if this passes only because the \
+             observer was never called, the whole feature is inert"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fuse_cache_hit_leaves_prefetched_region_alone() {
+        // Guards the `cache_hit` argument specifically: a hook that called
+        // the observer but hardcoded `false` would pass the test above.
+        assert!(
+            run_dds_request_over_prefetched_region(true).await,
+            "serving a prefetched tile from cache is the system working — \
+             the region must keep its state"
+        );
+    }
 }

--- a/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
+++ b/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
@@ -39,12 +39,13 @@
 use super::inode::InodeManager;
 use super::shared::{DdsRequestor, FileAttrBuilder, VirtualDdsConfig, TTL};
 use super::types::{Fuse3Error, Fuse3Result};
+use crate::coord::TileCoord;
 use crate::executor::{DdsClient, StorageConcurrencyLimiter};
 use crate::fuse::coalesce::RequestCoalescer;
 use crate::fuse::{get_default_placeholder, parse_dds_filename};
 use crate::geo_index::GeoIndex;
 use crate::ortho_union::OrthoUnionIndex;
-use crate::prefetch::{DdsAccessEvent, DsfTileCoord, TileRequestCallback};
+use crate::prefetch::{DdsAccessEvent, DsfTileCoord, PrefetchStateObserver, TileRequestCallback};
 use crate::scene_tracker::{DdsTileCoord, FuseAccessEvent};
 use bytes::Bytes;
 use fuse3::raw::prelude::*;
@@ -108,6 +109,8 @@ pub struct Fuse3OrthoUnionFS {
     /// When set, FUSE filters lazy resolution to only serve patch sources in
     /// those regions, hiding package files that would cause X-Plane conflicts.
     geo_index: Option<Arc<GeoIndex>>,
+    /// Observer for prefetch state divergence (#176).
+    state_observer: Option<Arc<PrefetchStateObserver>>,
     /// Client for DDS generation requests (new daemon architecture)
     dds_client: Arc<dyn DdsClient>,
     /// Inode manager for path mappings
@@ -186,6 +189,7 @@ impl Fuse3OrthoUnionFS {
         Self {
             index: Arc::new(index),
             geo_index: None,
+            state_observer: None,
             dds_client,
             inode_manager: InodeManager::new(virtual_root),
             virtual_dds_config: VirtualDdsConfig::new(expected_dds_size as u64),
@@ -217,6 +221,7 @@ impl Fuse3OrthoUnionFS {
         Self {
             index: Arc::new(index),
             geo_index: None,
+            state_observer: None,
             dds_client,
             inode_manager: InodeManager::new(virtual_root),
             virtual_dds_config: VirtualDdsConfig::new(expected_dds_size as u64),
@@ -318,6 +323,15 @@ impl Fuse3OrthoUnionFS {
     /// only from patch sources, hiding package files that could conflict.
     pub fn with_geo_index(mut self, geo_index: Arc<GeoIndex>) -> Self {
         self.geo_index = Some(geo_index);
+        self
+    }
+
+    /// Set the prefetch state observer.
+    ///
+    /// When set, an on-demand generation in a region prefetch marked
+    /// `Prefetched` or `NoCoverage` demotes that region.
+    pub fn with_state_observer(mut self, observer: Arc<PrefetchStateObserver>) -> Self {
+        self.state_observer = Some(observer);
         self
     }
 
@@ -498,6 +512,12 @@ impl DdsRequestor for Fuse3OrthoUnionFS {
 
     fn metrics_client(&self) -> Option<&crate::metrics::MetricsClient> {
         self.metrics_client.as_ref()
+    }
+
+    fn on_dds_response(&self, tile: TileCoord, cache_hit: bool) {
+        if let Some(ref observer) = self.state_observer {
+            observer.observe(tile, cache_hit);
+        }
     }
 }
 

--- a/xearthlayer/src/fuse/fuse3/shared.rs
+++ b/xearthlayer/src/fuse/fuse3/shared.rs
@@ -292,6 +292,13 @@ pub trait DdsRequestor: FileAttrBuilder {
     /// Get the optional tile request callback.
     fn tile_request_callback(&self) -> Option<&crate::prefetch::TileRequestCallback>;
 
+    /// Hook invoked after a DDS response is received.
+    ///
+    /// Default is a no-op; `Fuse3OrthoUnionFS` overrides it to detect
+    /// prefetch state divergence (#176). Kept on the trait so the check sits
+    /// at the one place every FUSE implementation receives a response.
+    fn on_dds_response(&self, _tile: TileCoord, _cache_hit: bool) {}
+
     /// Get the optional request coalescer for deduplicating concurrent requests.
     ///
     /// When this returns `Some`, requests for the same tile are coalesced at the
@@ -455,6 +462,7 @@ pub trait DdsRequestor: FileAttrBuilder {
                     context = context_label,
                     "DDS request completed"
                 );
+                self.on_dds_response(tile, response.cache_hit);
                 response.data
             }
             Ok(Err(_)) => {

--- a/xearthlayer/src/geo_index/layers.rs
+++ b/xearthlayer/src/geo_index/layers.rs
@@ -218,9 +218,14 @@ mod tests {
     #[test]
     fn test_prefetched_region_staleness_timeout() {
         use std::time::Duration;
-        let state = PrefetchedRegion::in_progress();
         // Fresh InProgress should not be stale
-        assert!(!state.is_stale(Duration::from_secs(120)));
+        assert!(!PrefetchedRegion::in_progress().is_stale(Duration::from_secs(120)));
+        // ...but an elapsed timeout makes it stale. A zero timeout is
+        // immediately elapsed.
+        assert!(PrefetchedRegion::in_progress().is_stale(Duration::ZERO));
+        // Terminal states never expire, however long the wait.
+        assert!(!PrefetchedRegion::prefetched().is_stale(Duration::ZERO));
+        assert!(!PrefetchedRegion::no_coverage().is_stale(Duration::ZERO));
     }
 
     #[test]

--- a/xearthlayer/src/manager/mounts.rs
+++ b/xearthlayer/src/manager/mounts.rs
@@ -27,7 +27,7 @@ use crate::package::{
 use crate::panic as panic_handler;
 use crate::patches::{extract_dsf_regions, PatchDiscovery};
 use crate::prefetch::tile_based::DdsAccessEvent;
-use crate::prefetch::TileRequestCallback;
+use crate::prefetch::{PrefetchStateObserver, TileRequestCallback};
 use crate::scene_tracker::{DefaultSceneTracker, FuseAccessEvent};
 use crate::service::{ServiceConfig, ServiceError, XEarthLayerService};
 
@@ -467,18 +467,30 @@ impl MountManager {
         // Store the index for tile-based prefetcher to use later
         let index_for_prefetch = Arc::new(index);
 
+        // Build the prefetch state observer (#176): detects when FUSE has to
+        // generate a tile on demand in a region prefetch already marked
+        // Prefetched or NoCoverage, and demotes that region so it is
+        // re-prefetched instead of leaving a stale, contradicted claim.
+        let metrics_client = service.metrics_client();
+        let mut state_observer = PrefetchStateObserver::new(Arc::clone(&geo_index));
+        if let Some(ref metrics) = metrics_client {
+            state_observer = state_observer.with_metrics_client(metrics.clone());
+        }
+        let state_observer = Arc::new(state_observer);
+
         // Create and mount the consolidated ortho union filesystem with DDS access channel
         // Wire Scene Tracker channel for empirical scenery tracking
         // Wire FUSE kernel limits for concurrent background request control
         let mut ortho_union_fs =
             Fuse3OrthoUnionFS::new((*index_for_prefetch).clone(), dds_client, expected_dds_size)
                 .with_geo_index(Arc::clone(&geo_index))
+                .with_state_observer(state_observer)
                 .with_dds_access_channel(dds_access_tx)
                 .with_scene_tracker_channel(scene_tracker_tx)
                 .with_fuse_limits(self.fuse_max_background, self.fuse_congestion_threshold);
 
         // Wire metrics client for coalesced request tracking
-        if let Some(metrics) = service.metrics_client() {
+        if let Some(metrics) = metrics_client {
             ortho_union_fs = ortho_union_fs.with_metrics(metrics);
         }
         let mountpoint_str = mountpoint.to_string_lossy();

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -389,6 +389,18 @@ impl MetricsClient {
     pub fn prefetch_region_demoted(&self) {
         self.send(MetricEvent::PrefetchRegionDemoted);
     }
+
+    /// Records regions promoted via the normal completion path.
+    #[inline]
+    pub fn prefetch_regions_promoted_normal(&self, count: usize) {
+        self.send(MetricEvent::PrefetchRegionsPromotedNormal { count });
+    }
+
+    /// Records a region promoted via the rescue path.
+    #[inline]
+    pub fn prefetch_region_promoted_rescue(&self) {
+        self.send(MetricEvent::PrefetchRegionPromotedRescue);
+    }
 }
 
 impl std::fmt::Debug for MetricsClient {

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -363,6 +363,32 @@ impl MetricsClient {
     pub fn fuse_request_dequeued(&self) {
         self.send(MetricEvent::FuseRequestDequeued);
     }
+
+    // =========================================================================
+    // Prefetch Region State Events
+    // =========================================================================
+
+    /// Reports the current region-state distribution (gauge).
+    #[inline]
+    pub fn prefetch_region_state(&self, in_progress: usize, prefetched: usize, no_coverage: usize) {
+        self.send(MetricEvent::PrefetchRegionState {
+            in_progress,
+            prefetched,
+            no_coverage,
+        });
+    }
+
+    /// Records an observed divergence between prefetch state and reality.
+    #[inline]
+    pub fn prefetch_state_diverged(&self) {
+        self.send(MetricEvent::PrefetchStateDiverged);
+    }
+
+    /// Records a region demoted in response to divergence.
+    #[inline]
+    pub fn prefetch_region_demoted(&self) {
+        self.send(MetricEvent::PrefetchRegionDemoted);
+    }
 }
 
 impl std::fmt::Debug for MetricsClient {

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -347,6 +347,12 @@ impl MetricsDaemon {
             MetricEvent::PrefetchRegionDemoted => {
                 self.state.prefetch_regions_demoted += 1;
             }
+            MetricEvent::PrefetchRegionsPromotedNormal { count } => {
+                self.state.prefetch_promotions_normal += count as u64;
+            }
+            MetricEvent::PrefetchRegionPromotedRescue => {
+                self.state.prefetch_promotions_rescue += 1;
+            }
         }
     }
 
@@ -420,6 +426,8 @@ impl MetricsDaemon {
             regions_in_progress = state.prefetch_regions_in_progress,
             regions_prefetched = state.prefetch_regions_prefetched,
             regions_nocoverage = state.prefetch_regions_nocoverage,
+            promotions_normal = state.prefetch_promotions_normal,
+            promotions_rescue = state.prefetch_promotions_rescue,
             state_diverged = state.prefetch_state_diverged,
             regions_demoted = state.prefetch_regions_demoted,
             "Prefetch sample"
@@ -1183,6 +1191,36 @@ mod tests {
         assert_eq!(daemon.state.prefetch_regions_in_progress, 2);
         assert_eq!(daemon.state.prefetch_regions_prefetched, 3);
         assert_eq!(daemon.state.prefetch_regions_nocoverage, 0);
+    }
+
+    #[test]
+    fn test_promotion_counters_accumulate_and_are_separate() {
+        let (mut daemon, _tx) = create_daemon();
+
+        // Two events, not one: from a zero start `0 += n` and `0 = n` are
+        // indistinguishable, so a single event cannot prove these are counters.
+        daemon.process_event(MetricEvent::PrefetchRegionsPromotedNormal { count: 3 });
+        daemon.process_event(MetricEvent::PrefetchRegionsPromotedNormal { count: 2 });
+        daemon.process_event(MetricEvent::PrefetchRegionPromotedRescue);
+
+        assert_eq!(
+            daemon.state.prefetch_promotions_normal, 5,
+            "must accumulate, not assign"
+        );
+        assert_eq!(daemon.state.prefetch_promotions_rescue, 1);
+    }
+
+    #[test]
+    fn test_promotion_counters_reset() {
+        let (mut daemon, _tx) = create_daemon();
+        daemon.process_event(MetricEvent::PrefetchRegionsPromotedNormal { count: 4 });
+        daemon.process_event(MetricEvent::PrefetchRegionPromotedRescue);
+        daemon.state.reset();
+        assert_eq!(
+            daemon.state.prefetch_promotions_normal, 0,
+            "counters reset, unlike the region gauges"
+        );
+        assert_eq!(daemon.state.prefetch_promotions_rescue, 0);
     }
 
     #[tokio::test]

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -430,6 +430,11 @@ impl MetricsDaemon {
             promotions_rescue = state.prefetch_promotions_rescue,
             state_diverged = state.prefetch_state_diverged,
             regions_demoted = state.prefetch_regions_demoted,
+            // Criterion 5's user-visible outcome (the others above are
+            // mechanism): on-demand FUSE generations should fall during
+            // cruise. Per-tile FUSE logging is debug-only (#209), so this
+            // aggregated counter is the only default-level source.
+            fuse_generations = state.fuse_jobs_submitted,
             "Prefetch sample"
         );
     }
@@ -1164,6 +1169,34 @@ mod tests {
         );
         assert_eq!(sample.get("state_diverged").map(String::as_str), Some("2"));
         assert_eq!(sample.get("regions_demoted").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn test_prefetch_sample_reports_fuse_generations() {
+        // Criterion 5 ("on-demand FUSE generations fall during cruise") has
+        // no field in the sample line unless fuse_jobs_submitted is surfaced
+        // here — per-tile FUSE logging is debug-only (#209), so this counter
+        // is the only default-level source for that criterion.
+        let (mut daemon, tx) = create_daemon();
+        let client = MetricsClient::new(tx);
+
+        client.job_submitted(true);
+        client.job_submitted(true);
+        client.job_submitted(false); // non-FUSE submission must not count
+
+        while let Ok(event) = daemon.rx.try_recv() {
+            daemon.process_event(event);
+        }
+
+        let events = capture_events(|| daemon.log_prefetch_sample());
+        let sample =
+            find_prefetch_sample(&events).expect("log_prefetch_sample must emit a sample line");
+
+        assert_eq!(
+            sample.get("fuse_generations").map(String::as_str),
+            Some("2"),
+            "fuse_generations must carry state.fuse_jobs_submitted"
+        );
     }
 
     #[test]

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -163,6 +163,7 @@ impl MetricsDaemon {
                 // Sample process memory
                 _ = memory_interval.tick() => {
                     self.log_memory_sample();
+                    self.log_prefetch_sample();
                 }
             }
         }
@@ -326,6 +327,26 @@ impl MetricsDaemon {
                 self.state.fuse_requests_waiting =
                     self.state.fuse_requests_waiting.saturating_sub(1);
             }
+
+            // Prefetch region state events (#176)
+            MetricEvent::PrefetchRegionState {
+                in_progress,
+                prefetched,
+                no_coverage,
+            } => {
+                // Gauge: assigns, does not increment. The coordinator reports
+                // the full distribution each maintenance cycle, so the latest
+                // event is always the authoritative value.
+                self.state.prefetch_regions_in_progress = in_progress;
+                self.state.prefetch_regions_prefetched = prefetched;
+                self.state.prefetch_regions_nocoverage = no_coverage;
+            }
+            MetricEvent::PrefetchStateDiverged => {
+                self.state.prefetch_state_diverged += 1;
+            }
+            MetricEvent::PrefetchRegionDemoted => {
+                self.state.prefetch_regions_demoted += 1;
+            }
         }
     }
 
@@ -383,6 +404,25 @@ impl MetricsDaemon {
             // doc comment in metrics/event.rs for why that was a diagnosis hole).
             mem_cache_writes_active = state.mem_cache_writes_active,
             "Memory sample"
+        );
+    }
+
+    /// Emit the periodic prefetch-state line.
+    ///
+    /// Runs on the same 60s cadence as the memory sample. The per-cycle
+    /// distribution stays at `debug!` in the coordinator; this exists so a
+    /// default-level flight log is enough to judge the #176 acceptance
+    /// criteria without running an entire flight at `--debug`.
+    fn log_prefetch_sample(&self) {
+        let state = &self.state;
+        tracing::info!(
+            uptime_s = state.uptime().as_secs(),
+            regions_in_progress = state.prefetch_regions_in_progress,
+            regions_prefetched = state.prefetch_regions_prefetched,
+            regions_nocoverage = state.prefetch_regions_nocoverage,
+            state_diverged = state.prefetch_state_diverged,
+            regions_demoted = state.prefetch_regions_demoted,
+            "Prefetch sample"
         );
     }
 
@@ -454,6 +494,7 @@ impl std::fmt::Debug for MetricsDaemon {
 
 #[cfg(test)]
 mod tests {
+    use super::super::client::MetricsClient;
     use super::*;
 
     fn create_daemon() -> (MetricsDaemon, mpsc::UnboundedSender<MetricEvent>) {
@@ -1061,6 +1102,87 @@ mod tests {
             daemon.state.disk_writes_active, 0,
             "dds completion must decrement too"
         );
+    }
+
+    // =========================================================================
+    // Prefetch sample tests (#176)
+    //
+    // Region-state counters are a gauge (assigned wholesale each maintenance
+    // cycle); divergence/demotion counters accumulate. Mixing up assign vs.
+    // increment for the gauge would produce a plausible-looking but
+    // monotonically-growing region count.
+    // =========================================================================
+
+    /// Finds the first captured event whose message is "Prefetch sample".
+    fn find_prefetch_sample(
+        events: &[std::collections::HashMap<String, String>],
+    ) -> Option<&std::collections::HashMap<String, String>> {
+        events
+            .iter()
+            .find(|fields| fields.get("message").map(String::as_str) == Some("Prefetch sample"))
+    }
+
+    #[test]
+    fn test_prefetch_sample_reports_divergence_and_region_state() {
+        let (mut daemon, tx) = create_daemon();
+        let client = MetricsClient::new(tx);
+
+        client.prefetch_region_state(3, 7, 2);
+        client.prefetch_state_diverged();
+        client.prefetch_state_diverged();
+        client.prefetch_region_demoted();
+
+        // The daemon's event loop isn't running in this unit test, so drain
+        // the channel into the daemon's state directly before sampling.
+        while let Ok(event) = daemon.rx.try_recv() {
+            daemon.process_event(event);
+        }
+
+        let events = capture_events(|| daemon.log_prefetch_sample());
+        let sample =
+            find_prefetch_sample(&events).expect("log_prefetch_sample must emit a sample line");
+
+        assert_eq!(
+            sample.get("regions_in_progress").map(String::as_str),
+            Some("3")
+        );
+        assert_eq!(
+            sample.get("regions_prefetched").map(String::as_str),
+            Some("7")
+        );
+        assert_eq!(
+            sample.get("regions_nocoverage").map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(sample.get("state_diverged").map(String::as_str), Some("2"));
+        assert_eq!(sample.get("regions_demoted").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn test_prefetch_region_state_is_a_gauge_not_a_counter() {
+        // Regression guard: a second PrefetchRegionState event must replace
+        // the previous values, not add to them. If this were mistakenly
+        // implemented as an increment, region counts would grow without
+        // bound across maintenance cycles.
+        let (mut daemon, _tx) = create_daemon();
+
+        daemon.process_event(MetricEvent::PrefetchRegionState {
+            in_progress: 5,
+            prefetched: 10,
+            no_coverage: 1,
+        });
+        assert_eq!(daemon.state.prefetch_regions_in_progress, 5);
+        assert_eq!(daemon.state.prefetch_regions_prefetched, 10);
+        assert_eq!(daemon.state.prefetch_regions_nocoverage, 1);
+
+        daemon.process_event(MetricEvent::PrefetchRegionState {
+            in_progress: 2,
+            prefetched: 3,
+            no_coverage: 0,
+        });
+        assert_eq!(daemon.state.prefetch_regions_in_progress, 2);
+        assert_eq!(daemon.state.prefetch_regions_prefetched, 3);
+        assert_eq!(daemon.state.prefetch_regions_nocoverage, 0);
     }
 
     #[tokio::test]

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -225,6 +225,31 @@ pub enum MetricEvent {
 
     /// A FUSE request was removed from the wait queue.
     FuseRequestDequeued,
+
+    // =========================================================================
+    // Prefetch Region State Events (#176)
+    // =========================================================================
+    /// Current region-state distribution, reported each maintenance cycle.
+    ///
+    /// This is a gauge, not a counter: each event replaces the previous values.
+    PrefetchRegionState {
+        /// Regions with tiles submitted, awaiting confirmation.
+        in_progress: usize,
+        /// Regions confirmed fully cached.
+        prefetched: usize,
+        /// Regions with no ortho scenery.
+        no_coverage: usize,
+    },
+
+    /// FUSE generated a tile in a region prefetch claimed was handled.
+    ///
+    /// Counted on every occurrence, including those where the rate limit
+    /// suppressed the demotion — so the metric shows the true divergence
+    /// rate rather than the demotion rate.
+    PrefetchStateDiverged,
+
+    /// A region's state was cleared in response to observed divergence.
+    PrefetchRegionDemoted,
 }
 
 impl MetricEvent {
@@ -264,6 +289,9 @@ impl MetricEvent {
             Self::FuseRequestCompleted => "fuse_request_completed",
             Self::FuseRequestQueued => "fuse_request_queued",
             Self::FuseRequestDequeued => "fuse_request_dequeued",
+            Self::PrefetchRegionState { .. } => "prefetch_region_state",
+            Self::PrefetchStateDiverged => "prefetch_state_diverged",
+            Self::PrefetchRegionDemoted => "prefetch_region_demoted",
         }
     }
 }

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -250,6 +250,20 @@ pub enum MetricEvent {
 
     /// A region's state was cleared in response to observed divergence.
     PrefetchRegionDemoted,
+
+    /// Regions promoted from `InProgress` to `Prefetched` via the normal
+    /// completion path (all tiles in the region confirmed present).
+    ///
+    /// `count` batches multiple regions promoted in the same maintenance
+    /// cycle into one event, mirroring how the coordinator reports them.
+    PrefetchRegionsPromotedNormal {
+        /// Number of regions promoted in this batch.
+        count: usize,
+    },
+
+    /// A region promoted via the rescue path (recovered from a state that
+    /// would otherwise have left it stuck, e.g. a missed normal promotion).
+    PrefetchRegionPromotedRescue,
 }
 
 impl MetricEvent {
@@ -292,6 +306,8 @@ impl MetricEvent {
             Self::PrefetchRegionState { .. } => "prefetch_region_state",
             Self::PrefetchStateDiverged => "prefetch_state_diverged",
             Self::PrefetchRegionDemoted => "prefetch_region_demoted",
+            Self::PrefetchRegionsPromotedNormal { .. } => "prefetch_regions_promoted_normal",
+            Self::PrefetchRegionPromotedRescue => "prefetch_region_promoted_rescue",
         }
     }
 }

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -264,6 +264,10 @@ pub struct AggregatedState {
     pub prefetch_state_diverged: u64,
     /// Total regions demoted in response to divergence (counter).
     pub prefetch_regions_demoted: u64,
+    /// Total regions promoted via the normal completion path (counter).
+    pub prefetch_promotions_normal: u64,
+    /// Total regions promoted via the rescue path (counter).
+    pub prefetch_promotions_rescue: u64,
 }
 
 impl Default for AggregatedState {
@@ -326,6 +330,8 @@ impl AggregatedState {
             prefetch_regions_nocoverage: 0,
             prefetch_state_diverged: 0,
             prefetch_regions_demoted: 0,
+            prefetch_promotions_normal: 0,
+            prefetch_promotions_rescue: 0,
         }
     }
 
@@ -384,6 +390,8 @@ impl AggregatedState {
         // them here would misreport "no regions" until the next cycle.
         self.prefetch_state_diverged = 0;
         self.prefetch_regions_demoted = 0;
+        self.prefetch_promotions_normal = 0;
+        self.prefetch_promotions_rescue = 0;
     }
 }
 

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -248,6 +248,22 @@ pub struct AggregatedState {
     // =========================================================================
     /// Peak bytes per second observed.
     pub peak_bytes_per_second: f64,
+
+    // =========================================================================
+    // Prefetch Region State Metrics (#176)
+    // =========================================================================
+    /// Regions with tiles submitted, awaiting confirmation (gauge, from
+    /// `PrefetchRegionState`; externally derived from `GeoIndex`, like the
+    /// disk-cache-size gauges above, so it is excluded from `reset()`).
+    pub prefetch_regions_in_progress: usize,
+    /// Regions confirmed fully cached (gauge).
+    pub prefetch_regions_prefetched: usize,
+    /// Regions with no ortho scenery (gauge).
+    pub prefetch_regions_nocoverage: usize,
+    /// Total observed divergences between prefetch state and reality (counter).
+    pub prefetch_state_diverged: u64,
+    /// Total regions demoted in response to divergence (counter).
+    pub prefetch_regions_demoted: u64,
 }
 
 impl Default for AggregatedState {
@@ -305,6 +321,11 @@ impl AggregatedState {
             fuse_requests_active: 0,
             fuse_requests_waiting: 0,
             peak_bytes_per_second: 0.0,
+            prefetch_regions_in_progress: 0,
+            prefetch_regions_prefetched: 0,
+            prefetch_regions_nocoverage: 0,
+            prefetch_state_diverged: 0,
+            prefetch_regions_demoted: 0,
         }
     }
 
@@ -355,6 +376,14 @@ impl AggregatedState {
         self.fuse_requests_active = 0;
         self.fuse_requests_waiting = 0;
         self.peak_bytes_per_second = 0.0;
+        // prefetch_regions_{in_progress,prefetched,nocoverage} are NOT reset:
+        // like chunk_disk_cache_size_bytes/dds_disk_cache_size_bytes/
+        // chunk_index_entries above, they are externally-derived gauges
+        // (assigned wholesale from GeoIndex each maintenance cycle), not
+        // counters accumulated from this daemon's own event stream. Zeroing
+        // them here would misreport "no regions" until the next cycle.
+        self.prefetch_state_diverged = 0;
+        self.prefetch_regions_demoted = 0;
     }
 }
 

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -9,7 +9,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::coord::{to_tile_coords, TileCoord};
+use crate::coord::TileCoord;
 use crate::executor::DdsDiskCacheChecker;
 use crate::geo_index::{DsfRegion, GeoIndex, PrefetchedRegion, RetainedRegion};
 use crate::prefetch::tile_based::DsfTileCoord;
@@ -17,40 +17,14 @@ use crate::prefetch::SceneryIndex;
 
 /// Region lifecycle management for the prefetch system.
 ///
-/// Handles tile expansion, region state transitions (InProgress → Prefetched),
-/// staleness sweeps, and retention-based eviction.
+/// Handles region state transitions (InProgress → Prefetched), staleness
+/// sweeps, and retention-based eviction.
 pub struct BoundaryStrategy;
 
 impl BoundaryStrategy {
     /// Creates a new `BoundaryStrategy`.
     pub fn new() -> Self {
         Self
-    }
-
-    /// Expand a DSF region into DDS tiles using a 4x4 sample grid.
-    ///
-    /// Samples 16 points within the 1x1 degree region and converts each to
-    /// a DDS tile coordinate at the given zoom level. Duplicates are removed
-    /// (nearby sample points may map to the same tile at lower zoom levels).
-    pub fn expand_to_tiles(&self, region: &DsfRegion, zoom: u8) -> Vec<TileCoord> {
-        let lat_min = region.lat as f64;
-        let lon_min = region.lon as f64;
-        let mut tiles = Vec::with_capacity(16);
-        let mut seen = std::collections::HashSet::with_capacity(16);
-
-        for lat_step in 0..4u32 {
-            for lon_step in 0..4u32 {
-                let sample_lat = lat_min + (lat_step as f64 * 0.25) + 0.125;
-                let sample_lon = lon_min + (lon_step as f64 * 0.25) + 0.125;
-                if let Ok(coord) = to_tile_coords(sample_lat, sample_lon, zoom) {
-                    if seen.insert((coord.row, coord.col)) {
-                        tiles.push(coord);
-                    }
-                }
-            }
-        }
-
-        tiles
     }
 
     /// Mark a region as having no scenery coverage.
@@ -164,27 +138,6 @@ impl BoundaryStrategy {
         promoted
     }
 
-    /// Get tiles for a DSF region using scenery index when available.
-    ///
-    /// Queries the scenery index for actual installed tiles (at correct zoom
-    /// levels), falling back to geometric 4x4 grid at zoom 14.
-    pub fn tiles_for_region(
-        strategy: &BoundaryStrategy,
-        region: &DsfRegion,
-        scenery_index: Option<&Arc<SceneryIndex>>,
-    ) -> Vec<TileCoord> {
-        if let Some(index) = scenery_index {
-            let center_lat = region.lat as f64 + 0.5;
-            let center_lon = region.lon as f64 + 0.5;
-            let tiles = index.tiles_near(center_lat, center_lon, 45.0);
-            let result: Vec<TileCoord> = tiles.iter().map(|t| t.to_tile_coord()).collect();
-            if !result.is_empty() {
-                return result;
-            }
-        }
-        strategy.expand_to_tiles(region, 14)
-    }
-
     /// Evict `PrefetchedRegion` entries for regions no longer in the retained window.
     ///
     /// Removes `Prefetched` and `NoCoverage` entries whose DSF region is not
@@ -263,30 +216,6 @@ impl Default for BoundaryStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_expand_region_to_dds_tiles() {
-        let strategy = BoundaryStrategy::new();
-        let region = DsfRegion::new(50, 9);
-        let tiles = strategy.expand_to_tiles(&region, 14);
-        // 4x4 grid = up to 16 tiles (dedup may reduce slightly)
-        assert!(!tiles.is_empty());
-        assert!(tiles.len() <= 16);
-        // All tiles should be at the requested zoom
-        for tile in &tiles {
-            assert_eq!(tile.zoom, 14);
-        }
-    }
-
-    #[test]
-    fn test_expand_region_tiles_within_dsf_bounds() {
-        let strategy = BoundaryStrategy::new();
-        let region = DsfRegion::new(50, 9);
-        let tiles = strategy.expand_to_tiles(&region, 14);
-        // Tiles should be within the DSF region's geographic bounds
-        // (can't easily check lat/lon from TileCoord, just verify non-empty)
-        assert!(!tiles.is_empty());
-    }
 
     #[test]
     fn test_mark_no_coverage() {
@@ -502,7 +431,7 @@ mod tests {
     }
 
     // =========================================================================
-    // tiles_for_region + SceneryIndex integration
+    // promote_completed_regions + SceneryIndex zoom integration
     // =========================================================================
 
     /// Create a SceneryIndex populated with tiles for a specific DSF region.
@@ -535,56 +464,6 @@ mod tests {
     }
 
     #[test]
-    fn test_tiles_for_region_without_scenery_index_uses_zoom_14() {
-        let strategy = BoundaryStrategy::new();
-        let region = DsfRegion::new(50, 9);
-
-        // No scenery index -> falls back to geometric expansion at zoom 14
-        let tiles = BoundaryStrategy::tiles_for_region(&strategy, &region, None);
-
-        assert!(!tiles.is_empty());
-        for tile in &tiles {
-            assert_eq!(tile.zoom, 14, "Fallback should use zoom 14");
-        }
-    }
-
-    #[test]
-    fn test_tiles_for_region_with_scenery_index_uses_actual_zoom() {
-        let strategy = BoundaryStrategy::new();
-        let region = DsfRegion::new(50, 9);
-
-        // SceneryIndex populated at chunk_zoom 16 -> tile zoom 12
-        let index = make_scenery_index_for_region(50, 9, 16);
-        let tiles = BoundaryStrategy::tiles_for_region(&strategy, &region, Some(&index));
-
-        assert!(!tiles.is_empty());
-        for tile in &tiles {
-            assert_eq!(
-                tile.zoom, 12,
-                "Should use zoom 12 from scenery index (chunk_zoom 16)"
-            );
-        }
-    }
-
-    #[test]
-    fn test_tiles_for_region_falls_back_when_index_empty_for_region() {
-        let strategy = BoundaryStrategy::new();
-        let region = DsfRegion::new(50, 9);
-
-        // SceneryIndex exists but has tiles only at different region (60, 20)
-        let index = make_scenery_index_for_region(60, 20, 16);
-        let tiles = BoundaryStrategy::tiles_for_region(&strategy, &region, Some(&index));
-
-        assert!(!tiles.is_empty());
-        for tile in &tiles {
-            assert_eq!(
-                tile.zoom, 14,
-                "Should fall back to zoom 14 when no index tiles nearby"
-            );
-        }
-    }
-
-    #[test]
     fn test_promote_completed_regions_with_scenery_index() {
         let geo_index = GeoIndex::new();
         let region = DsfRegion::new(50, 9);
@@ -595,8 +474,7 @@ mod tests {
         let index = make_scenery_index_for_region(50, 9, 16);
 
         // Get tiles via SceneryIndex — these are zoom 12 tiles
-        let strategy = BoundaryStrategy::new();
-        let tiles = BoundaryStrategy::tiles_for_region(&strategy, &region, Some(&index));
+        let tiles = index.tiles_in_region(region);
         assert!(!tiles.is_empty());
         assert!(tiles.iter().all(|t| t.zoom == 12));
 
@@ -626,9 +504,14 @@ mod tests {
         // SceneryIndex at chunk_zoom 16 -> tile zoom 12
         let index = make_scenery_index_for_region(50, 9, 16);
 
-        // Cache zoom 14 tiles (the OLD wrong behavior) instead of zoom 12
-        let strategy = BoundaryStrategy::new();
-        let wrong_tiles = strategy.expand_to_tiles(&region, 14);
+        // Cache zoom 14 tiles (the OLD wrong behavior) instead of zoom 12.
+        // Built explicitly rather than via the removed geometric expansion —
+        // only the zoom mismatch matters here, not real geographic tiles.
+        let wrong_tiles = vec![TileCoord {
+            row: 999,
+            col: 999,
+            zoom: 14,
+        }];
         let checker: Arc<dyn DdsDiskCacheChecker> =
             MockDiskChecker::with_tile_coords(wrong_tiles.into_iter());
 

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -1,8 +1,6 @@
 //! Region lifecycle management for the prefetch system.
 //!
 //! Provides region lifecycle management:
-//! - [`BoundaryStrategy::sweep_stale_regions`] — removes `InProgress` regions
-//!   that have exceeded the staleness timeout (eligible for re-prefetch).
 //! - [`BoundaryStrategy::promote_completed_regions`] — promotes `InProgress`
 //!   regions to `Prefetched` once all their tiles are confirmed in cache.
 
@@ -17,8 +15,10 @@ use crate::prefetch::SceneryIndex;
 
 /// Region lifecycle management for the prefetch system.
 ///
-/// Handles region state transitions (InProgress → Prefetched), staleness
-/// sweeps, and retention-based eviction.
+/// Handles region state transitions (InProgress → Prefetched) and
+/// retention-based eviction. Staleness is handled by the coordinator's
+/// `evaluate_stale_regions`, which checks the DDS disk before deciding
+/// whether a stale region should be promoted or retried.
 pub struct BoundaryStrategy;
 
 impl BoundaryStrategy {
@@ -45,30 +45,6 @@ impl BoundaryStrategy {
             lon = region.lon,
             "boundary: marked InProgress"
         );
-    }
-
-    /// Sweep the GeoIndex for stale `InProgress` regions and remove them.
-    ///
-    /// Stale regions have been `InProgress` for longer than the specified timeout,
-    /// indicating the prefetch job either failed or was never completed. Removing
-    /// them makes them eligible for re-prefetch.
-    pub fn sweep_stale_regions(geo_index: &GeoIndex, timeout: std::time::Duration) -> usize {
-        let stale: Vec<DsfRegion> = geo_index
-            .iter::<PrefetchedRegion>()
-            .into_iter()
-            .filter(|(_, region)| region.is_stale(timeout))
-            .map(|(dsf, _)| dsf)
-            .collect();
-
-        let removed = stale.len();
-        for region in &stale {
-            geo_index.remove::<PrefetchedRegion>(region);
-        }
-
-        if removed > 0 {
-            tracing::debug!(removed, "Swept stale InProgress regions");
-        }
-        removed
     }
 
     /// Check InProgress regions and promote to Prefetched if all tiles are
@@ -242,56 +218,6 @@ mod tests {
     }
 
     // =========================================================================
-    // Staleness sweep
-    // =========================================================================
-
-    #[test]
-    fn test_sweep_stale_regions() {
-        use std::time::Duration;
-
-        let geo_index = GeoIndex::new();
-        let region = DsfRegion::new(50, 9);
-
-        // Insert InProgress with a timestamp that will be stale immediately
-        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
-
-        // Use a zero timeout so that any InProgress region is immediately stale
-        let removed = BoundaryStrategy::sweep_stale_regions(&geo_index, Duration::ZERO);
-        assert_eq!(removed, 1);
-        assert!(!geo_index.contains::<PrefetchedRegion>(&region));
-    }
-
-    #[test]
-    fn test_sweep_keeps_fresh_regions() {
-        use std::time::Duration;
-
-        let geo_index = GeoIndex::new();
-        let region = DsfRegion::new(50, 9);
-
-        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
-
-        // Use a very long timeout — region should not be stale
-        let removed = BoundaryStrategy::sweep_stale_regions(&geo_index, Duration::from_secs(3600));
-        assert_eq!(removed, 0);
-        assert!(geo_index.contains::<PrefetchedRegion>(&region));
-    }
-
-    #[test]
-    fn test_sweep_keeps_prefetched_regions() {
-        use std::time::Duration;
-
-        let geo_index = GeoIndex::new();
-        let region = DsfRegion::new(50, 9);
-
-        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
-
-        // Even with zero timeout, Prefetched regions are never stale
-        let removed = BoundaryStrategy::sweep_stale_regions(&geo_index, Duration::ZERO);
-        assert_eq!(removed, 0);
-        assert!(geo_index.contains::<PrefetchedRegion>(&region));
-    }
-
-    // =========================================================================
     // Region promotion
     // =========================================================================
 
@@ -341,8 +267,8 @@ mod tests {
     #[test]
     fn test_promote_completed_regions() {
         // #176: promotion has no geometric fallback — it needs a
-        // SceneryIndex to know the region's tile set. Wire a minimal
-        // single-tile index rather than relying on `expand_to_tiles`.
+        // SceneryIndex to know the region's tile set, so wire a minimal
+        // single-tile index.
         let geo_index = GeoIndex::new();
         let region = DsfRegion::new(50, 9);
 

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -150,7 +150,7 @@ impl BoundaryStrategy {
         dds_disk_checker: Option<&Arc<dyn DdsDiskCacheChecker>>,
         scenery_index: Option<&Arc<SceneryIndex>>,
         ortho_union_index: Option<&Arc<OrthoUnionIndex>>,
-    ) -> usize {
+    ) -> Vec<DsfRegion> {
         let in_progress: Vec<DsfRegion> = geo_index
             .iter::<PrefetchedRegion>()
             .into_iter()
@@ -158,7 +158,7 @@ impl BoundaryStrategy {
             .map(|(dsf, _)| dsf)
             .collect();
 
-        let mut promoted = 0;
+        let mut promoted: Vec<DsfRegion> = Vec::new();
         for region in &in_progress {
             match Self::region_disk_state(
                 *region,
@@ -168,7 +168,7 @@ impl BoundaryStrategy {
             ) {
                 RegionDiskState::Complete => {
                     geo_index.insert::<PrefetchedRegion>(*region, PrefetchedRegion::prefetched());
-                    promoted += 1;
+                    promoted.push(*region);
                 }
                 RegionDiskState::Incomplete
                 | RegionDiskState::NoTiles
@@ -178,8 +178,11 @@ impl BoundaryStrategy {
             }
         }
 
-        if promoted > 0 {
-            tracing::debug!(promoted, "Promoted InProgress regions to Prefetched");
+        if !promoted.is_empty() {
+            tracing::debug!(
+                promoted = promoted.len(),
+                "Promoted InProgress regions to Prefetched"
+            );
         }
         promoted
     }
@@ -366,7 +369,7 @@ mod tests {
             Some(&index),
             None,
         );
-        assert_eq!(promoted, 1);
+        assert_eq!(promoted.len(), 1);
 
         let state = geo_index.get::<PrefetchedRegion>(&region).unwrap();
         assert!(state.is_prefetched());
@@ -409,7 +412,7 @@ mod tests {
             Some(&index),
             None,
         );
-        assert_eq!(promoted, 0);
+        assert_eq!(promoted.len(), 0);
 
         let state = geo_index.get::<PrefetchedRegion>(&region).unwrap();
         assert!(state.is_in_progress());
@@ -425,7 +428,7 @@ mod tests {
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
 
         let promoted = BoundaryStrategy::promote_completed_regions(&geo_index, None, None, None);
-        assert_eq!(promoted, 0);
+        assert_eq!(promoted.len(), 0);
 
         let state = geo_index.get::<PrefetchedRegion>(&region).unwrap();
         assert!(
@@ -494,7 +497,8 @@ mod tests {
             None,
         );
         assert_eq!(
-            promoted, 1,
+            promoted.len(),
+            1,
             "Should promote when all scenery index tiles are on disk"
         );
 
@@ -531,7 +535,8 @@ mod tests {
             None,
         );
         assert_eq!(
-            promoted, 0,
+            promoted.len(),
+            0,
             "Should not promote when cached tiles are at wrong zoom level"
         );
 
@@ -605,7 +610,8 @@ mod tests {
         );
 
         assert_eq!(
-            promoted, 1,
+            promoted.len(),
+            1,
             "the adjacent region's missing tile must not block promotion"
         );
         assert!(geo_index
@@ -654,7 +660,11 @@ mod tests {
             None,
         );
 
-        assert_eq!(promoted, 0, "a missing in-region tile must block promotion");
+        assert_eq!(
+            promoted.len(),
+            0,
+            "a missing in-region tile must block promotion"
+        );
         assert!(geo_index
             .get::<PrefetchedRegion>(&region)
             .unwrap()

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -4,14 +4,12 @@
 //! - [`BoundaryStrategy::promote_completed_regions`] — promotes `InProgress`
 //!   regions to `Prefetched` once all their tiles are confirmed in cache.
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::coord::TileCoord;
 use crate::executor::DdsDiskCacheChecker;
 use crate::geo_index::{DsfRegion, GeoIndex, PrefetchedRegion, RetainedRegion};
 use crate::ortho_union::OrthoUnionIndex;
-use crate::prefetch::tile_based::DsfTileCoord;
 use crate::prefetch::SceneryIndex;
 
 /// Region lifecycle management for the prefetch system.
@@ -140,11 +138,12 @@ impl BoundaryStrategy {
     /// to know which tiles the region should contain. The rescue path
     /// (`evaluate_stale_regions`) will still fire for stale regions.
     ///
-    /// See #172 Part 3: the prior version consulted a `cached_tiles`
-    /// `HashSet` shadow that failed to track ~94% of actually-cached
-    /// tiles during production flights (4 normal vs. 61 stale-rescue
-    /// promotions in a 9-hour log). Querying the authoritative cache
-    /// directly collapses one source of truth.
+    /// See #172 Part 3: the prior version consulted a local `HashSet`
+    /// shadow of "tiles we believe are cached" that failed to track ~94%
+    /// of actually-cached tiles during production flights (4 normal vs.
+    /// 61 stale-rescue promotions in a 9-hour log). Querying the
+    /// authoritative cache directly collapses one source of truth; the
+    /// shadow itself was deleted in #176 once confirmed write-only.
     pub fn promote_completed_regions(
         geo_index: &GeoIndex,
         dds_disk_checker: Option<&Arc<dyn DdsDiskCacheChecker>>,
@@ -220,40 +219,6 @@ impl BoundaryStrategy {
         }
         evicted
     }
-
-    /// Remove entries from `cached_tiles` whose DSF region is not in the retained window.
-    ///
-    /// Returns 0 (no-op) when the `RetainedRegion` layer is empty, indicating
-    /// retention tracking is not yet active. This prevents stale `cached_tiles`
-    /// entries from blocking re-prefetch of regions the aircraft has moved past.
-    pub fn evict_cached_tiles_outside_retained(
-        cached_tiles: &mut HashSet<TileCoord>,
-        geo_index: &GeoIndex,
-    ) -> usize {
-        let retained = geo_index.regions::<RetainedRegion>();
-        if retained.is_empty() {
-            return 0;
-        }
-
-        let retained_set: std::collections::HashSet<DsfRegion> = retained.into_iter().collect();
-
-        let before = cached_tiles.len();
-        cached_tiles.retain(|tile| {
-            let (lat, lon) = tile.to_lat_lon();
-            let dsf = DsfTileCoord::from_lat_lon(lat, lon);
-            retained_set.contains(&DsfRegion::new(dsf.lat, dsf.lon))
-        });
-        let evicted = before - cached_tiles.len();
-
-        if evicted > 0 {
-            tracing::debug!(
-                evicted,
-                remaining = cached_tiles.len(),
-                "Evicted cached_tiles outside retained window"
-            );
-        }
-        evicted
-    }
 }
 
 impl Default for BoundaryStrategy {
@@ -265,6 +230,7 @@ impl Default for BoundaryStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     #[test]
     fn test_mark_no_coverage() {
@@ -871,48 +837,6 @@ mod tests {
         assert_eq!(evicted, 1); // Only Prefetched, not InProgress
         assert!(geo_index.contains::<PrefetchedRegion>(&DsfRegion::new(50, 7)));
         assert!(!geo_index.contains::<PrefetchedRegion>(&DsfRegion::new(51, 7)));
-    }
-
-    #[test]
-    fn test_evict_cached_tiles_removes_tiles_outside_retained() {
-        use crate::coord::to_tile_coords;
-
-        let geo_index = GeoIndex::new();
-        geo_index.insert::<RetainedRegion>(DsfRegion::new(50, 7), RetainedRegion);
-
-        let mut cached_tiles = std::collections::HashSet::new();
-
-        // Tile inside retained region (50, 7)
-        let tile_inside = to_tile_coords(50.5, 7.5, 14).unwrap();
-        cached_tiles.insert(tile_inside);
-
-        // Tile outside retained region (48, 5)
-        let tile_outside = to_tile_coords(48.5, 5.5, 14).unwrap();
-        cached_tiles.insert(tile_outside);
-
-        let evicted =
-            BoundaryStrategy::evict_cached_tiles_outside_retained(&mut cached_tiles, &geo_index);
-
-        assert_eq!(evicted, 1);
-        assert!(cached_tiles.contains(&tile_inside));
-        assert!(!cached_tiles.contains(&tile_outside));
-    }
-
-    #[test]
-    fn test_evict_cached_tiles_noop_when_no_retained_regions() {
-        use crate::coord::to_tile_coords;
-
-        let geo_index = GeoIndex::new();
-        let mut cached_tiles = std::collections::HashSet::new();
-
-        let tile = to_tile_coords(50.5, 7.5, 14).unwrap();
-        cached_tiles.insert(tile);
-
-        let evicted =
-            BoundaryStrategy::evict_cached_tiles_outside_retained(&mut cached_tiles, &geo_index);
-
-        assert_eq!(evicted, 0);
-        assert!(cached_tiles.contains(&tile));
     }
 
     #[test]

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -100,14 +100,16 @@ impl BoundaryStrategy {
     /// Check InProgress regions and promote to Prefetched if all tiles are
     /// present in the authoritative DDS disk cache.
     ///
-    /// For each InProgress region, expands it to DDS tiles via
-    /// `tiles_for_region` (using the scenery index when available) and
-    /// queries the `DdsDiskCacheChecker` for each tile. A region is
-    /// promoted to `Prefetched` only when **every** one of its tiles
-    /// is present on disk (check-all with short-circuit on first miss).
+    /// For each InProgress region, looks up its tile set via
+    /// `SceneryIndex::tiles_in_region` — the single definition of "what
+    /// tiles belong to this region" shared with the submit and rescue
+    /// paths (#176) — and queries the `DdsDiskCacheChecker` for each tile.
+    /// A region is promoted to `Prefetched` only when **every** one of its
+    /// tiles is present on disk (check-all with short-circuit on first miss).
     ///
-    /// If `dds_disk_checker` is `None`, promotion is skipped — there is
-    /// no source of truth to consult. The rescue path
+    /// If either `dds_disk_checker` or `scenery_index` is `None`, promotion
+    /// is skipped — there is no authoritative source to consult, or no way
+    /// to know which tiles the region should contain. The rescue path
     /// (`evaluate_stale_regions`) will still fire for stale regions.
     ///
     /// See #172 Part 3: the prior version consulted a `cached_tiles`
@@ -645,6 +647,12 @@ mod tests {
     // =========================================================================
     // Region tile-set SSOT regression tests (#176)
     // =========================================================================
+    //
+    // Note: the `row`/`col` values in the `SceneryTile` fixtures below are
+    // arbitrary and not geographically consistent with their `lat`/`lon` —
+    // only `lat`/`lon` drive region membership in `tiles_in_region`. `row`/`col`
+    // just need to be distinct per tile so dedup/coverage assertions are
+    // meaningful.
 
     use crate::prefetch::scenery_index::SceneryTile;
 

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -17,7 +17,12 @@ use crate::prefetch::SceneryIndex;
 /// Handles region state transitions (InProgress → Prefetched) and
 /// retention-based eviction. Staleness is handled by the coordinator's
 /// `evaluate_stale_regions`, which checks the DDS disk before deciding
-/// whether a stale region should be promoted or retried.
+/// whether a stale region should be promoted, retried, or — after
+/// `MAX_REGION_ATTEMPTS` retries — retired to `NoCoverage` permanently
+/// for the session. A fourth outcome exists alongside those three: when
+/// [`RegionDiskState::Unknown`] reports no authoritative source to
+/// consult, the region is left untouched and the attempt does not count
+/// against the retry limit.
 pub struct BoundaryStrategy;
 
 /// What the authoritative DDS disk cache can tell us about a region.

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -735,21 +735,23 @@ mod tests {
     /// named at the given CHUNK coordinates (row, col, zoom) — matching how
     /// `dds_tile_exists` resolves `textures/{row}_{col}_{prefix}{zoom}.dds`.
     ///
-    /// The backing `TempDir` is deliberately leaked so its files remain on
-    /// disk for the rest of the test process: `dds_tile_exists` stats the
-    /// real filesystem on every call (lazy resolution), so dropping the
-    /// directory would make every lookup silently miss.
+    /// Takes the backing `TempDir` by reference — same pattern as
+    /// `create_package_with_dds` in `ortho_union/index.rs` — so the caller
+    /// owns the guard and its files stay on disk for exactly the scope of
+    /// the calling test function. `dds_tile_exists` stats the real
+    /// filesystem on every call (lazy resolution), so the `TempDir` must
+    /// outlive every lookup made against the returned index, but no longer:
+    /// no leaking required.
     fn make_ortho_index_with_chunk_tiles(
+        temp: &tempfile::TempDir,
         chunk_tiles: Vec<(u32, u32, u8)>,
     ) -> Arc<crate::ortho_union::OrthoUnionIndex> {
-        let temp = tempfile::TempDir::new().unwrap();
         std::fs::create_dir_all(temp.path().join("textures")).unwrap();
         for (row, col, zoom) in chunk_tiles {
             let filename = format!("{row}_{col}_ZL{zoom}.dds");
             std::fs::write(temp.path().join("textures").join(filename), b"dds content").unwrap();
         }
         let source = crate::ortho_union::OrthoSource::new_package("test", temp.path());
-        Box::leak(Box::new(temp));
         Arc::new(crate::ortho_union::OrthoUnionIndex::with_sources(vec![
             source,
         ]))
@@ -772,7 +774,9 @@ mod tests {
         // chunk coords while tile_exists_blocking takes tile coords. If the
         // implementation passes tile coords here the lookup silently misses and
         // this test fails, which is the point.
+        let temp = tempfile::TempDir::new().unwrap();
         let ortho = make_ortho_index_with_chunk_tiles(
+            &temp,
             tiles.iter().map(|t| t.chunk_origin()).collect::<Vec<_>>(),
         );
 
@@ -792,7 +796,8 @@ mod tests {
         // Guards the disjunction against becoming a tautology.
         let index = make_scenery_index_for_region(50, 9, 16);
         let region = DsfRegion { lat: 50, lon: 9 };
-        let ortho = make_ortho_index_with_chunk_tiles(vec![]);
+        let temp = tempfile::TempDir::new().unwrap();
+        let ortho = make_ortho_index_with_chunk_tiles(&temp, vec![]);
         assert_eq!(
             BoundaryStrategy::region_disk_state(
                 region,

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -21,10 +21,60 @@ use crate::prefetch::SceneryIndex;
 /// whether a stale region should be promoted or retried.
 pub struct BoundaryStrategy;
 
+/// What the authoritative DDS disk cache can tell us about a region.
+///
+/// Deliberately not a `bool`: the answer feeds a decision whose terminal
+/// outcome is permanent exclusion (`NoCoverage`), so "we cannot tell" must
+/// be distinguishable from "we checked and it is absent".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionDiskState {
+    /// Every tile the scenery index attributes to this region is present.
+    Complete,
+    /// At least one attributed tile is absent.
+    Incomplete,
+    /// The scenery index attributes no tiles to this region.
+    NoTiles,
+    /// No authoritative source to consult — no checker and/or no index.
+    Unknown,
+}
+
 impl BoundaryStrategy {
     /// Creates a new `BoundaryStrategy`.
     pub fn new() -> Self {
         Self
+    }
+
+    /// The single definition of "is this region fully covered?".
+    ///
+    /// Consumed by both the fast path (`promote_completed_regions`) and the
+    /// rescue path (`AdaptivePrefetchCoordinator::evaluate_stale_regions`).
+    /// Prior to #223's review these were two copies that already disagreed
+    /// on the empty and unanswerable cases — the same copy-drift shape #176
+    /// was filed to remove.
+    pub fn region_disk_state(
+        region: DsfRegion,
+        scenery_index: Option<&Arc<SceneryIndex>>,
+        dds_disk_checker: Option<&Arc<dyn DdsDiskCacheChecker>>,
+    ) -> RegionDiskState {
+        let (Some(index), Some(checker)) = (scenery_index, dds_disk_checker) else {
+            return RegionDiskState::Unknown;
+        };
+        let tiles = index.tiles_in_region(region);
+        if tiles.is_empty() {
+            return RegionDiskState::NoTiles;
+        }
+        // Short-circuits on first miss.
+        // Pass tile coords (not chunk_origin) — the DDS disk cache is keyed
+        // by `tile:{tile_zoom}:{tile_row}:{tile_col}`. Using chunk coords
+        // here silently returned false for every tile, preventing promotion.
+        if tiles
+            .iter()
+            .all(|t| checker.tile_exists_blocking(t.row, t.col, t.zoom))
+        {
+            RegionDiskState::Complete
+        } else {
+            RegionDiskState::Incomplete
+        }
     }
 
     /// Mark a region as having no scenery coverage.
@@ -72,14 +122,6 @@ impl BoundaryStrategy {
         dds_disk_checker: Option<&Arc<dyn DdsDiskCacheChecker>>,
         scenery_index: Option<&Arc<SceneryIndex>>,
     ) -> usize {
-        let (Some(checker), Some(index)) = (dds_disk_checker, scenery_index) else {
-            // Without an authoritative checker there is nothing to consult,
-            // and without the scenery index there is no way to know which
-            // tiles the region should contain. Skip promotion; the rescue
-            // path handles stale regions.
-            return 0;
-        };
-
         let in_progress: Vec<DsfRegion> = geo_index
             .iter::<PrefetchedRegion>()
             .into_iter()
@@ -89,22 +131,16 @@ impl BoundaryStrategy {
 
         let mut promoted = 0;
         for region in &in_progress {
-            let tiles = index.tiles_in_region(*region);
-            if tiles.is_empty() {
-                continue;
-            }
-            // Check-all with short-circuit on first miss. Each lookup is
-            // an O(1) in-memory index check.
-            // Pass tile coords (not chunk_origin) — the DDS disk cache is
-            // keyed by tile coords `tile:{tile_zoom}:{tile_row}:{tile_col}`.
-            // Using chunk coords here silently returned false for every
-            // tile, preventing promotion.
-            let all_present = tiles
-                .iter()
-                .all(|t| checker.tile_exists_blocking(t.row, t.col, t.zoom));
-            if all_present {
-                geo_index.insert::<PrefetchedRegion>(*region, PrefetchedRegion::prefetched());
-                promoted += 1;
+            match Self::region_disk_state(*region, scenery_index, dds_disk_checker) {
+                RegionDiskState::Complete => {
+                    geo_index.insert::<PrefetchedRegion>(*region, PrefetchedRegion::prefetched());
+                    promoted += 1;
+                }
+                RegionDiskState::Incomplete
+                | RegionDiskState::NoTiles
+                | RegionDiskState::Unknown => {
+                    continue;
+                }
             }
         }
 
@@ -565,6 +601,60 @@ mod tests {
             .get::<PrefetchedRegion>(&region)
             .unwrap()
             .is_in_progress());
+    }
+
+    // =========================================================================
+    // region_disk_state tests (#176 Task 1 — single completeness predicate)
+    // =========================================================================
+
+    #[test]
+    fn test_region_disk_state_unknown_without_checker() {
+        let index = make_scenery_index_for_region(50, 9, 16);
+        let region = DsfRegion { lat: 50, lon: 9 };
+        assert_eq!(
+            BoundaryStrategy::region_disk_state(region, Some(&index), None),
+            RegionDiskState::Unknown,
+            "no checker means we cannot tell — must not be reported as Incomplete"
+        );
+    }
+
+    #[test]
+    fn test_region_disk_state_no_tiles_for_unindexed_region() {
+        let index = make_scenery_index_for_region(50, 9, 16);
+        let checker = test_checker(&[]);
+        // A region the index knows nothing about.
+        let region = DsfRegion { lat: -40, lon: 170 };
+        assert_eq!(
+            BoundaryStrategy::region_disk_state(region, Some(&index), Some(&checker)),
+            RegionDiskState::NoTiles
+        );
+    }
+
+    #[test]
+    fn test_region_disk_state_complete_and_incomplete() {
+        let index = make_scenery_index_for_region(50, 9, 16);
+        let region = DsfRegion { lat: 50, lon: 9 };
+        let tiles = index.tiles_in_region(region);
+        assert!(
+            tiles.len() >= 2,
+            "fixture must expose >=2 tiles for this test to discriminate"
+        );
+
+        let all: Vec<TileCoord> = tiles.clone();
+        assert_eq!(
+            BoundaryStrategy::region_disk_state(region, Some(&index), Some(&test_checker(&all))),
+            RegionDiskState::Complete
+        );
+
+        let all_but_one: Vec<TileCoord> = tiles.iter().skip(1).cloned().collect();
+        assert_eq!(
+            BoundaryStrategy::region_disk_state(
+                region,
+                Some(&index),
+                Some(&test_checker(&all_but_one))
+            ),
+            RegionDiskState::Incomplete
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -516,14 +516,20 @@ mod tests {
         // SceneryIndex at chunk_zoom 16 -> tile zoom 12
         let index = make_scenery_index_for_region(50, 9, 16);
 
-        // Cache zoom 14 tiles (the OLD wrong behavior) instead of zoom 12.
-        // Built explicitly rather than via the removed geometric expansion —
-        // only the zoom mismatch matters here, not real geographic tiles.
-        let wrong_tiles = vec![TileCoord {
-            row: 999,
-            col: 999,
-            zoom: 14,
-        }];
+        // Cache the region's real tiles but at zoom 14 (the OLD wrong
+        // behavior) instead of zoom 12. Row and col are taken from the
+        // region's actual tile set so zoom is the only differing
+        // component — otherwise a zoom-insensitive presence check could
+        // pass this test for the wrong reason (row/col mismatch alone).
+        let region_tiles = index.tiles_in_region(region);
+        assert!(
+            !region_tiles.is_empty(),
+            "Precondition: index covers region (50, 9)"
+        );
+        let wrong_tiles: Vec<TileCoord> = region_tiles
+            .iter()
+            .map(|t| TileCoord { zoom: 14, ..*t })
+            .collect();
         let checker: Arc<dyn DdsDiskCacheChecker> =
             MockDiskChecker::with_tile_coords(wrong_tiles.into_iter());
 

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use crate::coord::TileCoord;
 use crate::executor::DdsDiskCacheChecker;
 use crate::geo_index::{DsfRegion, GeoIndex, PrefetchedRegion, RetainedRegion};
+use crate::ortho_union::OrthoUnionIndex;
 use crate::prefetch::tile_based::DsfTileCoord;
 use crate::prefetch::SceneryIndex;
 
@@ -55,6 +56,7 @@ impl BoundaryStrategy {
         region: DsfRegion,
         scenery_index: Option<&Arc<SceneryIndex>>,
         dds_disk_checker: Option<&Arc<dyn DdsDiskCacheChecker>>,
+        ortho_union_index: Option<&Arc<OrthoUnionIndex>>,
     ) -> RegionDiskState {
         let (Some(index), Some(checker)) = (scenery_index, dds_disk_checker) else {
             return RegionDiskState::Unknown;
@@ -63,17 +65,43 @@ impl BoundaryStrategy {
         if tiles.is_empty() {
             return RegionDiskState::NoTiles;
         }
-        // Short-circuits on first miss.
-        // Pass tile coords (not chunk_origin) — the DDS disk cache is keyed
-        // by `tile:{tile_zoom}:{tile_row}:{tile_col}`. Using chunk coords
-        // here silently returned false for every tile, preventing promotion.
+        // Short-circuits on first miss. A tile counts as covered if either
+        // the XEL DDS disk cache or an installed package already has it —
+        // see `tile_is_covered`.
         if tiles
             .iter()
-            .all(|t| checker.tile_exists_blocking(t.row, t.col, t.zoom))
+            .all(|t| Self::tile_is_covered(t, checker, ortho_union_index))
         {
             RegionDiskState::Complete
         } else {
             RegionDiskState::Incomplete
+        }
+    }
+
+    /// A tile counts as covered if EITHER source has it.
+    ///
+    /// This is the same disjunction the submit-side filter pipeline applies:
+    /// stage 3 (`filter_disk_tiles`) drops tiles that already exist as real
+    /// `.dds` files in an installed package, so prefetch never writes them to
+    /// the XEL DDS cache. Promotion must use the same definition or regions
+    /// covered by package-shipped imagery can never be confirmed.
+    fn tile_is_covered(
+        tile: &TileCoord,
+        checker: &Arc<dyn DdsDiskCacheChecker>,
+        ortho_union_index: Option<&Arc<OrthoUnionIndex>>,
+    ) -> bool {
+        // XEL DDS disk cache: keyed by TILE coords.
+        if checker.tile_exists_blocking(tile.row, tile.col, tile.zoom) {
+            return true;
+        }
+        // OrthoUnionIndex: keyed by CHUNK coords. Mixing these up silently
+        // returns false for every tile — see the #172 keying bug.
+        match ortho_union_index {
+            Some(ortho) => {
+                let (chunk_row, chunk_col, chunk_zoom) = tile.chunk_origin();
+                ortho.dds_tile_exists(chunk_row, chunk_col, chunk_zoom)
+            }
+            None => false,
         }
     }
 
@@ -121,6 +149,7 @@ impl BoundaryStrategy {
         geo_index: &GeoIndex,
         dds_disk_checker: Option<&Arc<dyn DdsDiskCacheChecker>>,
         scenery_index: Option<&Arc<SceneryIndex>>,
+        ortho_union_index: Option<&Arc<OrthoUnionIndex>>,
     ) -> usize {
         let in_progress: Vec<DsfRegion> = geo_index
             .iter::<PrefetchedRegion>()
@@ -131,7 +160,12 @@ impl BoundaryStrategy {
 
         let mut promoted = 0;
         for region in &in_progress {
-            match Self::region_disk_state(*region, scenery_index, dds_disk_checker) {
+            match Self::region_disk_state(
+                *region,
+                scenery_index,
+                dds_disk_checker,
+                ortho_union_index,
+            ) {
                 RegionDiskState::Complete => {
                     geo_index.insert::<PrefetchedRegion>(*region, PrefetchedRegion::prefetched());
                     promoted += 1;
@@ -326,8 +360,12 @@ mod tests {
         let checker: Arc<dyn DdsDiskCacheChecker> =
             MockDiskChecker::with_tile_coords(tiles.iter().copied());
 
-        let promoted =
-            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
+        let promoted = BoundaryStrategy::promote_completed_regions(
+            &geo_index,
+            Some(&checker),
+            Some(&index),
+            None,
+        );
         assert_eq!(promoted, 1);
 
         let state = geo_index.get::<PrefetchedRegion>(&region).unwrap();
@@ -365,8 +403,12 @@ mod tests {
         let checker: Arc<dyn DdsDiskCacheChecker> =
             MockDiskChecker::with_tile_coords(std::iter::once(tiles[0]));
 
-        let promoted =
-            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
+        let promoted = BoundaryStrategy::promote_completed_regions(
+            &geo_index,
+            Some(&checker),
+            Some(&index),
+            None,
+        );
         assert_eq!(promoted, 0);
 
         let state = geo_index.get::<PrefetchedRegion>(&region).unwrap();
@@ -382,7 +424,7 @@ mod tests {
         let region = DsfRegion::new(50, 9);
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
 
-        let promoted = BoundaryStrategy::promote_completed_regions(&geo_index, None, None);
+        let promoted = BoundaryStrategy::promote_completed_regions(&geo_index, None, None, None);
         assert_eq!(promoted, 0);
 
         let state = geo_index.get::<PrefetchedRegion>(&region).unwrap();
@@ -445,8 +487,12 @@ mod tests {
             MockDiskChecker::with_tile_coords(tiles.iter().copied());
 
         // Promote should work with SceneryIndex (not hardcoded zoom 14)
-        let promoted =
-            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
+        let promoted = BoundaryStrategy::promote_completed_regions(
+            &geo_index,
+            Some(&checker),
+            Some(&index),
+            None,
+        );
         assert_eq!(
             promoted, 1,
             "Should promote when all scenery index tiles are on disk"
@@ -478,8 +524,12 @@ mod tests {
             MockDiskChecker::with_tile_coords(wrong_tiles.into_iter());
 
         // Promote should NOT succeed — cached zoom 14, but index expects zoom 12
-        let promoted =
-            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
+        let promoted = BoundaryStrategy::promote_completed_regions(
+            &geo_index,
+            Some(&checker),
+            Some(&index),
+            None,
+        );
         assert_eq!(
             promoted, 0,
             "Should not promote when cached tiles are at wrong zoom level"
@@ -547,8 +597,12 @@ mod tests {
             zoom: 12,
         }]);
 
-        let promoted =
-            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
+        let promoted = BoundaryStrategy::promote_completed_regions(
+            &geo_index,
+            Some(&checker),
+            Some(&index),
+            None,
+        );
 
         assert_eq!(
             promoted, 1,
@@ -593,8 +647,12 @@ mod tests {
             zoom: 12,
         }]);
 
-        let promoted =
-            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
+        let promoted = BoundaryStrategy::promote_completed_regions(
+            &geo_index,
+            Some(&checker),
+            Some(&index),
+            None,
+        );
 
         assert_eq!(promoted, 0, "a missing in-region tile must block promotion");
         assert!(geo_index
@@ -612,7 +670,7 @@ mod tests {
         let index = make_scenery_index_for_region(50, 9, 16);
         let region = DsfRegion { lat: 50, lon: 9 };
         assert_eq!(
-            BoundaryStrategy::region_disk_state(region, Some(&index), None),
+            BoundaryStrategy::region_disk_state(region, Some(&index), None, None),
             RegionDiskState::Unknown,
             "no checker means we cannot tell — must not be reported as Incomplete"
         );
@@ -625,7 +683,7 @@ mod tests {
         // A region the index knows nothing about.
         let region = DsfRegion { lat: -40, lon: 170 };
         assert_eq!(
-            BoundaryStrategy::region_disk_state(region, Some(&index), Some(&checker)),
+            BoundaryStrategy::region_disk_state(region, Some(&index), Some(&checker), None),
             RegionDiskState::NoTiles
         );
     }
@@ -642,7 +700,12 @@ mod tests {
 
         let all: Vec<TileCoord> = tiles.clone();
         assert_eq!(
-            BoundaryStrategy::region_disk_state(region, Some(&index), Some(&test_checker(&all))),
+            BoundaryStrategy::region_disk_state(
+                region,
+                Some(&index),
+                Some(&test_checker(&all)),
+                None
+            ),
             RegionDiskState::Complete
         );
 
@@ -651,7 +714,91 @@ mod tests {
             BoundaryStrategy::region_disk_state(
                 region,
                 Some(&index),
-                Some(&test_checker(&all_but_one))
+                Some(&test_checker(&all_but_one)),
+                None
+            ),
+            RegionDiskState::Incomplete
+        );
+    }
+
+    // =========================================================================
+    // region_disk_state + OrthoUnionIndex coverage (#176 Task 2 / #223 F2)
+    // =========================================================================
+    //
+    // Prefetch deliberately never downloads tiles that already ship as real
+    // `.dds` files in installed scenery packages (stage-3 `filter_disk_tiles`
+    // in the submit-side filter pipeline). Promotion must recognise those
+    // tiles as covered too, or the region can never be confirmed and
+    // ratchets to `NoCoverage` over land — a false alarm.
+
+    /// Build an [`OrthoUnionIndex`] backed by real `.dds` files on disk,
+    /// named at the given CHUNK coordinates (row, col, zoom) — matching how
+    /// `dds_tile_exists` resolves `textures/{row}_{col}_{prefix}{zoom}.dds`.
+    ///
+    /// The backing `TempDir` is deliberately leaked so its files remain on
+    /// disk for the rest of the test process: `dds_tile_exists` stats the
+    /// real filesystem on every call (lazy resolution), so dropping the
+    /// directory would make every lookup silently miss.
+    fn make_ortho_index_with_chunk_tiles(
+        chunk_tiles: Vec<(u32, u32, u8)>,
+    ) -> Arc<crate::ortho_union::OrthoUnionIndex> {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(temp.path().join("textures")).unwrap();
+        for (row, col, zoom) in chunk_tiles {
+            let filename = format!("{row}_{col}_ZL{zoom}.dds");
+            std::fs::write(temp.path().join("textures").join(filename), b"dds content").unwrap();
+        }
+        let source = crate::ortho_union::OrthoSource::new_package("test", temp.path());
+        Box::leak(Box::new(temp));
+        Arc::new(crate::ortho_union::OrthoUnionIndex::with_sources(vec![
+            source,
+        ]))
+    }
+
+    #[test]
+    fn test_region_complete_when_tiles_ship_in_an_installed_package() {
+        // A region whose tiles are NOT in the XEL DDS cache but ARE present as
+        // real .dds files in an installed package. Prefetch correctly never
+        // submitted them (stage-3 disk filter), so promotion must still be able
+        // to confirm the region — otherwise it ratchets to NoCoverage over land.
+        let index = make_scenery_index_for_region(50, 9, 16);
+        let region = DsfRegion { lat: 50, lon: 9 };
+        let tiles = index.tiles_in_region(region);
+        assert!(!tiles.is_empty(), "fixture precondition");
+
+        let empty_xel_cache = test_checker(&[]);
+
+        // Seed the ortho index at CHUNK coordinates — dds_tile_exists takes
+        // chunk coords while tile_exists_blocking takes tile coords. If the
+        // implementation passes tile coords here the lookup silently misses and
+        // this test fails, which is the point.
+        let ortho = make_ortho_index_with_chunk_tiles(
+            tiles.iter().map(|t| t.chunk_origin()).collect::<Vec<_>>(),
+        );
+
+        assert_eq!(
+            BoundaryStrategy::region_disk_state(
+                region,
+                Some(&index),
+                Some(&empty_xel_cache),
+                Some(&ortho),
+            ),
+            RegionDiskState::Complete
+        );
+    }
+
+    #[test]
+    fn test_region_incomplete_when_neither_source_has_the_tile() {
+        // Guards the disjunction against becoming a tautology.
+        let index = make_scenery_index_for_region(50, 9, 16);
+        let region = DsfRegion { lat: 50, lon: 9 };
+        let ortho = make_ortho_index_with_chunk_tiles(vec![]);
+        assert_eq!(
+            BoundaryStrategy::region_disk_state(
+                region,
+                Some(&index),
+                Some(&test_checker(&[])),
+                Some(&ortho)
             ),
             RegionDiskState::Incomplete
         );

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -120,15 +120,14 @@ impl BoundaryStrategy {
         dds_disk_checker: Option<&Arc<dyn DdsDiskCacheChecker>>,
         scenery_index: Option<&Arc<SceneryIndex>>,
     ) -> usize {
-        let Some(checker) = dds_disk_checker else {
-            // Without an authoritative checker there is nothing to
-            // consult — skip promotion and let the rescue path handle
-            // stale regions. This preserves behaviour for tests that
-            // don't wire a checker.
+        let (Some(checker), Some(index)) = (dds_disk_checker, scenery_index) else {
+            // Without an authoritative checker there is nothing to consult,
+            // and without the scenery index there is no way to know which
+            // tiles the region should contain. Skip promotion; the rescue
+            // path handles stale regions.
             return 0;
         };
 
-        let strategy = BoundaryStrategy::new();
         let in_progress: Vec<DsfRegion> = geo_index
             .iter::<PrefetchedRegion>()
             .into_iter()
@@ -138,7 +137,7 @@ impl BoundaryStrategy {
 
         let mut promoted = 0;
         for region in &in_progress {
-            let tiles = Self::tiles_for_region(&strategy, region, scenery_index);
+            let tiles = index.tiles_in_region(*region);
             if tiles.is_empty() {
                 continue;
             }
@@ -410,23 +409,32 @@ mod tests {
 
     #[test]
     fn test_promote_completed_regions() {
+        // #176: promotion has no geometric fallback — it needs a
+        // SceneryIndex to know the region's tile set. Wire a minimal
+        // single-tile index rather than relying on `expand_to_tiles`.
         let geo_index = GeoIndex::new();
         let region = DsfRegion::new(50, 9);
 
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
 
-        // Get the tiles for this region at zoom 14
-        let strategy = BoundaryStrategy::new();
-        let tiles = strategy.expand_to_tiles(&region, 14);
-        assert!(!tiles.is_empty());
+        let index = Arc::new(SceneryIndex::with_defaults());
+        index.add_tile(SceneryTile {
+            row: 25000,
+            col: 10000,
+            chunk_zoom: 16,
+            lat: 50.5,
+            lon: 9.5,
+            is_sea: false,
+        });
+        let tiles = index.tiles_in_region(region);
+        assert_eq!(tiles.len(), 1);
 
         // Populate the mock disk checker with every tile's chunk coords.
         let checker: Arc<dyn DdsDiskCacheChecker> =
             MockDiskChecker::with_tile_coords(tiles.iter().copied());
 
-        // No scenery index — uses geometric fallback
         let promoted =
-            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), None);
+            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
         assert_eq!(promoted, 1);
 
         let state = geo_index.get::<PrefetchedRegion>(&region).unwrap();
@@ -440,17 +448,32 @@ mod tests {
 
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
 
-        // Get the tiles for this region at zoom 14
-        let strategy = BoundaryStrategy::new();
-        let tiles = strategy.expand_to_tiles(&region, 14);
-        assert!(tiles.len() > 1);
+        let index = Arc::new(SceneryIndex::with_defaults());
+        index.add_tile(SceneryTile {
+            row: 25000,
+            col: 10000,
+            chunk_zoom: 16,
+            lat: 50.2,
+            lon: 9.2,
+            is_sea: false,
+        });
+        index.add_tile(SceneryTile {
+            row: 26000,
+            col: 11000,
+            chunk_zoom: 16,
+            lat: 50.8,
+            lon: 9.8,
+            is_sea: false,
+        });
+        let tiles = index.tiles_in_region(region);
+        assert_eq!(tiles.len(), 2);
 
         // Mock checker knows only one tile → region is incomplete
         let checker: Arc<dyn DdsDiskCacheChecker> =
             MockDiskChecker::with_tile_coords(std::iter::once(tiles[0]));
 
         let promoted =
-            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), None);
+            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
         assert_eq!(promoted, 0);
 
         let state = geo_index.get::<PrefetchedRegion>(&region).unwrap();
@@ -617,6 +640,114 @@ mod tests {
 
         let state = geo_index.get::<PrefetchedRegion>(&region).unwrap();
         assert!(state.is_in_progress());
+    }
+
+    // =========================================================================
+    // Region tile-set SSOT regression tests (#176)
+    // =========================================================================
+
+    use crate::prefetch::scenery_index::SceneryTile;
+
+    /// Build a [`DdsDiskCacheChecker`] that reports only the listed tiles as
+    /// present on disk.
+    fn test_checker(tiles: &[TileCoord]) -> Arc<dyn DdsDiskCacheChecker> {
+        MockDiskChecker::with_tile_coords(tiles.iter().copied())
+    }
+
+    #[test]
+    fn test_promotion_not_blocked_by_missing_tile_in_adjacent_region() {
+        // Regression for #176 defect 1. The old implementation queried a 45nm
+        // radius around the region centre, which reaches ~15nm into the regions
+        // north and south. Promotion then demanded tiles that were never
+        // submitted for this region, so under a moving prefetch box the fast
+        // path could effectively never fire.
+        let index = Arc::new(SceneryIndex::with_defaults());
+        let region = DsfRegion::new(33, -119);
+
+        // One tile inside the region, cached.
+        index.add_tile(SceneryTile {
+            row: 1000,
+            col: 2000,
+            chunk_zoom: 16,
+            lat: 33.5,
+            lon: -118.5,
+            is_sea: false,
+        });
+        // One tile in the region immediately north, NOT cached. Well within
+        // 45nm of the +33-119 centre, so the old code demanded it.
+        index.add_tile(SceneryTile {
+            row: 3000,
+            col: 4000,
+            chunk_zoom: 16,
+            lat: 34.2,
+            lon: -118.5,
+            is_sea: false,
+        });
+
+        let geo_index = GeoIndex::new();
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+
+        // Checker knows only the in-region tile.
+        let checker = test_checker(&[TileCoord {
+            row: 1000 / 16,
+            col: 2000 / 16,
+            zoom: 12,
+        }]);
+
+        let promoted =
+            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
+
+        assert_eq!(
+            promoted, 1,
+            "the adjacent region's missing tile must not block promotion"
+        );
+        assert!(geo_index
+            .get::<PrefetchedRegion>(&region)
+            .unwrap()
+            .is_prefetched());
+    }
+
+    #[test]
+    fn test_promotion_blocked_by_missing_tile_inside_region() {
+        // The other half of the contract: a genuinely incomplete region must
+        // not be promoted.
+        let index = Arc::new(SceneryIndex::with_defaults());
+        let region = DsfRegion::new(33, -119);
+
+        index.add_tile(SceneryTile {
+            row: 1000,
+            col: 2000,
+            chunk_zoom: 16,
+            lat: 33.5,
+            lon: -118.5,
+            is_sea: false,
+        });
+        index.add_tile(SceneryTile {
+            row: 5000,
+            col: 6000,
+            chunk_zoom: 16,
+            lat: 33.7,
+            lon: -118.2,
+            is_sea: false,
+        });
+
+        let geo_index = GeoIndex::new();
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+
+        let checker = test_checker(&[TileCoord {
+            row: 1000 / 16,
+            col: 2000 / 16,
+            zoom: 12,
+        }]);
+
+        let promoted =
+            BoundaryStrategy::promote_completed_regions(&geo_index, Some(&checker), Some(&index));
+
+        assert_eq!(promoted, 0, "a missing in-region tile must block promotion");
+        assert!(geo_index
+            .get::<PrefetchedRegion>(&region)
+            .unwrap()
+            .is_in_progress());
     }
 
     // -------------------------------------------------------------------------

--- a/xearthlayer/src/prefetch/adaptive/config.rs
+++ b/xearthlayer/src/prefetch/adaptive/config.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 
 use crate::config::defaults::{
     DEFAULT_BOX_MAX_SPEED, DEFAULT_BOX_MIN_EXTENT, DEFAULT_BOX_MIN_SPEED,
+    DEFAULT_PREFETCH_STALE_REGION_TIMEOUT,
 };
 use crate::config::PrefetchSettings;
 use crate::service::PrefetchConfig;
@@ -143,7 +144,7 @@ impl Default for AdaptivePrefetchConfig {
             ramp_duration: Duration::from_secs(30),
             ramp_start_fraction: 0.25,
             window_buffer: 1,
-            stale_region_timeout: Duration::from_secs(120),
+            stale_region_timeout: Duration::from_secs(DEFAULT_PREFETCH_STALE_REGION_TIMEOUT),
             box_extent: 7.0,
             box_max_bias: 0.8,
             box_min_extent: DEFAULT_BOX_MIN_EXTENT,

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -11,6 +11,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::coord::TileCoord;
 use crate::executor::{DaemonMemoryCache, DdsClient, DdsDiskCacheChecker};
+use crate::metrics::MetricsClient;
 
 /// Maximum demotion attempts before marking a region as NoCoverage.
 const MAX_REGION_ATTEMPTS: u8 = 3;
@@ -191,6 +192,13 @@ pub struct AdaptivePrefetchCoordinator {
     ///
     /// Cleared after each [`execute()`] call (per-plan transient state).
     pub(super) current_plan_regions: std::collections::HashMap<TileCoord, DsfRegion>,
+
+    /// Metrics client for prefetch telemetry (#176).
+    ///
+    /// When set, `run_region_maintenance` reports the region-state
+    /// distribution each cycle so a default-level flight log carries the
+    /// 60s "Prefetch sample" line without needing `--debug`.
+    metrics_client: Option<MetricsClient>,
 }
 
 impl std::fmt::Debug for AdaptivePrefetchCoordinator {
@@ -240,6 +248,7 @@ impl AdaptivePrefetchCoordinator {
             dds_disk_checker: None,
             region_attempts: std::collections::HashMap::new(),
             current_plan_regions: std::collections::HashMap::new(),
+            metrics_client: None,
         }
     }
 
@@ -281,6 +290,12 @@ impl AdaptivePrefetchCoordinator {
     /// to discover actual installed zoom levels rather than assuming zoom 14.
     pub fn with_scenery_index(mut self, index: Arc<SceneryIndex>) -> Self {
         self.scenery_index = Some(index);
+        self
+    }
+
+    /// Attach a metrics client for prefetch telemetry.
+    pub fn with_metrics_client(mut self, client: MetricsClient) -> Self {
+        self.metrics_client = Some(client);
         self
     }
 
@@ -1009,6 +1024,10 @@ impl AdaptivePrefetchCoordinator {
             regions_nocoverage = no_coverage,
             "Region maintenance: state distribution"
         );
+
+        if let Some(ref metrics) = self.metrics_client {
+            metrics.prefetch_region_state(in_progress, prefetched, no_coverage);
+        }
     }
 
     /// Evaluate stale InProgress regions and decide: promote, demote, or NoCoverage.

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -332,15 +332,16 @@ impl AdaptivePrefetchCoordinator {
         self
     }
 
-    /// Get DDS tiles for a DSF region from the scenery index or geometric fallback.
+    /// Get DDS tiles for a DSF region from the scenery index.
     ///
     /// If a scenery index is available, queries it for tiles in the region.
     /// This returns tiles at whatever zoom levels are actually installed in the
     /// X-Plane scenery (e.g., ZL12 at cruise altitude), rather than assuming
     /// a fixed zoom level.
     ///
-    /// Falls back to the boundary strategy's geometric 4x4 grid expansion at
-    /// zoom 14 when no scenery index is available or has no tiles for the region.
+    /// There is no geometric fallback (#176): when no scenery index is
+    /// configured, or the index has no tiles for the region, this returns
+    /// empty and the caller marks the region NoCoverage.
     fn get_tiles_for_region(&self, region: &DsfRegion) -> Vec<TileCoord> {
         match self.scenery_index {
             // An empty result means the index knows of no ortho scenery
@@ -1849,6 +1850,11 @@ mod tests {
         // Regression for #176 defect 2. The rescue path sampled tiles.first()
         // and promoted the whole region on that single hit, which is how 61 of
         // 65 promotions were decided in the #172 LOWW log.
+        //
+        // Note: the `row`/`col` values in the `SceneryTile` fixtures in this
+        // test (and its positive counterpart below) are arbitrary and not
+        // geographically consistent with their `lat`/`lon` — only `lat`/`lon`
+        // drive region membership in `tiles_in_region`.
         use crate::prefetch::scenery_index::SceneryTile;
 
         let index = Arc::new(SceneryIndex::with_defaults());
@@ -1880,6 +1886,19 @@ mod tests {
             zoom: 12,
         }]);
 
+        // Precondition: the rescue path must actually be looking at the
+        // region's real tile set (2 tiles), not silently falling through to
+        // an empty result. Without this guard, gutting the rescue path's
+        // tile lookup to `Vec::new()` would make `tiles_on_disk` fall
+        // through to the `_ => false` arm, the region would demote instead
+        // of promote, and the assertion below would still pass — proving
+        // nothing about whether the real tile set was consulted.
+        assert_eq!(
+            index.tiles_in_region(region).len(),
+            2,
+            "Precondition: index must expose both region tiles for this test to be meaningful"
+        );
+
         let mut coord = AdaptivePrefetchCoordinator::with_defaults()
             .with_scenery_index(Arc::clone(&index))
             .with_geo_index(Arc::clone(&geo_index))
@@ -1892,6 +1911,71 @@ mod tests {
         assert!(
             state.is_none_or(|s| !s.is_prefetched()),
             "partial coverage must not be promoted by the rescue path"
+        );
+    }
+
+    #[test]
+    fn test_stale_rescue_promotes_when_full_coverage_on_disk() {
+        // Positive counterpart to `test_stale_rescue_requires_full_coverage_not_one_tile`.
+        // The rescue promote branch (evaluate_stale_regions, tiles_on_disk == true)
+        // had no positive test anywhere in the suite — only the demotion path was
+        // covered. Same fixture, but both tiles are present in the checker this time.
+        use crate::prefetch::scenery_index::SceneryTile;
+
+        let index = Arc::new(SceneryIndex::with_defaults());
+        index.add_tile(SceneryTile {
+            row: 1000,
+            col: 2000,
+            chunk_zoom: 16,
+            lat: 33.5,
+            lon: -118.5,
+            is_sea: false,
+        });
+        index.add_tile(SceneryTile {
+            row: 5000,
+            col: 6000,
+            chunk_zoom: 16,
+            lat: 33.7,
+            lon: -118.2,
+            is_sea: false,
+        });
+
+        let region = DsfRegion::new(33, -119);
+        let geo_index = Arc::new(GeoIndex::new());
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+
+        // Both tiles are on disk this time.
+        let checker = test_checker(&[
+            TileCoord {
+                row: 1000 / 16,
+                col: 2000 / 16,
+                zoom: 12,
+            },
+            TileCoord {
+                row: 5000 / 16,
+                col: 6000 / 16,
+                zoom: 12,
+            },
+        ]);
+
+        assert_eq!(
+            index.tiles_in_region(region).len(),
+            2,
+            "Precondition: index must expose both region tiles for this test to be meaningful"
+        );
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(checker);
+        coord.config.stale_region_timeout = std::time::Duration::ZERO; // everything is stale
+
+        coord.run_region_maintenance();
+
+        let state = geo_index.get::<PrefetchedRegion>(&region);
+        assert!(
+            state.is_some_and(|s| s.is_prefetched()),
+            "full coverage on disk must be promoted by the rescue path"
         );
     }
 
@@ -2607,11 +2691,12 @@ mod tests {
         let plan = plan.unwrap();
 
         // Box at (48, 15) heading 270° with default extent covers dozens
-        // of DSF regions. With ~16 tiles per region (geometric fallback),
-        // plan size should be in the hundreds — clearly above the 5-cap
-        // the old code would have imposed. The exact number depends on
-        // box extent & region tile count; assert ">> 5" to prove the
-        // cap is not being applied.
+        // of DSF regions. With ~16 tiles per region (the 4x4 sample density
+        // of the wired `wide_scenery_index_at_48_15` fixture), plan size
+        // should be in the hundreds — clearly above the 5-cap the old code
+        // would have imposed. The exact number depends on box extent &
+        // region tile count; assert ">> 5" to prove the cap is not being
+        // applied.
         assert!(
             plan.tiles.len() > 20,
             "Plan must contain many more than max_tiles_per_cycle=5 tiles — \
@@ -2833,6 +2918,15 @@ mod tests {
             count_in_progress_regions(&geo_index),
             0,
             "No regions should be marked InProgress when the entire plan is deferred",
+        );
+        // Prove a real plan existed rather than `submitted == 0` and
+        // `in_progress == 0` both being trivially true of an empty plan
+        // (e.g. if the scenery index wiring silently broke). HighLoadDdsClient
+        // stores the whole deferred plan as pending, so a non-empty
+        // `pending_tiles` is direct evidence tiles were actually planned.
+        assert!(
+            !coord.pending_tiles.is_empty(),
+            "A real plan must have been generated and deferred, not an empty one"
         );
     }
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -1068,12 +1068,24 @@ impl AdaptivePrefetchCoordinator {
         // failed to track ~94% of actually-cached tiles in production,
         // leaving the rescue path (evaluate_stale_regions) to carry
         // the work.
-        BoundaryStrategy::promote_completed_regions(
+        let promoted = BoundaryStrategy::promote_completed_regions(
             &geo_index,
             self.dds_disk_checker.as_ref(),
             self.scenery_index.as_ref(),
             self.ortho_union_index.as_ref(),
         );
+        if !promoted.is_empty() {
+            // A promoted region's failure history belongs to the episode that
+            // failed, not to the region. Without this, a region that recovers and
+            // is later demoted by the FUSE observer can be retired to NoCoverage
+            // after a single fresh failure.
+            for region in &promoted {
+                self.region_attempts.remove(region);
+            }
+            if let Some(ref metrics) = self.metrics_client {
+                metrics.prefetch_regions_promoted_normal(promoted.len());
+            }
+        }
         // Evict PrefetchedRegion entries for regions outside the retained window,
         // making them eligible for re-prefetch when the aircraft returns.
         BoundaryStrategy::evict_non_retained(&geo_index);
@@ -1144,6 +1156,12 @@ impl AdaptivePrefetchCoordinator {
                 RegionDiskState::Complete => {
                     // Tiles generated successfully — promote despite lost cached_tiles tracking
                     geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
+                    // See the fast-path promotion comment in `run_region_maintenance`:
+                    // the strike count belongs to the failed episode, not the region.
+                    self.region_attempts.remove(&region);
+                    if let Some(ref metrics) = self.metrics_client {
+                        metrics.prefetch_region_promoted_rescue();
+                    }
                     tracing::info!(
                         lat = region.lat,
                         lon = region.lon,
@@ -1169,7 +1187,17 @@ impl AdaptivePrefetchCoordinator {
                             MAX_REGION_ATTEMPTS
                         );
                     } else {
-                        // Remove from GeoIndex to allow retry on next cycle
+                        // Remove from GeoIndex to allow retry on next cycle.
+                        //
+                        // Do NOT clear `region_attempts` here. This removal is
+                        // deliberate — it makes the region eligible for
+                        // re-prefetching — and `region_attempts` is the only
+                        // thing that remembers the strike across it. Clearing
+                        // on this branch (by symmetry with the promote branch
+                        // above) would make `MAX_REGION_ATTEMPTS` unreachable:
+                        // every retry would start the count over, and a region
+                        // that never succeeds would retry forever instead of
+                        // eventually being retired to `NoCoverage`.
                         geo_index.remove::<PrefetchedRegion>(&region);
                         tracing::info!(
                             lat = region.lat,
@@ -2114,6 +2142,156 @@ mod tests {
         assert!(
             !coord.region_attempts.contains_key(&region),
             "an unanswerable check must not consume a retry"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Strike count lifecycle + promotion metrics (#176 Task 4 / F1 + F17)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_promotion_clears_stale_attempt_count() {
+        // Two early failures, then a successful promotion, then one fresh
+        // failure must NOT retire the region: the strike count belongs to the
+        // failed episode, not to the region forever.
+        let index = make_scenery_index(50, 9, 16);
+        let region = DsfRegion::new(50, 9);
+        let tiles = index.tiles_in_region(region);
+        assert!(
+            !tiles.is_empty(),
+            "Precondition: index covers region (50,9)"
+        );
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let empty_checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(std::iter::empty::<TileCoord>());
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(Arc::clone(&empty_checker));
+
+        // Phase 1: checker empty, region InProgress, stale -> 2 strikes.
+        coord.config.stale_region_timeout = std::time::Duration::ZERO;
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
+        assert_eq!(
+            coord.region_attempts.get(&region),
+            Some(&1),
+            "Precondition: first stale failure recorded"
+        );
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
+        assert_eq!(
+            coord.region_attempts.get(&region),
+            Some(&2),
+            "Precondition: second stale failure recorded (below MAX_REGION_ATTEMPTS)"
+        );
+
+        // Phase 2: checker seeded with the region's tiles -> promote via the
+        // fast path (large timeout so the region is not picked up as stale).
+        let full_checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(tiles.iter().copied());
+        coord.dds_disk_checker = Some(full_checker);
+        coord.config.stale_region_timeout = std::time::Duration::from_secs(600);
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.run_region_maintenance();
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region)
+                .is_some_and(|s| s.is_prefetched()),
+            "Precondition: region promoted via the fast path"
+        );
+        assert!(
+            !coord.region_attempts.contains_key(&region),
+            "Promotion must clear the strike count from the failed episode"
+        );
+
+        // Phase 3: checker emptied, region re-marked InProgress, stale once.
+        coord.dds_disk_checker = Some(empty_checker);
+        coord.config.stale_region_timeout = std::time::Duration::ZERO;
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
+
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region)
+                .map(|s| !s.is_no_coverage())
+                .unwrap_or(true),
+            "one fresh failure after a successful promotion must not retire the region"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_normal_and_rescue_promotions_are_counted_separately() {
+        use crate::metrics::MetricEvent;
+
+        let index = make_scenery_index_covering(49..=50, 9..=9, 16);
+        let region_rescue = DsfRegion::new(49, 9);
+        let region_normal = DsfRegion::new(50, 9);
+        let tiles_rescue = index.tiles_in_region(region_rescue);
+        let tiles_normal = index.tiles_in_region(region_normal);
+        assert!(
+            !tiles_rescue.is_empty(),
+            "Precondition: rescue region covered"
+        );
+        assert!(
+            !tiles_normal.is_empty(),
+            "Precondition: normal region covered"
+        );
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let checker: Arc<dyn DdsDiskCacheChecker> = MockDiskChecker::with_tile_coords(
+            tiles_rescue.iter().chain(tiles_normal.iter()).copied(),
+        );
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let metrics = MetricsClient::new(tx);
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(checker)
+            .with_metrics_client(metrics);
+
+        // Drive one rescue-path promotion: the region is stale, and the
+        // rescue path (`evaluate_stale_regions`) finds full coverage.
+        coord.config.stale_region_timeout = std::time::Duration::ZERO;
+        geo_index.insert::<PrefetchedRegion>(region_rescue, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region_rescue)
+                .is_some_and(|s| s.is_prefetched()),
+            "Precondition: rescue path promoted the region"
+        );
+
+        // Drive one fast-path promotion: large timeout so the region is not
+        // stale, and `promote_completed_regions` (run unconditionally by
+        // `run_region_maintenance`) finds full coverage.
+        coord.config.stale_region_timeout = std::time::Duration::from_secs(600);
+        geo_index.insert::<PrefetchedRegion>(region_normal, PrefetchedRegion::in_progress());
+        coord.run_region_maintenance();
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region_normal)
+                .is_some_and(|s| s.is_prefetched()),
+            "Precondition: fast path promoted the region"
+        );
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                MetricEvent::PrefetchRegionsPromotedNormal { count } if *count >= 1
+            )),
+            "fast-path promotion must emit a normal-path count"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::PrefetchRegionPromotedRescue)),
+            "rescue-path promotion must emit a rescue count"
         );
     }
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -775,13 +775,6 @@ impl AdaptivePrefetchCoordinator {
         &self.phase_detector
     }
 
-    /// Reset the coordinator state.
-    ///
-    /// Call this when teleporting or starting a new flight.
-    pub fn reset(&mut self) {
-        self.status = CoordinatorStatus::default();
-    }
-
     // ─────────────────────────────────────────────────────────────────────────
     // Internal helpers
     // ─────────────────────────────────────────────────────────────────────────

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -1270,9 +1270,9 @@ mod tests {
     use super::*;
     use crate::prefetch::adaptive::coordinator::test_support::{
         ground_state, make_scenery_index, make_scenery_index_covering, patched_region_area,
-        test_calibration, test_plan, AlwaysHitDiskChecker, AlwaysMissMemoryCache,
-        BackpressureMockClient, CapLimitedDdsClient, DummyTracker, HighLoadDdsClient,
-        MockDiskChecker, StableBoundsTracker,
+        test_calibration, test_plan, AlwaysHitDiskChecker, AlwaysHitMemoryCache,
+        AlwaysMissMemoryCache, BackpressureMockClient, CapLimitedDdsClient, DummyTracker,
+        HighLoadDdsClient, MockDiskChecker, StableBoundsTracker,
     };
     // ─────────────────────────────────────────────────────────────────────────
     // Creation tests
@@ -1944,11 +1944,18 @@ mod tests {
     }
 
     #[test]
-    fn test_region_with_no_indexed_tiles_is_marked_no_coverage() {
+    fn test_get_tiles_for_region_empty_for_unindexed_region() {
         // Removing the geometric fallback means an empty index result is a
         // statement — "no ortho scenery here" — rather than a cue to guess 16
-        // tiles at zoom 14. The submit loop must mark the region NoCoverage and
-        // submit nothing.
+        // tiles at zoom 14.
+        //
+        // NOTE: despite this test's prior name
+        // (`test_region_with_no_indexed_tiles_is_marked_no_coverage`), it only
+        // ever exercised `get_tiles_for_region` directly — no `GeoIndex` is
+        // wired, no planning cycle runs, and no `PrefetchedRegion` state is
+        // ever read. It does not, and never did, verify the NoCoverage
+        // marking. See `test_no_coverage_region_marked_and_nothing_submitted`
+        // below for a real test of that behaviour.
         use crate::prefetch::scenery_index::SceneryTile;
 
         let index = Arc::new(SceneryIndex::with_defaults());
@@ -1975,6 +1982,73 @@ mod tests {
         assert_eq!(
             coord.get_tiles_for_region(&DsfRegion::new(33, -119)).len(),
             1
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // NoCoverage marking on the planning path (#223 remediation, F5)
+    //
+    // `test_get_tiles_for_region_empty_for_unindexed_region` above only
+    // proves `get_tiles_for_region` returns empty for an unindexed region —
+    // it never runs a planning cycle and never reads `PrefetchedRegion`
+    // state, so the production marking at the `if tiles.is_empty()` branch
+    // in `update()` (which calls `BoundaryStrategy::mark_no_coverage`) was
+    // unverified: deleting that branch left the whole suite green.
+    //
+    // This test wires a real `GeoIndex` and a scenery index with zero
+    // coverage anywhere in the prefetch box, runs a full planning cycle via
+    // `process_telemetry`, and asserts both halves of the contract: the
+    // touched regions carry `PrefetchedRegion::no_coverage()`, and nothing
+    // reached the DDS client.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_no_coverage_region_marked_and_nothing_submitted() {
+        use crate::geo_index::{GeoIndex, PrefetchedRegion};
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let client = Arc::new(CapLimitedDdsClient::new(100_000));
+        // Zero tiles anywhere — every region the prefetch box touches must
+        // report no coverage.
+        let empty_index = Arc::new(SceneryIndex::with_defaults());
+
+        let config = AdaptivePrefetchConfig {
+            mode: PrefetchMode::Aggressive,
+            ramp_duration: std::time::Duration::from_secs(0),
+            ..Default::default()
+        };
+        let mut coord = AdaptivePrefetchCoordinator::new(config)
+            .with_calibration(test_calibration())
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
+            .with_scenery_index(empty_index);
+
+        fast_forward_to_cruise(&mut coord);
+        assert_eq!(coord.phase_detector.current_phase(), FlightPhase::Cruise);
+
+        let state = AircraftState::new(50.0, 10.0, 0.0, 200.0, 35000.0, false);
+        let submitted = coord.process_telemetry(&state).await;
+
+        assert_eq!(
+            submitted.unwrap_or(0),
+            0,
+            "A scenery index with no coverage anywhere must yield no submissions",
+        );
+        assert_eq!(
+            client.submitted_count(),
+            0,
+            "No tiles should ever reach the DDS client when there is no coverage",
+        );
+
+        let no_coverage_regions: Vec<_> = geo_index
+            .iter::<PrefetchedRegion>()
+            .into_iter()
+            .filter(|(_, r)| r.is_no_coverage())
+            .collect();
+        assert!(
+            !no_coverage_regions.is_empty(),
+            "Regions the prefetch box touched with zero scenery coverage must be \
+             marked NoCoverage, not left unmarked to be re-planned every cycle",
         );
     }
 
@@ -3467,6 +3541,93 @@ mod tests {
             count_prefetched_regions(&geo_index) > 0,
             "A region whose tiles are all already cached must reach Prefetched, \
              not sit unmarked and be re-planned forever",
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Two-phase commit boundary (#223 remediation, F6)
+    //
+    // `test_fully_cached_region_reaches_prefetched` above uses
+    // `AlwaysHitDiskChecker` as BOTH the filter authority (stage 4 of the
+    // filter pipeline, which empties the plan and triggers
+    // `mark_fully_filtered_regions`) AND the promotion authority
+    // (`promote_completed_regions`, consulted by `run_region_maintenance`).
+    // With one mock playing both roles, that test cannot distinguish a
+    // disk-verified promotion from the filter's say-so — replacing
+    // `mark_in_progress` in `mark_fully_filtered_regions` with a direct
+    // `PrefetchedRegion::prefetched()` insert leaves it green.
+    //
+    // This test empties the plan via the MEMORY CACHE filter stage (stage 1)
+    // instead, using `AlwaysHitMemoryCache`, while wiring a DDS disk checker
+    // that reports every tile ABSENT. If promotion were driven by the
+    // filter's say-so rather than a real disk check, the region would reach
+    // Prefetched here too. It must not: the region should land in
+    // InProgress and stay there, including across a subsequent maintenance
+    // pass with no new telemetry.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_filtered_region_stays_in_progress_without_disk_confirmation() {
+        use crate::executor::DaemonMemoryCache;
+        use crate::geo_index::GeoIndex;
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let client = Arc::new(CapLimitedDdsClient::new(100_000));
+        // Memory cache reports every tile as already cached — this is what
+        // empties the plan and fires `mark_fully_filtered_regions`. It is
+        // NOT the disk checker, so this test is independent of the disk
+        // check's answer.
+        let always_hit_memory: Arc<dyn DaemonMemoryCache> = Arc::new(AlwaysHitMemoryCache);
+        // Disk checker (the promotion authority) reports every tile absent.
+        let checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(std::iter::empty::<TileCoord>());
+
+        let config = AdaptivePrefetchConfig {
+            mode: PrefetchMode::Aggressive,
+            ramp_duration: std::time::Duration::from_secs(0),
+            ..Default::default()
+        };
+        let mut coord = AdaptivePrefetchCoordinator::new(config)
+            .with_calibration(test_calibration())
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
+            .with_memory_cache(always_hit_memory)
+            .with_dds_disk_checker(Arc::clone(&checker))
+            .with_scenery_index(wide_scenery_index_at_50_10());
+
+        fast_forward_to_cruise(&mut coord);
+        assert_eq!(coord.phase_detector.current_phase(), FlightPhase::Cruise);
+
+        let state = AircraftState::new(50.0, 10.0, 0.0, 200.0, 35000.0, false);
+
+        let submitted = coord.process_telemetry(&state).await.unwrap_or(0);
+        assert_eq!(
+            submitted, 0,
+            "Precondition: the memory-cache filter must empty the whole plan",
+        );
+        assert!(
+            count_in_progress_regions(&geo_index) > 0,
+            "A fully-filtered region must still be marked InProgress",
+        );
+        assert_eq!(
+            count_prefetched_regions(&geo_index),
+            0,
+            "Without a disk-verified full-coverage check, the region must NOT \
+             reach Prefetched — reaching it here would mean promotion trusts \
+             the filter's say-so instead of the authoritative disk checker",
+        );
+
+        // A subsequent maintenance pass (another cycle, no new coverage on
+        // disk) must not promote it either.
+        coord.process_telemetry(&state).await;
+        assert_eq!(
+            count_prefetched_regions(&geo_index),
+            0,
+            "Region must still not be Prefetched after a subsequent maintenance pass",
+        );
+        assert!(
+            count_in_progress_regions(&geo_index) > 0,
+            "Region should remain InProgress, not be silently dropped",
         );
     }
 }

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -208,6 +208,7 @@ impl std::fmt::Debug for AdaptivePrefetchCoordinator {
             .field("config.mode", &self.config.mode)
             .field("has_calibration", &self.calibration.is_some())
             .field("has_dds_client", &self.dds_client.is_some())
+            .field("has_metrics_client", &self.metrics_client.is_some())
             .field("cached_tiles_count", &self.cached_tiles.len())
             .field("status", &self.status)
             .finish()

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -15,7 +15,7 @@ use crate::metrics::MetricsClient;
 
 /// Maximum demotion attempts before marking a region as NoCoverage.
 const MAX_REGION_ATTEMPTS: u8 = 3;
-use crate::geo_index::{DsfRegion, GeoIndex, PrefetchedRegion};
+use crate::geo_index::{DsfRegion, GeoIndex, PatchCoverage, PrefetchedRegion};
 use crate::ortho_union::OrthoUnionIndex;
 use crate::prefetch::state::{AircraftState, SharedPrefetchStatus};
 use crate::prefetch::SceneryIndex;
@@ -703,6 +703,76 @@ impl AdaptivePrefetchCoordinator {
         tiles_submitted
     }
 
+    /// Mark every region whose planned tiles were *all* removed by the
+    /// filter pipeline as `InProgress`.
+    ///
+    /// `surviving` is the plan's tile list after filtering. A region with no
+    /// surviving tile contributes nothing to submission, so [`execute()`]'s
+    /// mark-after-submit never sees it; and if that is true of every region,
+    /// the plan is empty and [`execute()`] is not called at all. Either way
+    /// the region would stay unmarked and be re-planned on every cycle.
+    ///
+    /// `InProgress` rather than `Prefetched` is deliberate. The filter says
+    /// the tiles looked cached at plan time; that is not proof they are on
+    /// the DDS disk. `BoundaryStrategy::promote_completed_regions` re-checks
+    /// every tile in the region against the authoritative disk cache during
+    /// the maintenance pass at the end of this same cycle, and only then
+    /// confirms `Prefetched`. If the check fails the region simply stays
+    /// `InProgress` until `evaluate_stale_regions` retires or retries it.
+    ///
+    /// Patch-owned regions are excluded. Their tiles filter out in full at
+    /// the `PatchCoverage` stage, but prefetch will never put those tiles on
+    /// the DDS disk — X-Plane is served them by the patch through FUSE
+    /// passthrough. Marking one `InProgress` would be a claim prefetch is
+    /// working on it, which `promote_completed_regions` could never confirm;
+    /// the region would go stale and be retired to `NoCoverage` with a
+    /// misleading "failed attempts" warning in the flight log. Patch
+    /// ownership is a whole-region property in the `GeoIndex`, so this
+    /// exclusion is exact rather than a heuristic. Such regions keep being
+    /// re-planned and filtered each cycle, as they were before this change.
+    ///
+    /// Marked regions are dropped from `current_plan_regions` so
+    /// [`execute()`] only reasons about regions that had tiles to submit.
+    ///
+    /// Returns the number of regions marked.
+    fn mark_fully_filtered_regions(&mut self, surviving: &[TileCoord]) -> usize {
+        if self.current_plan_regions.is_empty() {
+            return 0;
+        }
+        let Some(geo_index) = self.geo_index.clone() else {
+            return 0;
+        };
+
+        let surviving_regions: HashSet<DsfRegion> = surviving
+            .iter()
+            .filter_map(|tile| self.current_plan_regions.get(tile).copied())
+            .collect();
+
+        let fully_filtered: HashSet<DsfRegion> = self
+            .current_plan_regions
+            .values()
+            .copied()
+            .filter(|region| !surviving_regions.contains(region))
+            .filter(|region| !geo_index.contains::<PatchCoverage>(region))
+            .collect();
+
+        if fully_filtered.is_empty() {
+            return 0;
+        }
+
+        for region in &fully_filtered {
+            self.boundary_strategy.mark_in_progress(region, &geo_index);
+        }
+        self.current_plan_regions
+            .retain(|_, region| !fully_filtered.contains(region));
+
+        tracing::debug!(
+            regions_marked = fully_filtered.len(),
+            "Prefetch: marked fully-filtered regions InProgress for disk-verified promotion"
+        );
+        fully_filtered.len()
+    }
+
     /// Mark tiles as cached (to avoid re-prefetching).
     pub fn mark_cached(&mut self, tiles: impl IntoIterator<Item = TileCoord>) {
         self.cached_tiles.extend(tiles);
@@ -935,6 +1005,15 @@ impl AdaptivePrefetchCoordinator {
             "Prefetch plan filter pipeline summary"
         );
 
+        // Regions whose entire planned tile set was filtered out submit
+        // nothing, so `execute()`'s mark-after-submit can never fire for
+        // them — and when *every* region is in that state the plan is empty
+        // and `execute()` is skipped outright. Left unmarked, the region
+        // stays absent from `PrefetchedRegion`, re-enters
+        // `new_regions_with_shape` on the next 2s cycle, and repeats forever
+        // while `regions_prefetched` under-reports. See #176.
+        self.mark_fully_filtered_regions(&plan.tiles);
+
         let submitted = if plan.is_empty() {
             0
         } else {
@@ -1157,8 +1236,9 @@ mod tests {
     use super::*;
     use crate::prefetch::adaptive::coordinator::test_support::{
         ground_state, make_scenery_index, make_scenery_index_covering, patched_region_area,
-        test_calibration, test_plan, AlwaysMissMemoryCache, BackpressureMockClient,
-        CapLimitedDdsClient, DummyTracker, HighLoadDdsClient, MockDiskChecker, StableBoundsTracker,
+        test_calibration, test_plan, AlwaysHitDiskChecker, AlwaysMissMemoryCache,
+        BackpressureMockClient, CapLimitedDdsClient, DummyTracker, HighLoadDdsClient,
+        MockDiskChecker, StableBoundsTracker,
     };
     // ─────────────────────────────────────────────────────────────────────────
     // Creation tests
@@ -3098,6 +3178,78 @@ mod tests {
         assert!(
             count_in_progress_regions(&geo_index) > 0,
             "Regions with all tiles submitted must be marked InProgress",
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Fully-filtered regions must still reach Prefetched (#176)
+    //
+    // `execute()` is skipped when the filtered plan is empty, and
+    // `mark_in_progress` only ever fired inside `execute()`. A region whose
+    // planned tiles all filter out as already-cached was therefore marked
+    // nothing at all: absent from PrefetchedRegion, so it re-entered
+    // `new_regions_with_shape` every 2s cycle and could never return to
+    // `Prefetched`.
+    //
+    // This branch is routine on this branch, not exotic: the #176 observer
+    // demotes a settled region on one on-demand FUSE generation, FUSE then
+    // re-caches that tile, and the next cycle re-plans a region in which
+    // every tile is cached. `regions_prefetched` — one of the numbers the
+    // flight test reads off the 60s Prefetch sample — would permanently
+    // under-report.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    fn count_prefetched_regions(geo_index: &crate::geo_index::GeoIndex) -> usize {
+        use crate::geo_index::PrefetchedRegion;
+        geo_index
+            .iter::<PrefetchedRegion>()
+            .into_iter()
+            .filter(|(_, r)| r.is_prefetched())
+            .count()
+    }
+
+    #[tokio::test]
+    async fn test_fully_cached_region_reaches_prefetched() {
+        use crate::geo_index::GeoIndex;
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let client = Arc::new(CapLimitedDdsClient::new(100_000));
+        // Every tile is already on the DDS disk. The filter pipeline empties
+        // the plan, so nothing is submitted — and the same checker is what
+        // `promote_completed_regions` consults, so the promotion is a real
+        // disk-verified full-coverage check, not the filter's say-so.
+        let checker: Arc<dyn DdsDiskCacheChecker> = Arc::new(AlwaysHitDiskChecker);
+
+        let config = AdaptivePrefetchConfig {
+            mode: PrefetchMode::Aggressive,
+            ramp_duration: std::time::Duration::from_secs(0),
+            ..Default::default()
+        };
+        let mut coord = AdaptivePrefetchCoordinator::new(config)
+            .with_calibration(test_calibration())
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
+            .with_dds_disk_checker(Arc::clone(&checker))
+            .with_scenery_index(wide_scenery_index_at_50_10());
+
+        fast_forward_to_cruise(&mut coord);
+        assert_eq!(coord.phase_detector.current_phase(), FlightPhase::Cruise);
+
+        let state = AircraftState::new(50.0, 10.0, 0.0, 200.0, 35000.0, false);
+
+        // Two cycles: the fix marks InProgress in the first and
+        // `promote_completed_regions` confirms it on a maintenance pass.
+        let submitted = coord.process_telemetry(&state).await.unwrap_or(0);
+        assert_eq!(
+            submitted, 0,
+            "Precondition: with every tile on disk the whole plan must filter out",
+        );
+        coord.process_telemetry(&state).await;
+
+        assert!(
+            count_prefetched_regions(&geo_index) > 0,
+            "A region whose tiles are all already cached must reach Prefetched, \
+             not sit unmarked and be re-planned forever",
         );
     }
 }

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -113,13 +113,6 @@ pub struct AdaptivePrefetchCoordinator {
     /// that are already cached, avoiding unnecessary job submissions.
     pub(super) memory_cache: Option<Arc<dyn DaemonMemoryCache>>,
 
-    /// Tiles currently in cache (for filtering).
-    ///
-    /// Note: This is a fallback for when memory_cache is not available.
-    /// When memory_cache is set, this set is only used for tiles we've
-    /// submitted in the current session (as a fast local cache).
-    pub(super) cached_tiles: HashSet<TileCoord>,
-
     /// Current status.
     pub(super) status: CoordinatorStatus,
 
@@ -209,7 +202,6 @@ impl std::fmt::Debug for AdaptivePrefetchCoordinator {
             .field("has_calibration", &self.calibration.is_some())
             .field("has_dds_client", &self.dds_client.is_some())
             .field("has_metrics_client", &self.metrics_client.is_some())
-            .field("cached_tiles_count", &self.cached_tiles.len())
             .field("status", &self.status)
             .finish()
     }
@@ -232,7 +224,6 @@ impl AdaptivePrefetchCoordinator {
             sim_state: crate::aircraft_position::web_api::sim_state::SimState::default(),
             dds_client: None,
             memory_cache: None,
-            cached_tiles: HashSet::new(),
             status: CoordinatorStatus::default(),
             shared_status: None,
             total_cycles: 0,
@@ -774,16 +765,6 @@ impl AdaptivePrefetchCoordinator {
         fully_filtered.len()
     }
 
-    /// Mark tiles as cached (to avoid re-prefetching).
-    pub fn mark_cached(&mut self, tiles: impl IntoIterator<Item = TileCoord>) {
-        self.cached_tiles.extend(tiles);
-    }
-
-    /// Clear cached tile tracking.
-    pub fn clear_cache_tracking(&mut self) {
-        self.cached_tiles.clear();
-    }
-
     /// Get current status for UI/logging.
     pub fn status(&self) -> &CoordinatorStatus {
         &self.status
@@ -798,7 +779,6 @@ impl AdaptivePrefetchCoordinator {
     ///
     /// Call this when teleporting or starting a new flight.
     pub fn reset(&mut self) {
-        self.cached_tiles.clear();
         self.status = CoordinatorStatus::default();
     }
 
@@ -905,7 +885,6 @@ impl AdaptivePrefetchCoordinator {
             let (filtered_pending, filter_counts) = super::filtering::run_filter_pipeline(
                 pending,
                 self.memory_cache.as_deref(),
-                &mut self.cached_tiles,
                 self.geo_index.as_ref(),
                 self.ortho_union_index.as_ref(),
                 self.dds_disk_checker.as_ref(),
@@ -951,10 +930,6 @@ impl AdaptivePrefetchCoordinator {
             let cancellation = CancellationToken::new();
             let submitted = self.execute(&plan, cancellation);
 
-            if submitted > 0 {
-                self.mark_cached(plan.tiles.iter().take(submitted).cloned());
-            }
-
             self.total_cycles += 1;
             self.total_tiles_submitted += submitted as u64;
             self.total_cache_hits += filtered_total as u64;
@@ -985,7 +960,6 @@ impl AdaptivePrefetchCoordinator {
         let (filtered_tiles, filter_counts) = super::filtering::run_filter_pipeline(
             std::mem::take(&mut plan.tiles),
             self.memory_cache.as_deref(),
-            &mut self.cached_tiles,
             self.geo_index.as_ref(),
             self.ortho_union_index.as_ref(),
             self.dds_disk_checker.as_ref(),
@@ -1021,11 +995,6 @@ impl AdaptivePrefetchCoordinator {
             let cancellation = CancellationToken::new();
             self.execute(&plan, cancellation)
         };
-
-        // Mark submitted tiles as cached to avoid re-submitting
-        if submitted > 0 {
-            self.mark_cached(plan.tiles.iter().cloned());
-        }
 
         // Update statistics
         self.total_cycles += 1;
@@ -1063,11 +1032,12 @@ impl AdaptivePrefetchCoordinator {
         // without checking whether tiles had actually been generated.
         self.evaluate_stale_regions(&geo_index);
 
-        // Consult the authoritative DDS disk cache rather than the
-        // `cached_tiles` shadow HashSet. See #172 Part 3: the shadow
-        // failed to track ~94% of actually-cached tiles in production,
-        // leaving the rescue path (evaluate_stale_regions) to carry
-        // the work.
+        // Consult the authoritative DDS disk cache rather than a local
+        // shadow of "tiles we believe are cached". See #172 Part 3: a
+        // prior `HashSet` shadow failed to track ~94% of actually-cached
+        // tiles in production, leaving the rescue path
+        // (evaluate_stale_regions) to carry the work. The shadow itself
+        // was deleted in #176 once it was confirmed write-only.
         let promoted = BoundaryStrategy::promote_completed_regions(
             &geo_index,
             self.dds_disk_checker.as_ref(),
@@ -1089,9 +1059,6 @@ impl AdaptivePrefetchCoordinator {
         // Evict PrefetchedRegion entries for regions outside the retained window,
         // making them eligible for re-prefetch when the aircraft returns.
         BoundaryStrategy::evict_non_retained(&geo_index);
-        // Evict cached_tiles entries for tiles outside the retained window,
-        // allowing re-query of the memory cache for those tiles.
-        BoundaryStrategy::evict_cached_tiles_outside_retained(&mut self.cached_tiles, &geo_index);
 
         // Per-maintenance-cycle instrumentation (#172 Part 4): report
         // region-state distribution. A healthy system shows normal-path
@@ -1154,7 +1121,9 @@ impl AdaptivePrefetchCoordinator {
                 self.ortho_union_index.as_ref(),
             ) {
                 RegionDiskState::Complete => {
-                    // Tiles generated successfully — promote despite lost cached_tiles tracking
+                    // Tiles generated successfully — promote based on the
+                    // authoritative disk check (this is the rescue path;
+                    // the fast path never had reliable tracking to lose).
                     geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
                     // See the fast-path promotion comment in `run_region_maintenance`:
                     // the strike count belongs to the failed episode, not the region.
@@ -1271,8 +1240,8 @@ mod tests {
     use crate::prefetch::adaptive::coordinator::test_support::{
         ground_state, make_scenery_index, make_scenery_index_covering, patched_region_area,
         test_calibration, test_plan, AlwaysHitDiskChecker, AlwaysHitMemoryCache,
-        AlwaysMissMemoryCache, BackpressureMockClient, CapLimitedDdsClient, DummyTracker,
-        HighLoadDdsClient, MockDiskChecker, StableBoundsTracker,
+        BackpressureMockClient, CapLimitedDdsClient, DummyTracker, HighLoadDdsClient,
+        MockDiskChecker, StableBoundsTracker,
     };
     // ─────────────────────────────────────────────────────────────────────────
     // Creation tests
@@ -1427,68 +1396,6 @@ mod tests {
             high_extent,
             low_extent
         );
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    // Cache tracking tests
-    // ─────────────────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_mark_cached() {
-        let mut coord = AdaptivePrefetchCoordinator::with_defaults();
-
-        let tiles = vec![
-            TileCoord {
-                row: 100,
-                col: 200,
-                zoom: 14,
-            },
-            TileCoord {
-                row: 101,
-                col: 200,
-                zoom: 14,
-            },
-        ];
-
-        coord.mark_cached(tiles);
-        assert_eq!(coord.cached_tiles.len(), 2);
-    }
-
-    #[test]
-    fn test_clear_cache_tracking() {
-        let mut coord = AdaptivePrefetchCoordinator::with_defaults();
-
-        coord.mark_cached(vec![TileCoord {
-            row: 100,
-            col: 200,
-            zoom: 14,
-        }]);
-        assert_eq!(coord.cached_tiles.len(), 1);
-
-        coord.clear_cache_tracking();
-        assert!(coord.cached_tiles.is_empty());
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    // Reset tests
-    // ─────────────────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_reset() {
-        let mut coord =
-            AdaptivePrefetchCoordinator::with_defaults().with_calibration(test_calibration());
-
-        // Update to set state
-        coord.update((53.5, 9.5), 45.0, 200.0, 0.0);
-        coord.mark_cached(vec![TileCoord {
-            row: 100,
-            col: 200,
-            zoom: 14,
-        }]);
-
-        // Reset
-        coord.reset();
-        assert!(coord.cached_tiles.is_empty());
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -3433,79 +3340,6 @@ mod tests {
         assert!(
             !coord.pending_tiles.is_empty(),
             "Unsubmitted tiles must be stored as pending for retry",
-        );
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    // Shadow-staleness integration regression (#172 post-flight finding)
-    //
-    // End-to-end guard: a pre-populated `cached_tiles` shadow combined with
-    // an empty memory cache must NOT cause the filter pipeline to starve
-    // the prefetcher. The coordinator must submit tiles whose reality
-    // differs from the shadow's belief.
-    //
-    // In production, this exact condition produced multiple
-    // `Prefetch plan filter pipeline summary raw_plan_tiles=200
-    // cache_skipped=200 ... remaining=0` lines over ~10 minutes of cruise,
-    // causing FUSE to fault tiles in on-demand at scenery-window boundary
-    // crossings (manifesting as 20-second hard sim freezes).
-    // ─────────────────────────────────────────────────────────────────────────
-
-    #[tokio::test]
-    async fn test_coordinator_submits_work_despite_stale_shadow_and_empty_cache() {
-        use crate::executor::DaemonMemoryCache;
-        use crate::geo_index::GeoIndex;
-
-        let geo_index = Arc::new(GeoIndex::new());
-        // Large channel cap — we want to see what the plan produces, not
-        // stress-test submission backpressure.
-        let client = Arc::new(CapLimitedDdsClient::new(10_000));
-        // Cache that reports miss for every query — simulates a memory
-        // cache that has evicted every tile it once held (the intentional
-        // "request absorber, not working-set holder" sizing).
-        let always_miss: Arc<dyn DaemonMemoryCache> = Arc::new(AlwaysMissMemoryCache);
-
-        let config = AdaptivePrefetchConfig {
-            mode: PrefetchMode::Aggressive,
-            ramp_duration: std::time::Duration::from_secs(0),
-            ..Default::default()
-        };
-        let mut coord = AdaptivePrefetchCoordinator::new(config)
-            .with_calibration(test_calibration())
-            .with_geo_index(Arc::clone(&geo_index))
-            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
-            .with_memory_cache(always_miss)
-            .with_scenery_index(wide_scenery_index_at_50_10());
-
-        // Pre-populate the shadow as if it had accumulated entries across
-        // many prior cycles before the memory cache evicted them. In
-        // production, this shadow grew to tens of thousands of entries
-        // that were no longer backed by real cache contents.
-        for row in 0..500u32 {
-            for col in 0..10u32 {
-                coord.cached_tiles.insert(TileCoord { row, col, zoom: 14 });
-            }
-        }
-        assert_eq!(
-            coord.cached_tiles.len(),
-            5000,
-            "Precondition: shadow is heavily populated",
-        );
-
-        fast_forward_to_cruise(&mut coord);
-        assert_eq!(coord.phase_detector.current_phase(), FlightPhase::Cruise);
-
-        let state = AircraftState::new(50.0, 10.0, 0.0, 200.0, 35000.0, false);
-        let submitted = coord.process_telemetry(&state).await.unwrap_or(0);
-
-        // Pre-hotfix behaviour: filter consults the shadow → claims all
-        // tiles are cached → plan empties → submitted == 0.
-        // Post-hotfix behaviour: filter queries the authoritative cache
-        // (always miss) → tiles survive filtering → submitted > 0.
-        assert!(
-            submitted > 0,
-            "Coordinator must submit tiles when the authoritative memory \
-             cache is empty, regardless of how populated the shadow HashSet is"
         );
     }
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -1155,6 +1155,19 @@ impl AdaptivePrefetchCoordinator {
                             "Region marked NoCoverage after {} failed attempts",
                             MAX_REGION_ATTEMPTS
                         );
+                        // Clear the strike count for the retired episode,
+                        // mirroring both promotion arms above. Without this,
+                        // a region the observer later demotes out of
+                        // NoCoverage (see `state_observer.rs::observe`) would
+                        // re-enter the prefetch cycle still carrying the old
+                        // count, so one single fresh failure would re-hit
+                        // `>= MAX_REGION_ATTEMPTS` and re-retire it instantly
+                        // — zero real retries. Clearing here gives a demoted
+                        // region a fresh set of `MAX_REGION_ATTEMPTS` strikes
+                        // each time it's demoted; the observer's per-region
+                        // demotion rate limit (one per `demotion_interval`)
+                        // is what bounds that loop, not this counter.
+                        self.region_attempts.remove(&region);
                     } else {
                         // Remove from GeoIndex to allow retry on next cycle.
                         //
@@ -2200,6 +2213,69 @@ mod tests {
                 .map(|s| !s.is_no_coverage())
                 .unwrap_or(true),
             "one fresh failure after a successful promotion must not retire the region"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_demoted_no_coverage_region_gets_fresh_strikes_after_retirement() {
+        // Regression for #223 Finding B: strike counts were cleared on both
+        // promotion paths but never on retirement to NoCoverage. A region
+        // demoted out of NoCoverage by `PrefetchStateObserver` (simulated
+        // here by removing its GeoIndex entry, exactly as the observer
+        // does — see `state_observer.rs::observe`) re-entered the prefetch
+        // cycle still carrying its old strike count, so a single fresh
+        // failure retired it again immediately: zero real retries.
+        let index = make_scenery_index(50, 9, 16);
+        let region = DsfRegion::new(50, 9);
+        assert!(
+            !index.tiles_in_region(region).is_empty(),
+            "Precondition: region has indexed tiles (land, not ocean) so the \
+             strike path is reachable — ocean regions take tiles.is_empty() \
+             and never touch region_attempts"
+        );
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let empty_checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(std::iter::empty::<TileCoord>());
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(Arc::clone(&empty_checker));
+        coord.config.stale_region_timeout = std::time::Duration::ZERO;
+
+        // Retire the region by strikes: MAX_REGION_ATTEMPTS consecutive
+        // stale failures (Incomplete: indexed tiles exist, none on disk).
+        for _ in 0..MAX_REGION_ATTEMPTS {
+            geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+            coord.evaluate_stale_regions(&geo_index);
+        }
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region)
+                .is_some_and(|s| s.is_no_coverage()),
+            "Precondition: region retired to NoCoverage by strikes"
+        );
+
+        // The observer demotes a NoCoverage region it sees contradicted by
+        // an on-demand FUSE generation — it clears the GeoIndex claim only
+        // (`PrefetchStateObserver::observe` -> `geo_index.remove`).
+        geo_index.remove::<PrefetchedRegion>(&region);
+
+        // The region is re-planned and marked InProgress again.
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+
+        // One single fresh stale failure.
+        coord.evaluate_stale_regions(&geo_index);
+
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region)
+                .map(|s| !s.is_no_coverage())
+                .unwrap_or(true),
+            "one fresh failure after an observer-driven demotion must not \
+             immediately re-retire the region — it should get a fresh set \
+             of MAX_REGION_ATTEMPTS strikes"
         );
     }
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -342,49 +342,14 @@ impl AdaptivePrefetchCoordinator {
     /// Falls back to the boundary strategy's geometric 4x4 grid expansion at
     /// zoom 14 when no scenery index is available or has no tiles for the region.
     fn get_tiles_for_region(&self, region: &DsfRegion) -> Vec<TileCoord> {
-        if let Some(ref index) = self.scenery_index {
-            let center_lat = region.lat as f64 + 0.5;
-            let center_lon = region.lon as f64 + 0.5;
-            // 1° DSF region ≈ 60nm at equator, 45nm radius covers the region
-            let tiles = index.tiles_near(center_lat, center_lon, 45.0);
-            // Filter to only tiles whose geographic center falls within the
-            // target 1° DSF region. Without this, the 45nm radius search spills
-            // across DSF boundaries, returning tiles from adjacent regions and
-            // causing massive tile count explosion (53K+ instead of ~700).
-            // Deduplicate: many .ter files share the same base DDS texture,
-            // so multiple SceneryTiles map to the same TileCoord after /16 division.
-            let unique: HashSet<TileCoord> = tiles
-                .iter()
-                .filter(|t| {
-                    t.lat.floor() as i32 == region.lat && t.lon.floor() as i32 == region.lon
-                })
-                .map(|t| t.to_tile_coord())
-                .collect();
-
-            tracing::debug!(
-                region_lat = region.lat,
-                region_lon = region.lon,
-                scenery_tiles = tiles.len(),
-                region_filtered = tiles
-                    .iter()
-                    .filter(|t| {
-                        t.lat.floor() as i32 == region.lat && t.lon.floor() as i32 == region.lon
-                    })
-                    .count(),
-                unique_tile_coords = unique.len(),
-                "get_tiles_for_region: deduplication results"
-            );
-
-            let result: Vec<TileCoord> = unique.into_iter().collect();
-
-            if !result.is_empty() {
-                return result;
-            }
-            // Fall through to geometric expansion if index had no tiles
+        match self.scenery_index {
+            // An empty result means the index knows of no ortho scenery
+            // here. The caller marks the region NoCoverage. There is no
+            // geometric fallback: a 4x4 sample of a region holding ~2,500
+            // tiles at zoom 14 made "all tiles cached" meaningless. See #176.
+            Some(ref index) => index.tiles_in_region(*region),
+            None => Vec::new(),
         }
-
-        // Fallback: geometric grid at zoom 14
-        self.boundary_strategy.expand_to_tiles(region, 14)
     }
 
     /// Get the current effective mode.
@@ -1064,21 +1029,19 @@ impl AdaptivePrefetchCoordinator {
             return;
         }
 
-        let strategy = BoundaryStrategy::new();
-
         for region in stale {
-            let tiles =
-                BoundaryStrategy::tiles_for_region(&strategy, &region, self.scenery_index.as_ref());
+            let tiles = match self.scenery_index {
+                Some(ref index) => index.tiles_in_region(region),
+                None => Vec::new(),
+            };
 
-            // Check if tiles exist on DDS disk cache.
-            // Uses the sync `tile_exists_blocking` method — see #172
-            // Part 3: the prior `block_in_place` + `block_on` dance has
-            // been pushed into the trait impl (`DdsDiskCacheBridge`).
-            // Keep the rescue-path "sample the first tile" heuristic;
-            // full coverage is checked by `promote_completed_regions`
-            // on the fast path.
-            let tiles_on_disk = match (self.dds_disk_checker.as_ref(), tiles.first()) {
-                (Some(checker), Some(t)) => checker.tile_exists_blocking(t.row, t.col, t.zoom),
+            // Full coverage, same predicate as the fast path. The previous
+            // version sampled `tiles.first()` and promoted the region on a
+            // single hit — see #176 defect 2. Short-circuits on first miss.
+            let tiles_on_disk = match self.dds_disk_checker.as_ref() {
+                Some(checker) if !tiles.is_empty() => tiles
+                    .iter()
+                    .all(|t| checker.tile_exists_blocking(t.row, t.col, t.zoom)),
                 _ => false,
             };
 
@@ -1173,9 +1136,9 @@ impl AdaptivePrefetchCoordinator {
 mod tests {
     use super::*;
     use crate::prefetch::adaptive::coordinator::test_support::{
-        ground_state, make_scenery_index, patched_region_area, test_calibration, test_plan,
-        AlwaysMissMemoryCache, BackpressureMockClient, CapLimitedDdsClient, DummyTracker,
-        HighLoadDdsClient, MockDiskChecker, StableBoundsTracker,
+        ground_state, make_scenery_index, make_scenery_index_covering, patched_region_area,
+        test_calibration, test_plan, AlwaysMissMemoryCache, BackpressureMockClient,
+        CapLimitedDdsClient, DummyTracker, HighLoadDdsClient, MockDiskChecker, StableBoundsTracker,
     };
     // ─────────────────────────────────────────────────────────────────────────
     // Creation tests
@@ -1550,9 +1513,20 @@ mod tests {
             .collect();
         geo_index.populate(entries);
 
+        // Post-#176, get_tiles_for_region has no geometric fallback — the
+        // ground box needs real scenery coverage to produce candidate tiles
+        // in the first place, before the patched-region filter can remove
+        // them. Cover the same area the patched regions cover.
+        let scenery_index = make_scenery_index_covering(
+            (aircraft_dsf.lat - coverage_radius)..=(aircraft_dsf.lat + coverage_radius),
+            (aircraft_dsf.lon - coverage_radius)..=(aircraft_dsf.lon + coverage_radius),
+            16,
+        );
+
         let mut coord = AdaptivePrefetchCoordinator::with_defaults()
             .with_calibration(test_calibration())
-            .with_geo_index(geo_index);
+            .with_geo_index(geo_index)
+            .with_scenery_index(scenery_index);
 
         let state = ground_state(aircraft_lat, aircraft_lon);
 
@@ -1764,15 +1738,18 @@ mod tests {
     // ─────────────────────────────────────────────────────────────────────────
 
     #[test]
-    fn test_get_tiles_for_region_without_index_uses_zoom_14() {
+    fn test_get_tiles_for_region_without_index_returns_empty() {
+        // #176: without a scenery index there is no geometric fallback —
+        // the coordinator has no way to know what tiles the region should
+        // contain, so it must yield nothing rather than guess zoom 14.
         let coord = AdaptivePrefetchCoordinator::with_defaults();
         let region = DsfRegion::new(50, 9);
 
         let tiles = coord.get_tiles_for_region(&region);
-        assert!(!tiles.is_empty());
-        for tile in &tiles {
-            assert_eq!(tile.zoom, 14, "Without scenery index, should use zoom 14");
-        }
+        assert!(
+            tiles.is_empty(),
+            "Without a scenery index, get_tiles_for_region must return nothing"
+        );
     }
 
     #[test]
@@ -1810,20 +1787,112 @@ mod tests {
     }
 
     #[test]
-    fn test_get_tiles_for_region_falls_back_when_no_coverage() {
+    fn test_get_tiles_for_region_returns_empty_when_no_coverage() {
+        // #176: an index with no tiles for the target region is a
+        // statement — "no ortho scenery here" — not a cue to fall back to
+        // a geometric zoom-14 guess.
         // Index has tiles at (60, 20) but we query (50, 9)
         let index = make_scenery_index(60, 20, 16);
         let coord = AdaptivePrefetchCoordinator::with_defaults().with_scenery_index(index);
         let region = DsfRegion::new(50, 9);
 
         let tiles = coord.get_tiles_for_region(&region);
-        assert!(!tiles.is_empty());
-        for tile in &tiles {
-            assert_eq!(
-                tile.zoom, 14,
-                "Should fall back to zoom 14 when scenery index has no coverage"
-            );
-        }
+        assert!(
+            tiles.is_empty(),
+            "Should return empty when scenery index has no coverage for the region"
+        );
+    }
+
+    /// Build a [`DdsDiskCacheChecker`] that reports only the listed tiles as
+    /// present on disk.
+    fn test_checker(tiles: &[TileCoord]) -> Arc<dyn DdsDiskCacheChecker> {
+        MockDiskChecker::with_tile_coords(tiles.iter().copied())
+    }
+
+    #[test]
+    fn test_region_with_no_indexed_tiles_is_marked_no_coverage() {
+        // Removing the geometric fallback means an empty index result is a
+        // statement — "no ortho scenery here" — rather than a cue to guess 16
+        // tiles at zoom 14. The submit loop must mark the region NoCoverage and
+        // submit nothing.
+        use crate::prefetch::scenery_index::SceneryTile;
+
+        let index = Arc::new(SceneryIndex::with_defaults());
+        index.add_tile(SceneryTile {
+            row: 1000,
+            col: 2000,
+            chunk_zoom: 16,
+            lat: 33.5,
+            lon: -118.5,
+            is_sea: false,
+        });
+
+        let coord =
+            AdaptivePrefetchCoordinator::with_defaults().with_scenery_index(Arc::clone(&index));
+
+        // A region the index knows nothing about — mid-Pacific.
+        assert!(
+            coord
+                .get_tiles_for_region(&DsfRegion::new(10, -150))
+                .is_empty(),
+            "an uncovered region must yield no tiles, not a geometric guess"
+        );
+        // And the covered one still yields its tile.
+        assert_eq!(
+            coord.get_tiles_for_region(&DsfRegion::new(33, -119)).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_stale_rescue_requires_full_coverage_not_one_tile() {
+        // Regression for #176 defect 2. The rescue path sampled tiles.first()
+        // and promoted the whole region on that single hit, which is how 61 of
+        // 65 promotions were decided in the #172 LOWW log.
+        use crate::prefetch::scenery_index::SceneryTile;
+
+        let index = Arc::new(SceneryIndex::with_defaults());
+        index.add_tile(SceneryTile {
+            row: 1000,
+            col: 2000,
+            chunk_zoom: 16,
+            lat: 33.5,
+            lon: -118.5,
+            is_sea: false,
+        });
+        index.add_tile(SceneryTile {
+            row: 5000,
+            col: 6000,
+            chunk_zoom: 16,
+            lat: 33.7,
+            lon: -118.2,
+            is_sea: false,
+        });
+
+        let region = DsfRegion::new(33, -119);
+        let geo_index = Arc::new(GeoIndex::new());
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+
+        // Only one of the two tiles is on disk.
+        let checker = test_checker(&[TileCoord {
+            row: 1000 / 16,
+            col: 2000 / 16,
+            zoom: 12,
+        }]);
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(checker);
+        coord.config.stale_region_timeout = std::time::Duration::ZERO; // everything is stale
+
+        coord.run_region_maintenance();
+
+        let state = geo_index.get::<PrefetchedRegion>(&region);
+        assert!(
+            state.is_none_or(|s| !s.is_prefetched()),
+            "partial coverage must not be promoted by the rescue path"
+        );
     }
 
     #[test]
@@ -1853,6 +1922,11 @@ mod tests {
             );
         }
 
+        // Post-#176, promotion needs a scenery index to know the region's
+        // tile set — there is no more geometric fallback. Cover region
+        // (55, 7), the one this test promotes below.
+        let scenery_index = make_scenery_index(55, 7, 16);
+
         let config = AdaptivePrefetchConfig {
             mode: PrefetchMode::Aggressive,
             ..Default::default()
@@ -1860,7 +1934,8 @@ mod tests {
         let mut coord = AdaptivePrefetchCoordinator::new(config)
             .with_calibration(test_calibration())
             .with_scene_tracker(tracker)
-            .with_geo_index(Arc::clone(&geo_index));
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_scenery_index(Arc::clone(&scenery_index));
 
         coord.phase_detector.hysteresis_duration = std::time::Duration::from_millis(1);
 
@@ -1889,7 +1964,11 @@ mod tests {
         // disk checker with the region's tiles so the authoritative
         // check sees them as present.
         let region = DsfRegion::new(55, 7);
-        let tiles = coord.boundary_strategy.expand_to_tiles(&region, 14);
+        let tiles = scenery_index.tiles_in_region(region);
+        assert!(
+            !tiles.is_empty(),
+            "Precondition: index covers region (55,7)"
+        );
         let checker: Arc<dyn crate::executor::DdsDiskCacheChecker> =
             MockDiskChecker::with_tile_coords(tiles.iter().copied());
         coord.dds_disk_checker = Some(checker);
@@ -1930,7 +2009,8 @@ mod tests {
         let mut coord = AdaptivePrefetchCoordinator::new(config)
             .with_calibration(test_calibration())
             .with_geo_index(Arc::clone(&geo_index))
-            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>);
+            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
+            .with_scenery_index(wide_scenery_index_at_50_10());
 
         // Fast-forward phase detector into cruise using a CENTER position
         // far from all boundaries. Window rows=6, so half_rows=3.
@@ -2441,9 +2521,15 @@ mod tests {
             mode: PrefetchMode::Aggressive,
             ..Default::default()
         };
+        // Post-#176, get_tiles_for_region has no geometric fallback. Cover
+        // the full westward flight path (lon 15 down to -5) plus box-extent
+        // margin in every direction.
+        let scenery_index = make_scenery_index_covering(40..=60, -15..=25, 16);
+
         let mut coord = AdaptivePrefetchCoordinator::new(config)
             .with_calibration(test_calibration())
-            .with_geo_index(geo_index);
+            .with_geo_index(geo_index)
+            .with_scenery_index(scenery_index);
 
         coord.phase_detector.hysteresis_duration = std::time::Duration::from_millis(1);
 
@@ -2499,7 +2585,8 @@ mod tests {
         };
         let mut coord = AdaptivePrefetchCoordinator::new(config)
             .with_calibration(test_calibration())
-            .with_geo_index(Arc::clone(&geo_index));
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_scenery_index(wide_scenery_index_at_48_15());
 
         coord.phase_detector.hysteresis_duration = std::time::Duration::from_millis(1);
         coord.phase_detector.takeoff_timeout = std::time::Duration::from_millis(1);
@@ -2594,7 +2681,8 @@ mod tests {
         };
         let mut coord = AdaptivePrefetchCoordinator::new(config)
             .with_calibration(test_calibration())
-            .with_geo_index(geo_index);
+            .with_geo_index(geo_index)
+            .with_scenery_index(wide_scenery_index_at_48_15());
 
         // Paused state — should still prefetch
         let paused = SimState {
@@ -2664,6 +2752,24 @@ mod tests {
     // tiles were never submitted.
     // ─────────────────────────────────────────────────────────────────────────
 
+    /// SceneryIndex covering the area used by `fast_forward_to_cruise` and
+    /// the tests built on it: centred on (50, 10), wide enough (±10°) for
+    /// the box's maximum extent (7°) plus retention margin in every
+    /// direction, including the (52.5, 10) position used by
+    /// `test_pending_tiles_retained_on_channel_full`. Post-#176,
+    /// `get_tiles_for_region` has no geometric fallback, so these tests
+    /// need real coverage to produce a non-empty plan.
+    fn wide_scenery_index_at_50_10() -> Arc<SceneryIndex> {
+        make_scenery_index_covering(40..=60, 0..=20, 16)
+    }
+
+    /// SceneryIndex covering the area used by the (48, 15) heading-270
+    /// cruise tests: wide enough for the box's maximum extent (7°) in
+    /// every direction from the aircraft's starting position.
+    fn wide_scenery_index_at_48_15() -> Arc<SceneryIndex> {
+        make_scenery_index_covering(38..=58, 5..=25, 16)
+    }
+
     /// Helper: fast-forward a coordinator into Cruise phase at (50.0, 10.0)
     /// heading 0° (north). Uses the existing hysteresis/timeout shortcut
     /// pattern from `test_pending_tiles_retained_on_channel_full`.
@@ -2706,7 +2812,8 @@ mod tests {
         let mut coord = AdaptivePrefetchCoordinator::new(config)
             .with_calibration(test_calibration())
             .with_geo_index(Arc::clone(&geo_index))
-            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>);
+            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
+            .with_scenery_index(wide_scenery_index_at_50_10());
 
         fast_forward_to_cruise(&mut coord);
         assert_eq!(
@@ -2735,7 +2842,8 @@ mod tests {
 
         let geo_index = Arc::new(GeoIndex::new());
         // Cap of 1 guarantees no region can be 100% submitted — every
-        // region in a geometric-fallback plan has multiple tiles.
+        // region in the plan has multiple tiles (4x4 sample grid per
+        // region from the scenery index).
         let client = Arc::new(CapLimitedDdsClient::new(1));
 
         let config = AdaptivePrefetchConfig {
@@ -2746,7 +2854,8 @@ mod tests {
         let mut coord = AdaptivePrefetchCoordinator::new(config)
             .with_calibration(test_calibration())
             .with_geo_index(Arc::clone(&geo_index))
-            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>);
+            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
+            .with_scenery_index(wide_scenery_index_at_50_10());
 
         fast_forward_to_cruise(&mut coord);
         assert_eq!(coord.phase_detector.current_phase(), FlightPhase::Cruise);
@@ -2808,7 +2917,8 @@ mod tests {
             .with_calibration(test_calibration())
             .with_geo_index(Arc::clone(&geo_index))
             .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
-            .with_memory_cache(always_miss);
+            .with_memory_cache(always_miss)
+            .with_scenery_index(wide_scenery_index_at_50_10());
 
         // Pre-populate the shadow as if it had accumulated entries across
         // many prior cycles before the memory cache evicted them. In
@@ -2858,7 +2968,8 @@ mod tests {
         let mut coord = AdaptivePrefetchCoordinator::new(config)
             .with_calibration(test_calibration())
             .with_geo_index(Arc::clone(&geo_index))
-            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>);
+            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
+            .with_scenery_index(wide_scenery_index_at_50_10());
 
         fast_forward_to_cruise(&mut coord);
         assert_eq!(coord.phase_detector.current_phase(), FlightPhase::Cruise);

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -20,7 +20,7 @@ use crate::ortho_union::OrthoUnionIndex;
 use crate::prefetch::state::{AircraftState, SharedPrefetchStatus};
 use crate::prefetch::SceneryIndex;
 
-use super::super::boundary_strategy::BoundaryStrategy;
+use super::super::boundary_strategy::{BoundaryStrategy, RegionDiskState};
 use super::super::calibration::{PerformanceCalibration, StrategyMode};
 use super::super::config::{AdaptivePrefetchConfig, PrefetchMode};
 use super::super::phase_detector::{FlightPhase, PhaseDetector};
@@ -1130,54 +1130,57 @@ impl AdaptivePrefetchCoordinator {
         }
 
         for region in stale {
-            let tiles = match self.scenery_index {
-                Some(ref index) => index.tiles_in_region(region),
-                None => Vec::new(),
-            };
-
-            // Full coverage, same predicate as the fast path. The previous
-            // version sampled `tiles.first()` and promoted the region on a
-            // single hit — see #176 defect 2. Short-circuits on first miss.
-            let tiles_on_disk = match self.dds_disk_checker.as_ref() {
-                Some(checker) if !tiles.is_empty() => tiles
-                    .iter()
-                    .all(|t| checker.tile_exists_blocking(t.row, t.col, t.zoom)),
-                _ => false,
-            };
-
-            if tiles_on_disk {
-                // Tiles generated successfully — promote despite lost cached_tiles tracking
-                geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
-                tracing::info!(
-                    lat = region.lat,
-                    lon = region.lon,
-                    "Stale InProgress region promoted — tiles found on DDS disk"
-                );
-            } else {
-                let attempts = self.region_attempts.entry(region).or_insert(0);
-                *attempts += 1;
-
-                if *attempts >= MAX_REGION_ATTEMPTS {
-                    // Exhausted retries — mark permanently excluded
-                    geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::no_coverage());
-                    tracing::warn!(
-                        lat = region.lat,
-                        lon = region.lon,
-                        attempts = *attempts,
-                        "Region marked NoCoverage after {} failed attempts",
-                        MAX_REGION_ATTEMPTS
-                    );
-                } else {
-                    // Remove from GeoIndex to allow retry on next cycle
-                    geo_index.remove::<PrefetchedRegion>(&region);
+            // Single definition of "is this region fully covered?", shared
+            // with the fast path (`BoundaryStrategy::promote_completed_regions`).
+            // Prior to #223's review these were two copies that already
+            // disagreed on the empty and unanswerable cases.
+            match BoundaryStrategy::region_disk_state(
+                region,
+                self.scenery_index.as_ref(),
+                self.dds_disk_checker.as_ref(),
+            ) {
+                RegionDiskState::Complete => {
+                    // Tiles generated successfully — promote despite lost cached_tiles tracking
+                    geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
                     tracing::info!(
                         lat = region.lat,
                         lon = region.lon,
-                        attempt = *attempts,
-                        max = MAX_REGION_ATTEMPTS,
-                        "Stale InProgress region demoted for retry"
+                        "Stale InProgress region promoted — tiles found on DDS disk"
                     );
                 }
+                // No tiles indexed: the region can never be confirmed, so
+                // retiring it after repeated attempts is correct — this
+                // preserves pre-#223 behavior.
+                RegionDiskState::Incomplete | RegionDiskState::NoTiles => {
+                    let attempts = self.region_attempts.entry(region).or_insert(0);
+                    *attempts += 1;
+
+                    if *attempts >= MAX_REGION_ATTEMPTS {
+                        // Exhausted retries — mark permanently excluded
+                        geo_index
+                            .insert::<PrefetchedRegion>(region, PrefetchedRegion::no_coverage());
+                        tracing::warn!(
+                            lat = region.lat,
+                            lon = region.lon,
+                            attempts = *attempts,
+                            "Region marked NoCoverage after {} failed attempts",
+                            MAX_REGION_ATTEMPTS
+                        );
+                    } else {
+                        // Remove from GeoIndex to allow retry on next cycle
+                        geo_index.remove::<PrefetchedRegion>(&region);
+                        tracing::info!(
+                            lat = region.lat,
+                            lon = region.lon,
+                            attempt = *attempts,
+                            max = MAX_REGION_ATTEMPTS,
+                            "Stale InProgress region demoted for retry"
+                        );
+                    }
+                }
+                // Unanswerable. Leave the claim standing and do not consume
+                // a retry; the next cycle may have a checker.
+                RegionDiskState::Unknown => continue,
             }
         }
     }
@@ -2076,6 +2079,39 @@ mod tests {
         assert!(
             state.is_some_and(|s| s.is_prefetched()),
             "full coverage on disk must be promoted by the rescue path"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stale_region_not_struck_when_disk_state_unknown() {
+        // A stale InProgress region with a scenery index but NO dds_disk_checker.
+        // Before: `_ => false` counted a failed attempt, and three of these
+        // retired the region to NoCoverage permanently. After: Unknown is not
+        // evidence of absence, so the region keeps its InProgress claim and no
+        // attempt is recorded.
+        let index = make_scenery_index_covering(50..=50, 9..=9, 16);
+        let geo_index = Arc::new(GeoIndex::new());
+        let region = DsfRegion { lat: 50, lon: 9 };
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index));
+        // deliberately no .with_dds_disk_checker(...)
+        coord.config.stale_region_timeout = std::time::Duration::ZERO; // force staleness
+
+        for _ in 0..MAX_REGION_ATTEMPTS + 1 {
+            coord.evaluate_stale_regions(&geo_index);
+        }
+
+        let state = geo_index.get::<PrefetchedRegion>(&region);
+        assert!(
+            state.map(|s| s.is_in_progress()).unwrap_or(false),
+            "region must remain InProgress; Unknown is not evidence of absence"
+        );
+        assert!(
+            !coord.region_attempts.contains_key(&region),
+            "an unanswerable check must not consume a retry"
         );
     }
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -2369,6 +2369,79 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_run_region_maintenance_emits_region_state_gauge() {
+        use crate::metrics::MetricEvent;
+
+        let geo_index = Arc::new(GeoIndex::new());
+
+        // Seed 1 InProgress, 2 Prefetched, 3 NoCoverage — deliberately
+        // distinct counts. With equal counts an argument swap at the
+        // `metrics.prefetch_region_state(...)` call site, or a swap of the
+        // `is_in_progress`/`is_prefetched` fold arms, would be undetectable.
+        geo_index
+            .insert::<PrefetchedRegion>(DsfRegion::new(10, 10), PrefetchedRegion::in_progress());
+        geo_index
+            .insert::<PrefetchedRegion>(DsfRegion::new(20, 20), PrefetchedRegion::prefetched());
+        geo_index
+            .insert::<PrefetchedRegion>(DsfRegion::new(21, 20), PrefetchedRegion::prefetched());
+        geo_index
+            .insert::<PrefetchedRegion>(DsfRegion::new(30, 30), PrefetchedRegion::no_coverage());
+        geo_index
+            .insert::<PrefetchedRegion>(DsfRegion::new(31, 30), PrefetchedRegion::no_coverage());
+        geo_index
+            .insert::<PrefetchedRegion>(DsfRegion::new(32, 30), PrefetchedRegion::no_coverage());
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let metrics = MetricsClient::new(tx);
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_metrics_client(metrics);
+
+        // No scenery_index/dds_disk_checker is wired, so `region_disk_state`
+        // returns `Unknown` for the InProgress region and neither
+        // `evaluate_stale_regions` nor `promote_completed_regions` promotes
+        // it. No `RetainedRegion` entries exist, so `evict_non_retained` is
+        // a no-op. The seeded distribution therefore survives untouched to
+        // the point the gauge samples it.
+        coord.run_region_maintenance();
+
+        // Guard the precondition: if maintenance had promoted or evicted
+        // anything, the assertion below would be measuring a different
+        // distribution than the one seeded.
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&DsfRegion::new(10, 10))
+                .is_some_and(|s| s.is_in_progress()),
+            "Precondition: seeded InProgress region must remain InProgress"
+        );
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let region_state_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, MetricEvent::PrefetchRegionState { .. }))
+            .collect();
+        assert_eq!(
+            region_state_events.len(),
+            1,
+            "expected exactly one PrefetchRegionState event, got {:?}",
+            region_state_events
+        );
+        assert!(
+            matches!(
+                region_state_events[0],
+                MetricEvent::PrefetchRegionState {
+                    in_progress: 1,
+                    prefetched: 2,
+                    no_coverage: 3,
+                }
+            ),
+            "expected PrefetchRegionState {{ in_progress: 1, prefetched: 2, no_coverage: 3 }}, got {:?}",
+            region_state_events[0]
+        );
+    }
+
     #[test]
     fn test_with_scenery_index_stores_on_coordinator() {
         let index = make_scenery_index(50, 9, 16);

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -1072,6 +1072,7 @@ impl AdaptivePrefetchCoordinator {
             &geo_index,
             self.dds_disk_checker.as_ref(),
             self.scenery_index.as_ref(),
+            self.ortho_union_index.as_ref(),
         );
         // Evict PrefetchedRegion entries for regions outside the retained window,
         // making them eligible for re-prefetch when the aircraft returns.
@@ -1138,6 +1139,7 @@ impl AdaptivePrefetchCoordinator {
                 region,
                 self.scenery_index.as_ref(),
                 self.dds_disk_checker.as_ref(),
+                self.ortho_union_index.as_ref(),
             ) {
                 RegionDiskState::Complete => {
                     // Tiles generated successfully — promote despite lost cached_tiles tracking

--- a/xearthlayer/src/prefetch/adaptive/coordinator/filtering.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/filtering.rs
@@ -11,7 +11,6 @@
 //! Each stage returns the filtered list and a count of skipped tiles.
 //! Stages are ordered cheapest-first to minimise per-tile filter cost.
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::coord::TileCoord;
@@ -27,7 +26,7 @@ use crate::prefetch::tile_based::DsfTileCoord;
 /// Counts from the filtering pipeline.
 #[derive(Debug, Default)]
 pub(crate) struct FilterCounts {
-    /// Tiles skipped because they were in the local tracking set or memory cache.
+    /// Tiles skipped because they were already in the memory cache.
     pub cache_hits: usize,
     /// Tiles skipped because they are in patch-owned DSF regions.
     pub patch_skipped: usize,
@@ -53,27 +52,22 @@ impl FilterCounts {
 /// Returns the surviving tiles and the number of cache hits.
 ///
 /// Consults the memory cache as the authoritative source on every call.
-/// The `cached_tiles` parameter is retained for compatibility with the
-/// retention machinery (`evict_cached_tiles_outside_retained`) but is no
-/// longer read as a fast-path — the memory cache is intentionally small
-/// (request absorber, not working-set holder), so a HashSet shadow of
-/// prior hits goes stale within seconds, causing the filter to produce
-/// false cache-hit reports and starving the prefetcher of real work.
-/// See #172 Part 5 post-flight finding: the shadow fast-path was the
-/// primary cause of continued FUSE misses on boundary crossings even
-/// after Parts 1-4 were shipped.
-#[allow(clippy::ptr_arg)]
+/// A local `HashSet` shadow of prior hits used to stand in for this query
+/// as a "fast path" — the memory cache is intentionally small (request
+/// absorber, not working-set holder), so the shadow went stale within
+/// seconds, causing the filter to produce false cache-hit reports and
+/// starving the prefetcher of real work. See #172 Part 5 post-flight
+/// finding: the shadow fast-path was the primary cause of continued FUSE
+/// misses on boundary crossings even after Parts 1-4 were shipped. The
+/// shadow itself was deleted in #176 once confirmed write-only.
 pub(crate) async fn filter_memory_cache(
     tiles: Vec<TileCoord>,
     cache: &dyn DaemonMemoryCache,
-    _cached_tiles: &mut HashSet<TileCoord>,
 ) -> (Vec<TileCoord>, usize) {
     let mut filtered = Vec::with_capacity(tiles.len());
     let mut hits = 0usize;
 
     for tile in &tiles {
-        // Always query the authoritative memory cache — the HashSet
-        // shadow is no longer trusted (see doc comment).
         if cache.contains(tile.row, tile.col, tile.zoom).await {
             hits += 1;
             continue;
@@ -204,7 +198,6 @@ pub(crate) fn filter_dds_disk_cache(
 pub(crate) async fn run_filter_pipeline(
     mut tiles: Vec<TileCoord>,
     memory_cache: Option<&dyn DaemonMemoryCache>,
-    cached_tiles: &mut HashSet<TileCoord>,
     geo_index: Option<&Arc<GeoIndex>>,
     ortho_union_index: Option<&Arc<OrthoUnionIndex>>,
     dds_disk_checker: Option<&Arc<dyn DdsDiskCacheChecker>>,
@@ -213,7 +206,7 @@ pub(crate) async fn run_filter_pipeline(
 
     // Stage 1: Memory cache filter
     if let Some(cache) = memory_cache {
-        let (filtered, hits) = filter_memory_cache(tiles, cache, cached_tiles).await;
+        let (filtered, hits) = filter_memory_cache(tiles, cache).await;
         counts.cache_hits = hits;
         tiles = filtered;
     }
@@ -346,28 +339,24 @@ mod tests {
     #[tokio::test]
     async fn test_run_filter_pipeline_no_filters() {
         let tiles = test_tiles(5);
-        let mut tracked = HashSet::new();
 
-        let (result, counts) =
-            run_filter_pipeline(tiles, None, &mut tracked, None, None, None).await;
+        let (result, counts) = run_filter_pipeline(tiles, None, None, None, None).await;
         assert_eq!(result.len(), 5);
         assert_eq!(counts.total(), 0);
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Regression guard: #172 post-flight finding — shadow staleness bug
+    // Authoritative memory cache behavior (#172 Part 5 post-flight finding)
     //
-    // The `cached_tiles` HashSet shadow is no longer consulted by
-    // `filter_memory_cache`. It went stale in production (memory cache
-    // evicts tiles under its small LRU budget, but the shadow keeps saying
-    // "cached"), causing the filter to falsely report 100% cache hits and
-    // starving the prefetcher of work for minutes at a time.
-    //
-    // The fix: always query the authoritative memory cache. The shadow is
-    // retained as a function parameter for compatibility with retention
-    // bookkeeping, but is neither read nor written by the filter.
-    //
-    // These tests prove the filter does NOT trust the shadow.
+    // `filter_memory_cache` used to be backed by a local `HashSet` shadow
+    // of "tiles we believe are cached" as a fast path. The shadow went
+    // stale in production (memory cache evicts tiles under its small LRU
+    // budget, but the shadow kept saying "cached"), causing the filter to
+    // falsely report 100% cache hits and starving the prefetcher of work
+    // for minutes at a time. The fix: always query the authoritative
+    // memory cache. The shadow itself was deleted in #176 once confirmed
+    // write-only, so these tests now simply pin the authoritative-query
+    // behavior directly.
     // ─────────────────────────────────────────────────────────────────────────
 
     use crate::executor::DaemonMemoryCache;
@@ -399,11 +388,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_filter_does_not_trust_stale_shadow_over_authoritative_cache() {
-        // Scenario: the caller populated `cached_tiles` (perhaps from a
-        // previous cycle's hits), but the memory cache has since evicted
-        // every one of those tiles. The filter must NOT claim cache hits
-        // based on the shadow — it must query the real cache.
+    async fn test_filter_memory_cache_always_miss_survives_all_tiles() {
+        // Authoritative check: a cache that has evicted every tile it once
+        // held must report zero hits — nothing survives from a stale
+        // local shadow, because there is no shadow to consult.
         let cache = AlwaysMissCache;
         let tiles: Vec<TileCoord> = (0..10)
             .map(|i| TileCoord {
@@ -413,29 +401,14 @@ mod tests {
             })
             .collect();
 
-        // Pre-populate the shadow with every tile — simulating the stale
-        // state seen in production where shadow insertions accumulated
-        // faster than retention eviction could clear them.
-        let mut stale_shadow: HashSet<TileCoord> = tiles.iter().copied().collect();
+        let (filtered, hits) = filter_memory_cache(tiles.clone(), &cache).await;
 
-        let (filtered, hits) = filter_memory_cache(tiles.clone(), &cache, &mut stale_shadow).await;
-
-        assert_eq!(
-            hits, 0,
-            "Stale shadow must not produce fake cache hits (real cache always misses)"
-        );
-        assert_eq!(
-            filtered, tiles,
-            "All uncached tiles must survive the filter regardless of shadow contents"
-        );
+        assert_eq!(hits, 0, "Real cache always misses, so no tiles are hits");
+        assert_eq!(filtered, tiles, "All tiles must survive the filter");
     }
 
     #[tokio::test]
-    async fn test_filter_does_not_write_to_shadow() {
-        // The shadow is now write-through inert — the filter should not
-        // add entries even when tiles ARE truly cached. This decouples
-        // the filter from the shadow's lifecycle (retention cleanup no
-        // longer races with filter population).
+    async fn test_filter_memory_cache_always_hit_filters_all_tiles() {
         struct AlwaysHitCache;
         impl DaemonMemoryCache for AlwaysHitCache {
             fn get(
@@ -460,16 +433,11 @@ mod tests {
 
         let cache = AlwaysHitCache;
         let tiles = test_tiles(5);
-        let mut shadow: HashSet<TileCoord> = HashSet::new();
 
-        let (filtered, hits) = filter_memory_cache(tiles, &cache, &mut shadow).await;
+        let (filtered, hits) = filter_memory_cache(tiles, &cache).await;
 
         assert_eq!(hits, 5, "Real hits should still be counted");
         assert!(filtered.is_empty(), "All hits should be filtered out");
-        assert!(
-            shadow.is_empty(),
-            "Filter must not write to the shadow — avoid accumulating stale entries"
-        );
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -560,7 +528,6 @@ mod tests {
         // End-to-end: pipeline with all filters OFF except DDS disk.
         // Tiles in the DDS disk mock should be stripped; the rest survive.
         let tiles = test_tiles(8);
-        let mut tracked = HashSet::new();
         let mut in_cache = HashSet::new();
         for tile in tiles.iter().take(3) {
             in_cache.insert((tile.row, tile.col, tile.zoom));
@@ -568,15 +535,8 @@ mod tests {
         let checker: Arc<dyn crate::executor::DdsDiskCacheChecker> =
             Arc::new(ChunkSetDiskChecker(in_cache));
 
-        let (result, counts) = run_filter_pipeline(
-            tiles.clone(),
-            None,
-            &mut tracked,
-            None,
-            None,
-            Some(&checker),
-        )
-        .await;
+        let (result, counts) =
+            run_filter_pipeline(tiles.clone(), None, None, None, Some(&checker)).await;
 
         assert_eq!(counts.dds_disk_hits, 3);
         assert_eq!(counts.cache_hits, 0);
@@ -590,8 +550,7 @@ mod tests {
     async fn test_filter_correctly_splits_partial_real_cache() {
         // Authoritative check: given a cache that hits on even rows and
         // misses on odd rows, the filter should split accordingly. This
-        // confirms the filter actually queries the real cache rather than
-        // rubber-stamping via shadow.
+        // confirms the filter actually queries the real cache per tile.
         struct EvenRowsCache;
         impl DaemonMemoryCache for EvenRowsCache {
             fn get(
@@ -623,9 +582,8 @@ mod tests {
 
         let cache = EvenRowsCache;
         let tiles = test_tiles(10); // rows 100..109 — evens at 100,102,104,106,108
-        let mut shadow = HashSet::new();
 
-        let (filtered, hits) = filter_memory_cache(tiles, &cache, &mut shadow).await;
+        let (filtered, hits) = filter_memory_cache(tiles, &cache).await;
 
         assert_eq!(hits, 5, "5 even-row tiles should hit");
         assert_eq!(filtered.len(), 5, "5 odd-row tiles should survive");

--- a/xearthlayer/src/prefetch/adaptive/coordinator/test_support.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/test_support.rs
@@ -105,6 +105,50 @@ pub(crate) fn make_scenery_index(lat: i32, lon: i32, chunk_zoom: u8) -> Arc<Scen
     Arc::new(index)
 }
 
+/// Helper to create a SceneryIndex covering every DSF region in a lat/lon
+/// rectangle, one tile per region (4x4 sample grid, same as
+/// [`make_scenery_index`]).
+///
+/// Post-#176, `get_tiles_for_region` has no geometric fallback — a region
+/// the index doesn't know about now yields zero tiles rather than a guessed
+/// 4x4 grid at zoom 14. Tests that exercise a prefetch box/ground ring
+/// spanning multiple regions must wire real coverage instead of relying on
+/// the removed fallback; this builds it in one call.
+pub(crate) fn make_scenery_index_covering(
+    lat_range: std::ops::RangeInclusive<i32>,
+    lon_range: std::ops::RangeInclusive<i32>,
+    chunk_zoom: u8,
+) -> Arc<SceneryIndex> {
+    use crate::coord::{to_tile_coords, CHUNKS_PER_TILE_SIDE, CHUNK_ZOOM_OFFSET};
+    use crate::prefetch::scenery_index::{SceneryIndexConfig, SceneryTile};
+
+    let index = SceneryIndex::new(SceneryIndexConfig::default());
+    let tile_zoom = chunk_zoom - CHUNK_ZOOM_OFFSET;
+
+    for lat in lat_range {
+        for lon in lon_range.clone() {
+            for lat_step in 0..4u32 {
+                for lon_step in 0..4u32 {
+                    let sample_lat = lat as f64 + (lat_step as f64 * 0.25) + 0.125;
+                    let sample_lon = lon as f64 + (lon_step as f64 * 0.25) + 0.125;
+                    if let Ok(coord) = to_tile_coords(sample_lat, sample_lon, tile_zoom) {
+                        index.add_tile(SceneryTile {
+                            row: coord.row * CHUNKS_PER_TILE_SIDE,
+                            col: coord.col * CHUNKS_PER_TILE_SIDE,
+                            chunk_zoom,
+                            lat: sample_lat as f32,
+                            lon: sample_lon as f32,
+                            is_sea: false,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    Arc::new(index)
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // SceneTracker mocks
 // ─────────────────────────────────────────────────────────────────────────────

--- a/xearthlayer/src/prefetch/adaptive/coordinator/test_support.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/test_support.rs
@@ -184,6 +184,34 @@ impl crate::executor::DaemonMemoryCache for AlwaysMissMemoryCache {
     }
 }
 
+/// Mock [`DaemonMemoryCache`] that always reports "hit". Used to empty a
+/// prefetch plan via the memory-cache filter stage specifically — as
+/// distinct from emptying it via the DDS disk cache checker — so tests can
+/// tell apart the two-phase commit's filter-driven `InProgress` marking from
+/// its disk-verified `Prefetched` promotion.
+pub(crate) struct AlwaysHitMemoryCache;
+
+impl crate::executor::DaemonMemoryCache for AlwaysHitMemoryCache {
+    fn get(
+        &self,
+        _row: u32,
+        _col: u32,
+        _zoom: u8,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<Vec<u8>>> + Send + '_>> {
+        Box::pin(async { Some(vec![0u8; 16]) })
+    }
+
+    fn put(
+        &self,
+        _row: u32,
+        _col: u32,
+        _zoom: u8,
+        _data: Vec<u8>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // DDS disk cache checker mock
 // ─────────────────────────────────────────────────────────────────────────────
@@ -414,6 +442,11 @@ impl CapLimitedDdsClient {
     /// Reset the counter to allow another batch of submissions.
     pub(crate) fn reset(&self) {
         self.submitted.store(0, Ordering::SeqCst);
+    }
+
+    /// Number of tiles accepted so far.
+    pub(crate) fn submitted_count(&self) -> usize {
+        self.submitted.load(Ordering::SeqCst)
     }
 }
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/test_support.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/test_support.rs
@@ -235,6 +235,29 @@ impl DdsDiskCacheChecker for MockDiskChecker {
     }
 }
 
+/// Mock [`DdsDiskCacheChecker`] that reports every tile as present on disk.
+///
+/// Models a DSF region whose tiles are all already in the DDS disk cache —
+/// the state in which the filter pipeline removes the region's entire
+/// planned tile set, so nothing is submitted and `execute()` is skipped
+/// (#176).
+pub(crate) struct AlwaysHitDiskChecker;
+
+impl DdsDiskCacheChecker for AlwaysHitDiskChecker {
+    fn tile_exists(
+        &self,
+        _row: u32,
+        _col: u32,
+        _zoom: u8,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+        Box::pin(async { true })
+    }
+
+    fn tile_exists_blocking(&self, _row: u32, _col: u32, _zoom: u8) -> bool {
+        true
+    }
+}
+
 /// Mock SceneTracker that returns no data for all queries.
 pub(crate) struct DummyTracker;
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/test_support.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/test_support.rs
@@ -157,33 +157,6 @@ pub(crate) fn make_scenery_index_covering(
 // Memory cache mocks
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Mock [`DaemonMemoryCache`] that always reports "miss". Simulates a
-/// memory cache that has evicted every tile it once held — the exact
-/// condition under which the filter-pipeline shadow-staleness bug
-/// (#172 post-flight finding) manifested in production.
-pub(crate) struct AlwaysMissMemoryCache;
-
-impl crate::executor::DaemonMemoryCache for AlwaysMissMemoryCache {
-    fn get(
-        &self,
-        _row: u32,
-        _col: u32,
-        _zoom: u8,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<Vec<u8>>> + Send + '_>> {
-        Box::pin(async { None })
-    }
-
-    fn put(
-        &self,
-        _row: u32,
-        _col: u32,
-        _zoom: u8,
-        _data: Vec<u8>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
-        Box::pin(async {})
-    }
-}
-
 /// Mock [`DaemonMemoryCache`] that always reports "hit". Used to empty a
 /// prefetch plan via the memory-cache filter stage specifically — as
 /// distinct from emptying it via the DDS disk cache checker — so tests can

--- a/xearthlayer/src/prefetch/adaptive/strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/strategy.rs
@@ -24,7 +24,7 @@
 //!     (lat, lon),
 //!     track,
 //!     &calibration,
-//!     &cached_tiles,
+//!     &already_cached,
 //! );
 //!
 //! for tile in plan.tiles {

--- a/xearthlayer/src/prefetch/adaptive/strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/strategy.rs
@@ -103,7 +103,12 @@ pub struct PrefetchPlan {
 /// Used by the coordinator for logging and UI reporting.
 #[derive(Debug, Clone)]
 pub struct PrefetchPlanMetadata {
-    /// Source of bounds data (e.g., "explicit", "cached_tiles", "default").
+    /// Source of bounds data. The only literal ever assigned to this field
+    /// is `"track"`, in [`PrefetchPlanMetadata::cruise`] — but that
+    /// constructor, [`PrefetchPlanMetadata::ground`], and
+    /// [`PrefetchPlan::with_tiles_and_metadata`] all currently have zero
+    /// callers, so in practice `PrefetchPlan::metadata` is always `None`
+    /// and this field is never observed.
     pub bounds_source: &'static str,
 
     /// Number of DSF tiles in the prefetch region.

--- a/xearthlayer/src/prefetch/mod.rs
+++ b/xearthlayer/src/prefetch/mod.rs
@@ -67,7 +67,8 @@ pub use types::{InputMode, PrefetchTile, PrefetchZone, TurnDirection, TurnState}
 
 // Scenery-aware prefetch
 pub use scenery_index::{
-    IndexingProgress, SceneryIndex, SceneryIndexConfig, SceneryIndexError, SceneryTile,
+    IndexingProgress, PackageIndexStats, SceneryIndex, SceneryIndexConfig, SceneryIndexError,
+    SceneryTile,
 };
 
 // Cold-start prewarm

--- a/xearthlayer/src/prefetch/mod.rs
+++ b/xearthlayer/src/prefetch/mod.rs
@@ -44,6 +44,7 @@ mod prewarm;
 pub mod scenery_cache;
 mod scenery_index;
 mod state;
+mod state_observer;
 mod strategy;
 pub mod tile_based;
 pub mod types;
@@ -88,3 +89,6 @@ pub use tile_based::{DdsAccessEvent, DsfTileCoord};
 
 // Adaptive prefetch (self-calibrating DSF-aligned)
 pub use adaptive::{AdaptivePrefetchConfig, AdaptivePrefetchCoordinator};
+
+// Prefetch state divergence detection (FUSE-side, #176)
+pub use state_observer::PrefetchStateObserver;

--- a/xearthlayer/src/prefetch/scenery_index.rs
+++ b/xearthlayer/src/prefetch/scenery_index.rs
@@ -272,28 +272,6 @@ impl SceneryIndex {
         result
     }
 
-    /// Query tiles within a radius, excluding sea tiles.
-    pub fn land_tiles_near(&self, lat: f64, lon: f64, radius_nm: f32) -> Vec<SceneryTile> {
-        self.tiles_near(lat, lon, radius_nm)
-            .into_iter()
-            .filter(|t| !t.is_sea)
-            .collect()
-    }
-
-    /// Query tiles within a radius at a specific zoom level.
-    pub fn tiles_near_at_zoom(
-        &self,
-        lat: f64,
-        lon: f64,
-        radius_nm: f32,
-        chunk_zoom: u8,
-    ) -> Vec<SceneryTile> {
-        self.tiles_near(lat, lon, radius_nm)
-            .into_iter()
-            .filter(|t| t.chunk_zoom == chunk_zoom)
-            .collect()
-    }
-
     /// Get the deduplicated set of DDS tiles belonging to a DSF region.
     ///
     /// A tile belongs to the region containing its geographic centre, which
@@ -806,7 +784,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scenery_index_land_tiles_filter() {
+    fn test_scenery_index_sea_and_land_counts() {
         let index = SceneryIndex::with_defaults();
 
         // Add a land tile
@@ -836,11 +814,6 @@ mod tests {
         // Query all tiles
         let all = index.tiles_near(45.0, -120.0, 10.0);
         assert_eq!(all.len(), 2);
-
-        // Query land tiles only
-        let land = index.land_tiles_near(45.0, -120.0, 10.0);
-        assert_eq!(land.len(), 1);
-        assert!(!land[0].is_sea);
     }
 
     #[test]
@@ -986,8 +959,7 @@ mod tests {
 
     #[test]
     fn test_tiles_in_region_includes_sea_tiles() {
-        // The spec requires sea tiles stay in scope: no is_sea filter here,
-        // unlike the adjacent land_tiles_near.
+        // The spec requires sea tiles stay in scope: no is_sea filter here.
         let index = SceneryIndex::with_defaults();
         let mut tile = tile_at(1000, 2000, 33.5, -118.5);
         tile.is_sea = true;

--- a/xearthlayer/src/prefetch/scenery_index.rs
+++ b/xearthlayer/src/prefetch/scenery_index.rs
@@ -33,7 +33,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use tokio::sync::mpsc;
-use tracing::{debug, info, trace};
+use tracing::{debug, info};
 
 use crate::coord::TileCoord;
 use crate::geo_index::DsfRegion;
@@ -139,7 +139,10 @@ impl SceneryIndex {
     /// Build the index by scanning a scenery package directory.
     ///
     /// Parses all `.ter` files in the `terrain` subdirectory.
-    pub fn build_from_package(&self, package_path: &Path) -> Result<usize, SceneryIndexError> {
+    pub fn build_from_package(
+        &self,
+        package_path: &Path,
+    ) -> Result<PackageIndexStats, SceneryIndexError> {
         debug!(
             package = %package_path.display(),
             "Building scenery index from package"
@@ -161,7 +164,10 @@ impl SceneryIndex {
             "Found terrain directory"
         );
 
-        let mut count = 0;
+        let mut stats = PackageIndexStats::default();
+        let mut failure_samples: Vec<String> = Vec::new();
+        const MAX_FAILURE_SAMPLES: usize = 5;
+
         let entries =
             fs::read_dir(&terrain_path).map_err(|e| SceneryIndexError::IoError(e.to_string()))?;
 
@@ -169,21 +175,39 @@ impl SceneryIndex {
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "ter") {
                 match self.parse_and_add_ter_file(&path) {
-                    Ok(()) => count += 1,
+                    Ok(()) => stats.parsed += 1,
                     Err(e) => {
-                        trace!(path = %path.display(), error = %e, "Failed to parse .ter file");
+                        stats.failed += 1;
+                        // Per-file stays at debug: a wholesale-malformed
+                        // package would emit millions of lines at warn.
+                        // The aggregate below is the visible signal.
+                        debug!(path = %path.display(), error = %e, "Failed to parse .ter file");
+                        if failure_samples.len() < MAX_FAILURE_SAMPLES {
+                            failure_samples.push(path.display().to_string());
+                        }
                     }
                 }
             }
         }
 
+        if stats.failed > 0 {
+            tracing::warn!(
+                package = %package_path.display(),
+                failed = stats.failed,
+                parsed = stats.parsed,
+                samples = ?failure_samples,
+                "Scenery index: .ter files failed to parse — prefetch may under-cover this package"
+            );
+        }
+
         info!(
             package = %package_path.display(),
-            tiles = count,
+            tiles = stats.parsed,
+            failed = stats.failed,
             "Built scenery index"
         );
 
-        Ok(count)
+        Ok(stats)
     }
 
     /// Parse a single .ter file and add it to the index.
@@ -435,6 +459,7 @@ impl SceneryIndex {
         use tokio::time::interval;
 
         let total_packages = packages.len();
+        let mut total_failed = 0usize;
 
         for (i, (name, path)) in packages.into_iter().enumerate() {
             // Send PackageStarted notification
@@ -484,7 +509,10 @@ impl SceneryIndex {
 
             // Get the tile count from the result
             let tiles = match result {
-                Ok(Ok(count)) => count,
+                Ok(Ok(stats)) => {
+                    total_failed += stats.failed;
+                    stats.parsed
+                }
                 Ok(Err(e)) => {
                     tracing::warn!(
                         package = %name_clone,
@@ -522,6 +550,7 @@ impl SceneryIndex {
             total = total,
             land = land,
             sea = sea,
+            failed = total_failed,
             "Scenery index build complete"
         );
     }
@@ -645,6 +674,32 @@ fn approximate_distance_nm(lat1: f32, lon1: f32, lat2: f32, lon2: f32) -> f32 {
     let lat_diff = (lat2 - lat1) * 60.0; // 1 degree = 60nm
     let lon_diff = (lon2 - lon1) * 60.0 * (lat1.to_radians().cos());
     (lat_diff * lat_diff + lon_diff * lon_diff).sqrt()
+}
+
+/// Parse outcome for one scenery package.
+///
+/// `failed` is the count of `.ter` files present on disk that did not yield a
+/// tile. The measured baseline across 4.45M files on a full 11-package install
+/// is zero, so any non-zero value is anomalous — see #176.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PackageIndexStats {
+    /// Files that parsed into an indexed tile.
+    ///
+    /// Note: this counts files that parsed successfully, not tiles added.
+    /// `parse_and_add_ter_file` returns `Ok(())` for a sea tile that was
+    /// skipped because `include_sea_tiles` is false, so `parsed` can exceed
+    /// `SceneryIndex::tile_count()`. That is still the correct denominator
+    /// for a parse-health metric: it counts files on disk, not tiles kept.
+    pub parsed: usize,
+    /// Files that failed to parse.
+    pub failed: usize,
+}
+
+impl PackageIndexStats {
+    /// Total `.ter` files seen.
+    pub fn total(&self) -> usize {
+        self.parsed + self.failed
+    }
 }
 
 /// Errors that can occur when building the scenery index.
@@ -975,6 +1030,53 @@ mod tests {
         );
     }
 
+    /// Write a minimal valid .ter file that parses into one tile.
+    fn write_valid_ter(dir: &std::path::Path, name: &str) {
+        let body = "A\n800\nTERRAIN\n\n\
+                    LOAD_CENTER 33.50000 -118.50000 1744 4096\n\
+                    BASE_TEX_NOWRAP ../textures/25328_49904_BI16.dds\n";
+        std::fs::write(dir.join(name), body).unwrap();
+    }
+
+    #[test]
+    fn test_build_from_package_counts_parse_failures() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let terrain = tmp.path().join("terrain");
+        std::fs::create_dir_all(&terrain).unwrap();
+
+        write_valid_ter(&terrain, "good_a.ter");
+        write_valid_ter(&terrain, "good_b.ter");
+        // No LOAD_CENTER and no BASE_TEX: parse must fail.
+        std::fs::write(terrain.join("bad.ter"), "A\n800\nTERRAIN\n").unwrap();
+        // Not a .ter file: must not be counted at all.
+        std::fs::write(terrain.join("notes.txt"), "ignored").unwrap();
+
+        let index = SceneryIndex::with_defaults();
+        let stats = index.build_from_package(tmp.path()).unwrap();
+
+        assert_eq!(stats.parsed, 2);
+        assert_eq!(stats.failed, 1);
+        assert_eq!(index.tile_count(), 2);
+    }
+
+    #[test]
+    fn test_build_from_package_reports_zero_failures_when_all_parse() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let terrain = tmp.path().join("terrain");
+        std::fs::create_dir_all(&terrain).unwrap();
+        write_valid_ter(&terrain, "a.ter");
+        write_valid_ter(&terrain, "b.ter");
+
+        let index = SceneryIndex::with_defaults();
+        let stats = index.build_from_package(tmp.path()).unwrap();
+
+        assert_eq!(
+            stats.failed, 0,
+            "the measured baseline across 4.45M real files is zero"
+        );
+        assert_eq!(stats.parsed, 2);
+    }
+
     /// Integration test with real scenery package.
     /// Run with: cargo test scenery_index --features integration -- --ignored
     #[test]
@@ -990,15 +1092,16 @@ mod tests {
         }
 
         let index = SceneryIndex::with_defaults();
-        let count = index
+        let stats = index
             .build_from_package(path)
             .expect("Failed to build index");
+        let count = stats.parsed;
 
         // Should find many tiles
         assert!(count > 1000, "Expected > 1000 tiles, found {}", count);
 
         // Print some statistics
-        eprintln!("Indexed {} tiles", count);
+        eprintln!("Indexed {} tiles ({} failed)", count, stats.failed);
         eprintln!("  Land tiles: {}", index.land_tile_count());
         eprintln!("  Sea tiles: {}", index.sea_tile_count());
 

--- a/xearthlayer/src/prefetch/scenery_index.rs
+++ b/xearthlayer/src/prefetch/scenery_index.rs
@@ -240,62 +240,6 @@ impl SceneryIndex {
         }
     }
 
-    /// Query tiles within a radius of a position.
-    ///
-    /// Returns all tiles whose center is within `radius_nm` nautical miles
-    /// of the given position.
-    pub fn tiles_near(&self, lat: f64, lon: f64, radius_nm: f32) -> Vec<SceneryTile> {
-        let lat = lat as f32;
-        let lon = lon as f32;
-
-        // Convert radius to approximate degrees (1 degree ≈ 60nm at equator)
-        let radius_deg = radius_nm / 60.0;
-
-        // Determine which grid cells to check
-        let min_lat_cell = ((lat - radius_deg) / self.cell_size).floor() as i16;
-        let max_lat_cell = ((lat + radius_deg) / self.cell_size).ceil() as i16;
-        let min_lon_cell = ((lon - radius_deg) / self.cell_size).floor() as i16;
-        let max_lon_cell = ((lon + radius_deg) / self.cell_size).ceil() as i16;
-
-        debug!(
-            lat = lat,
-            lon = lon,
-            radius_nm = radius_nm,
-            lat_cells = format!("{}..={}", min_lat_cell, max_lat_cell),
-            lon_cells = format!("{}..={}", min_lon_cell, max_lon_cell),
-            total_tiles_indexed = *self.tile_count.read().unwrap(),
-            "Searching tiles_near"
-        );
-
-        let grid = self.grid.read().unwrap();
-        let mut result = Vec::new();
-        let mut cells_with_tiles = 0;
-
-        for lat_cell in min_lat_cell..=max_lat_cell {
-            for lon_cell in min_lon_cell..=max_lon_cell {
-                if let Some(cell) = grid.get(&(lat_cell, lon_cell)) {
-                    cells_with_tiles += 1;
-                    for tile in &cell.tiles {
-                        // Check actual distance
-                        let dist = approximate_distance_nm(lat, lon, tile.lat, tile.lon);
-                        if dist <= radius_nm {
-                            result.push(*tile);
-                        }
-                    }
-                }
-            }
-        }
-
-        debug!(
-            cells_searched = (max_lat_cell - min_lat_cell + 1) * (max_lon_cell - min_lon_cell + 1),
-            cells_with_tiles = cells_with_tiles,
-            tiles_found = result.len(),
-            "tiles_near search complete"
-        );
-
-        result
-    }
-
     /// Get the deduplicated set of DDS tiles belonging to a DSF region.
     ///
     /// A tile belongs to the region containing its geographic centre, which
@@ -666,16 +610,6 @@ fn parse_dds_filename(filename: &str) -> Option<(u32, u32, u8)> {
     Some((row, col, zoom))
 }
 
-/// Approximate distance in nautical miles using equirectangular projection.
-///
-/// Accurate enough for spatial queries within ~200nm.
-#[inline]
-fn approximate_distance_nm(lat1: f32, lon1: f32, lat2: f32, lon2: f32) -> f32 {
-    let lat_diff = (lat2 - lat1) * 60.0; // 1 degree = 60nm
-    let lon_diff = (lon2 - lon1) * 60.0 * (lat1.to_radians().cos());
-    (lat_diff * lat_diff + lon_diff * lon_diff).sqrt()
-}
-
 /// Parse outcome for one scenery package.
 ///
 /// `failed` is the count of `.ter` files present on disk that did not yield a
@@ -812,33 +746,6 @@ mod tests {
     }
 
     #[test]
-    fn test_scenery_index_add_and_query() {
-        let index = SceneryIndex::with_defaults();
-
-        // Add a tile at (45.0, -120.0)
-        let tile = SceneryTile {
-            row: 25000,
-            col: 10000,
-            chunk_zoom: 16,
-            lat: 45.0,
-            lon: -120.0,
-            is_sea: false,
-        };
-        index.add_tile(tile);
-
-        assert_eq!(index.tile_count(), 1);
-
-        // Query near the tile
-        let results = index.tiles_near(45.0, -120.0, 10.0);
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].row, 25000);
-
-        // Query far from the tile
-        let results = index.tiles_near(50.0, -120.0, 10.0);
-        assert_eq!(results.len(), 0);
-    }
-
-    #[test]
     fn test_scenery_index_sea_and_land_counts() {
         let index = SceneryIndex::with_defaults();
 
@@ -865,24 +772,6 @@ mod tests {
         assert_eq!(index.tile_count(), 2);
         assert_eq!(index.sea_tile_count(), 1);
         assert_eq!(index.land_tile_count(), 1);
-
-        // Query all tiles
-        let all = index.tiles_near(45.0, -120.0, 10.0);
-        assert_eq!(all.len(), 2);
-    }
-
-    #[test]
-    fn test_approximate_distance_nm() {
-        // Same point
-        assert!(approximate_distance_nm(45.0, -120.0, 45.0, -120.0) < 0.01);
-
-        // 1 degree north (should be ~60nm)
-        let dist = approximate_distance_nm(45.0, -120.0, 46.0, -120.0);
-        assert!((dist - 60.0).abs() < 1.0);
-
-        // 1 degree east at 45° lat (should be ~42nm due to cosine)
-        let dist = approximate_distance_nm(45.0, -120.0, 45.0, -119.0);
-        assert!((dist - 42.4).abs() < 2.0);
     }
 
     /// Helper: a land tile at a given position. Row/col are irrelevant to the
@@ -1105,12 +994,17 @@ mod tests {
         eprintln!("  Land tiles: {}", index.land_tile_count());
         eprintln!("  Sea tiles: {}", index.sea_tile_count());
 
-        // Query tiles near a known location (California)
-        let tiles = index.tiles_near(36.28, -119.49, 10.0);
-        assert!(!tiles.is_empty(), "Expected tiles near (36.28, -119.49)");
+        // Spot-check the DSF region containing a known location (California).
+        // floor(36.28) == 36, floor(-119.49) == -120, so the region is (36, -120).
+        let tiles = index.tiles_in_region(DsfRegion::new(36, -120));
+        assert!(!tiles.is_empty(), "Expected tiles in region (36, -120)");
 
-        // Verify we have both ZL16 and ZL18 tiles
-        let has_zl16 = tiles.iter().any(|t| t.chunk_zoom == 16);
+        // Verify we have ZL16 tiles. tiles_in_region returns TileCoord, whose
+        // zoom is the *tile* zoom, not the chunk zoom baked into DDS filenames:
+        // chunk_zoom 16 corresponds to tile_zoom 16 - CHUNK_ZOOM_OFFSET == 12.
+        let has_zl16 = tiles
+            .iter()
+            .any(|t| t.zoom == 16 - crate::coord::CHUNK_ZOOM_OFFSET);
         eprintln!("Has ZL16 tiles: {}", has_zl16);
     }
 }

--- a/xearthlayer/src/prefetch/scenery_index.rs
+++ b/xearthlayer/src/prefetch/scenery_index.rs
@@ -958,6 +958,51 @@ mod tests {
         assert!(index.tiles_in_region(DsfRegion::new(50, 10)).is_empty());
     }
 
+    #[test]
+    fn test_tiles_in_region_predicate_filters_within_shared_cell() {
+        // At cell_size 2.0, one grid cell spans two DSF regions along the lat
+        // axis: floor(33.5 / 2.0) == floor(32.5 / 2.0) == 16, so both tiles
+        // land in the same cell, but floor(33.5) == 33 and floor(32.5) == 32
+        // put them in different regions. Only the predicate -- not cell
+        // visitation -- can tell them apart.
+        let config = SceneryIndexConfig {
+            grid_cell_size: 2.0,
+            include_sea_tiles: true,
+        };
+        let index = SceneryIndex::new(config);
+        index.add_tile(tile_at(1000, 2000, 33.5, -119.5)); // region 33,-120
+        index.add_tile(tile_at(2000, 3000, 32.5, -119.5)); // region 32,-120, same cell
+
+        let tiles = index.tiles_in_region(DsfRegion::new(33, -120));
+
+        assert_eq!(
+            tiles.len(),
+            1,
+            "the same-cell tile from region 32,-120 must be excluded, got {:?}",
+            tiles
+        );
+        assert_eq!(tiles[0].row, 1000 / 16);
+    }
+
+    #[test]
+    fn test_tiles_in_region_includes_sea_tiles() {
+        // The spec requires sea tiles stay in scope: no is_sea filter here,
+        // unlike the adjacent land_tiles_near.
+        let index = SceneryIndex::with_defaults();
+        let mut tile = tile_at(1000, 2000, 33.5, -118.5);
+        tile.is_sea = true;
+        index.add_tile(tile);
+
+        let tiles = index.tiles_in_region(DsfRegion::new(33, -119));
+
+        assert_eq!(
+            tiles.len(),
+            1,
+            "sea tiles must remain in scope, got {:?}",
+            tiles
+        );
+    }
+
     /// Integration test with real scenery package.
     /// Run with: cargo test scenery_index --features integration -- --ignored
     #[test]

--- a/xearthlayer/src/prefetch/scenery_index.rs
+++ b/xearthlayer/src/prefetch/scenery_index.rs
@@ -26,7 +26,7 @@
 //! - **Efficient**: Only prefetch tiles that actually exist in scenery
 //! - **Skip sea tiles**: Can deprioritize simple water textures
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -36,6 +36,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, trace};
 
 use crate::coord::TileCoord;
+use crate::geo_index::DsfRegion;
 
 /// A tile entry in the scenery index.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -291,6 +292,67 @@ impl SceneryIndex {
             .into_iter()
             .filter(|t| t.chunk_zoom == chunk_zoom)
             .collect()
+    }
+
+    /// Get the deduplicated set of DDS tiles belonging to a DSF region.
+    ///
+    /// A tile belongs to the region containing its geographic centre, which
+    /// is the `LOAD_CENTER` of its `.ter` file. This is the single definition
+    /// of a region's tile set — the submit, promote and rescue paths all
+    /// consult it, so they cannot disagree about whether a region is complete.
+    ///
+    /// # Why this is cheap
+    ///
+    /// A `DsfRegion` is 1°×1° and `cell_key` floors by `cell_size`, which
+    /// defaults to 1.0 — so in the default configuration a region *is* a grid
+    /// cell and this is a single `HashMap` lookup. The predicate is still
+    /// applied per tile because `grid_cell_size` is configurable.
+    ///
+    /// See #176: the previous implementations reconstructed this answer from a
+    /// 45nm radius query, which returns a circle overlapping the neighbouring
+    /// regions rather than the region itself.
+    pub fn tiles_in_region(&self, region: DsfRegion) -> Vec<TileCoord> {
+        let grid = self.grid.read().unwrap();
+        let mut unique: HashSet<TileCoord> = HashSet::new();
+
+        for key in self.cells_covering_region(region) {
+            let Some(cell) = grid.get(&key) else {
+                continue;
+            };
+            for tile in &cell.tiles {
+                if tile.lat.floor() as i32 == region.lat && tile.lon.floor() as i32 == region.lon {
+                    unique.insert(tile.to_tile_coord());
+                }
+            }
+        }
+
+        unique.into_iter().collect()
+    }
+
+    /// Grid cell keys that overlap a DSF region.
+    ///
+    /// Derives the corners through `cell_key` rather than recomputing the
+    /// floor division, so there is one mapping from position to cell. With
+    /// the default 1.0 cell size this yields exactly one key.
+    fn cells_covering_region(&self, region: DsfRegion) -> Vec<(i16, i16)> {
+        // Nudge inside the region's far edge: the region is the half-open
+        // box [lat, lat+1) x [lon, lon+1), so lat+1.0 belongs to the *next*
+        // region and must not pull in an extra row of cells.
+        const INSIDE_EDGE: f32 = 1.0 - 1e-4;
+
+        let (lat_min, lon_min) = self.cell_key(region.lat as f32, region.lon as f32);
+        let (lat_max, lon_max) = self.cell_key(
+            region.lat as f32 + INSIDE_EDGE,
+            region.lon as f32 + INSIDE_EDGE,
+        );
+
+        let mut keys = Vec::new();
+        for lat_cell in lat_min..=lat_max {
+            for lon_cell in lon_min..=lon_max {
+                keys.push((lat_cell, lon_cell));
+            }
+        }
+        keys
     }
 
     /// Get the total number of indexed tiles.
@@ -673,6 +735,7 @@ impl std::error::Error for SceneryIndexError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::geo_index::DsfRegion;
 
     #[test]
     fn test_parse_dds_filename_bing() {
@@ -792,6 +855,107 @@ mod tests {
         // 1 degree east at 45° lat (should be ~42nm due to cosine)
         let dist = approximate_distance_nm(45.0, -120.0, 45.0, -119.0);
         assert!((dist - 42.4).abs() < 2.0);
+    }
+
+    /// Helper: a land tile at a given position. Row/col are irrelevant to the
+    /// region predicate but must be distinct so dedup tests are meaningful.
+    fn tile_at(row: u32, col: u32, lat: f32, lon: f32) -> SceneryTile {
+        SceneryTile {
+            row,
+            col,
+            chunk_zoom: 16,
+            lat,
+            lon,
+            is_sea: false,
+        }
+    }
+
+    #[test]
+    fn test_tiles_in_region_includes_only_tiles_centred_inside() {
+        let index = SceneryIndex::with_defaults();
+        // Inside the +33-119 region.
+        index.add_tile(tile_at(1000, 2000, 33.01, -118.99));
+        index.add_tile(tile_at(1016, 2016, 33.99, -118.01));
+        // Just outside each edge.
+        index.add_tile(tile_at(2000, 2000, 32.99, -118.5)); // south
+        index.add_tile(tile_at(2016, 2016, 34.01, -118.5)); // north
+        index.add_tile(tile_at(2032, 2032, 33.5, -119.01)); // west
+        index.add_tile(tile_at(2048, 2048, 33.5, -117.99)); // east
+
+        let tiles = index.tiles_in_region(DsfRegion::new(33, -119));
+
+        assert_eq!(
+            tiles.len(),
+            2,
+            "only the two tiles centred inside +33-119 belong to it, got {:?}",
+            tiles
+        );
+    }
+
+    #[test]
+    fn test_tiles_in_region_deduplicates_shared_textures() {
+        let index = SceneryIndex::with_defaults();
+        // Many .ter files share one base DDS texture. After the /16 division in
+        // to_tile_coord these collapse to the same TileCoord.
+        index.add_tile(tile_at(1000, 2000, 33.1, -118.9));
+        index.add_tile(tile_at(1001, 2001, 33.2, -118.8));
+        index.add_tile(tile_at(1007, 2015, 33.3, -118.7));
+
+        let tiles = index.tiles_in_region(DsfRegion::new(33, -119));
+
+        assert_eq!(
+            tiles.len(),
+            1,
+            "1000, 1001, 1007 all fall in chunk-row block [992, 1008), one tile coord"
+        );
+        assert_eq!(tiles[0].row, 1000 / 16);
+        assert_eq!(tiles[0].col, 2000 / 16);
+    }
+
+    #[test]
+    fn test_tiles_in_region_southern_western_hemisphere() {
+        // floor() on negatives is where an off-by-one hides: floor(-33.5) is -34,
+        // so the region containing -33.5 is DsfRegion { lat: -34 }.
+        let index = SceneryIndex::with_defaults();
+        index.add_tile(tile_at(1000, 2000, -33.5, -70.5));
+        index.add_tile(tile_at(3000, 4000, -32.5, -70.5)); // region -33, not -34
+
+        let tiles = index.tiles_in_region(DsfRegion::new(-34, -71));
+
+        assert_eq!(tiles.len(), 1, "only the -33.5 tile is in +-34-071");
+        assert_eq!(tiles[0].row, 1000 / 16);
+    }
+
+    #[test]
+    fn test_tiles_in_region_honours_non_default_cell_size() {
+        // A 0.5 degree grid splits one DSF region across four cells. All four
+        // must be visited or the result silently loses three quarters of them.
+        let config = SceneryIndexConfig {
+            grid_cell_size: 0.5,
+            include_sea_tiles: true,
+        };
+        let index = SceneryIndex::new(config);
+        index.add_tile(tile_at(1000, 2000, 33.2, -118.8)); // cell (66, -238)
+        index.add_tile(tile_at(2000, 3000, 33.7, -118.8)); // cell (67, -238)
+        index.add_tile(tile_at(3000, 4000, 33.2, -118.3)); // cell (66, -237)
+        index.add_tile(tile_at(4000, 5000, 33.7, -118.3)); // cell (67, -237)
+
+        let tiles = index.tiles_in_region(DsfRegion::new(33, -119));
+
+        assert_eq!(
+            tiles.len(),
+            4,
+            "all four sub-cells must be visited, got {:?}",
+            tiles
+        );
+    }
+
+    #[test]
+    fn test_tiles_in_region_empty_for_uncovered_region() {
+        let index = SceneryIndex::with_defaults();
+        index.add_tile(tile_at(1000, 2000, 33.5, -118.5));
+
+        assert!(index.tiles_in_region(DsfRegion::new(50, 10)).is_empty());
     }
 
     /// Integration test with real scenery package.

--- a/xearthlayer/src/prefetch/state_observer.rs
+++ b/xearthlayer/src/prefetch/state_observer.rs
@@ -7,7 +7,6 @@
 //! clear the state so the region is re-prefetched. See #176.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -31,8 +30,6 @@ pub struct PrefetchStateObserver {
     /// ever diverged, which is small enough not to need eviction.
     last_demotion: Mutex<HashMap<DsfRegion, Instant>>,
     demotion_interval: Duration,
-    divergences: AtomicU64,
-    demotions: AtomicU64,
 }
 
 impl PrefetchStateObserver {
@@ -42,8 +39,6 @@ impl PrefetchStateObserver {
             metrics_client: None,
             last_demotion: Mutex::new(HashMap::new()),
             demotion_interval: DEFAULT_DEMOTION_INTERVAL,
-            divergences: AtomicU64::new(0),
-            demotions: AtomicU64::new(0),
         }
     }
 
@@ -56,27 +51,6 @@ impl PrefetchStateObserver {
     pub fn with_demotion_interval(mut self, interval: Duration) -> Self {
         self.demotion_interval = interval;
         self
-    }
-
-    /// Total divergences observed since this observer was created.
-    ///
-    /// Mirrors the `PrefetchStateDiverged` metric emitted on the same path.
-    /// It exists because `MetricsClient` is fire-and-forget over an
-    /// unbounded channel — a test cannot synchronously assert that a metric
-    /// was emitted, so this counter gives the rate-limiting behaviour
-    /// something observable to check.
-    pub fn divergences(&self) -> u64 {
-        self.divergences.load(Ordering::Relaxed)
-    }
-
-    /// Total demotions performed since this observer was created.
-    ///
-    /// Mirrors the `PrefetchRegionDemoted` metric emitted on the same path.
-    /// It exists for the same reason as [`Self::divergences`]: the metrics
-    /// path cannot be observed synchronously, so tests need a direct way to
-    /// confirm the rate limit actually suppressed a demotion.
-    pub fn demotions(&self) -> u64 {
-        self.demotions.load(Ordering::Relaxed)
     }
 
     /// Evaluate a completed DDS response.
@@ -99,7 +73,6 @@ impl PrefetchStateObserver {
             return;
         }
 
-        self.divergences.fetch_add(1, Ordering::Relaxed);
         if let Some(ref metrics) = self.metrics_client {
             metrics.prefetch_state_diverged();
         }
@@ -109,7 +82,6 @@ impl PrefetchStateObserver {
         }
 
         self.geo_index.remove::<PrefetchedRegion>(&region);
-        self.demotions.fetch_add(1, Ordering::Relaxed);
         if let Some(ref metrics) = self.metrics_client {
             metrics.prefetch_region_demoted();
         }
@@ -129,6 +101,13 @@ impl PrefetchStateObserver {
     ///
     /// The lock is only reached on the divergence path, after both early
     /// returns, so contention is not a concern.
+    ///
+    /// `.unwrap()` on the lock panics on poisoning, matching the existing
+    /// convention for `Mutex` state elsewhere in prefetch (e.g.
+    /// `boundary_strategy.rs`, `calibrator.rs`) — this is not a novel risk.
+    /// It also cannot corrupt the DDS bytes served to X-Plane: the caller
+    /// (`do_request()` in `fuse3/shared.rs`) reads `response.data` *after*
+    /// invoking this hook, so this call sits off the texture-response path.
     fn claim_demotion(&self, region: DsfRegion) -> bool {
         let now = Instant::now();
         let mut log = self.last_demotion.lock().unwrap();
@@ -146,6 +125,7 @@ impl PrefetchStateObserver {
 mod tests {
     use super::*;
     use crate::geo_index::PrefetchedRegion;
+    use crate::metrics::MetricEvent;
 
     /// A tile whose centre lies inside DsfRegion { lat: 33, lon: -119 }.
     fn tile_in_33_119() -> TileCoord {
@@ -155,6 +135,18 @@ mod tests {
     fn region_of(tile: TileCoord) -> DsfRegion {
         let (lat, lon) = tile.to_lat_lon();
         DsfRegion::from_lat_lon(lat, lon)
+    }
+
+    /// Build a `MetricsClient` over a fresh channel, returning it alongside
+    /// the receiver so a test can drain and assert exactly which events were
+    /// emitted. `MetricsClient` is otherwise fire-and-forget with no way to
+    /// observe emission synchronously — this is that seam.
+    fn test_metrics_client() -> (
+        MetricsClient,
+        tokio::sync::mpsc::UnboundedReceiver<MetricEvent>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (MetricsClient::new(tx), rx)
     }
 
     #[test]
@@ -195,7 +187,9 @@ mod tests {
         let region = region_of(tile);
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
 
-        let observer = PrefetchStateObserver::new(Arc::clone(&geo_index));
+        let (metrics, mut rx) = test_metrics_client();
+        let observer =
+            PrefetchStateObserver::new(Arc::clone(&geo_index)).with_metrics_client(metrics);
         observer.observe(tile, true);
 
         assert!(
@@ -204,6 +198,10 @@ mod tests {
                 .unwrap()
                 .is_prefetched(),
             "serving a prefetched tile from cache is the system working"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "a cache hit must not emit any metric — it never reaches the lookup"
         );
     }
 
@@ -238,22 +236,42 @@ mod tests {
         let tile = tile_in_33_119();
         let region = region_of(tile);
 
-        let observer = PrefetchStateObserver::new(Arc::clone(&geo_index));
+        let (metrics, mut rx) = test_metrics_client();
+        let observer =
+            PrefetchStateObserver::new(Arc::clone(&geo_index)).with_metrics_client(metrics);
 
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
         observer.observe(tile, false);
-        assert_eq!(observer.divergences(), 1);
-        assert_eq!(observer.demotions(), 1);
+
+        // First divergence demotes: both events fire, diverged before demoted.
+        assert!(
+            matches!(rx.try_recv(), Ok(MetricEvent::PrefetchStateDiverged)),
+            "a demoted divergence must emit PrefetchStateDiverged"
+        );
+        assert!(
+            matches!(rx.try_recv(), Ok(MetricEvent::PrefetchRegionDemoted)),
+            "a demoted divergence must emit PrefetchRegionDemoted"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "exactly two events for a demoted divergence"
+        );
 
         // Region re-promoted, then diverges again inside the window.
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
         observer.observe(tile, false);
 
-        assert_eq!(observer.divergences(), 2, "every divergence is counted");
-        assert_eq!(
-            observer.demotions(),
-            1,
-            "the second demotion is rate limited"
+        // Second divergence is still counted (diverged fires)...
+        assert!(
+            matches!(rx.try_recv(), Ok(MetricEvent::PrefetchStateDiverged)),
+            "every divergence is counted, even when the demotion is rate limited"
+        );
+        // ...but the demotion itself is rate limited: no PrefetchRegionDemoted.
+        // This is the assertion that would catch the two emission calls being
+        // swapped: a swap would emit PrefetchRegionDemoted here instead.
+        assert!(
+            rx.try_recv().is_err(),
+            "the second demotion is rate limited — no PrefetchRegionDemoted"
         );
         assert!(
             geo_index
@@ -270,7 +288,9 @@ mod tests {
         let tile = tile_in_33_119();
         let region = region_of(tile);
 
+        let (metrics, mut rx) = test_metrics_client();
         let observer = PrefetchStateObserver::new(Arc::clone(&geo_index))
+            .with_metrics_client(metrics)
             .with_demotion_interval(Duration::ZERO);
 
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
@@ -278,10 +298,12 @@ mod tests {
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
         observer.observe(tile, false);
 
+        let demoted_count = std::iter::from_fn(|| rx.try_recv().ok())
+            .filter(|event| matches!(event, MetricEvent::PrefetchRegionDemoted))
+            .count();
         assert_eq!(
-            observer.demotions(),
-            2,
-            "a zero window permits every demotion"
+            demoted_count, 2,
+            "a zero window permits every demotion to emit PrefetchRegionDemoted"
         );
     }
 }

--- a/xearthlayer/src/prefetch/state_observer.rs
+++ b/xearthlayer/src/prefetch/state_observer.rs
@@ -1,0 +1,287 @@
+//! Detects divergence between prefetch's region-state claims and reality.
+//!
+//! When FUSE has to generate a tile on demand in a region prefetch marked
+//! `Prefetched` or `NoCoverage`, the claim was wrong. Three causes produce
+//! this — a gap in the scenery index, a premature promotion, or eviction of
+//! the tile after promotion — and the response is the same for all three:
+//! clear the state so the region is re-prefetched. See #176.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::coord::TileCoord;
+use crate::geo_index::{DsfRegion, GeoIndex, PrefetchedRegion};
+use crate::metrics::MetricsClient;
+
+/// Minimum interval between demotions of the same region.
+///
+/// Mirrors the default `prefetch.stale_region_timeout`. It is a constant
+/// rather than plumbed config because FUSE has no reason to depend on the
+/// prefetch config, and this bounds a diagnostic response, not a correctness
+/// decision. Eviction inside the retained window can recur, and an unbounded
+/// demote → re-prefetch → evict loop would churn on a long flight.
+const DEFAULT_DEMOTION_INTERVAL: Duration = Duration::from_secs(120);
+
+pub struct PrefetchStateObserver {
+    geo_index: Arc<GeoIndex>,
+    metrics_client: Option<MetricsClient>,
+    /// Last demotion per region. Bounded by the number of regions that have
+    /// ever diverged, which is small enough not to need eviction.
+    last_demotion: Mutex<HashMap<DsfRegion, Instant>>,
+    demotion_interval: Duration,
+    divergences: AtomicU64,
+    demotions: AtomicU64,
+}
+
+impl PrefetchStateObserver {
+    pub fn new(geo_index: Arc<GeoIndex>) -> Self {
+        Self {
+            geo_index,
+            metrics_client: None,
+            last_demotion: Mutex::new(HashMap::new()),
+            demotion_interval: DEFAULT_DEMOTION_INTERVAL,
+            divergences: AtomicU64::new(0),
+            demotions: AtomicU64::new(0),
+        }
+    }
+
+    pub fn with_metrics_client(mut self, client: MetricsClient) -> Self {
+        self.metrics_client = Some(client);
+        self
+    }
+
+    /// Override the demotion rate-limit window. Test seam.
+    pub fn with_demotion_interval(mut self, interval: Duration) -> Self {
+        self.demotion_interval = interval;
+        self
+    }
+
+    /// Total divergences observed since this observer was created.
+    ///
+    /// Mirrors the `PrefetchStateDiverged` metric emitted on the same path.
+    /// It exists because `MetricsClient` is fire-and-forget over an
+    /// unbounded channel — a test cannot synchronously assert that a metric
+    /// was emitted, so this counter gives the rate-limiting behaviour
+    /// something observable to check.
+    pub fn divergences(&self) -> u64 {
+        self.divergences.load(Ordering::Relaxed)
+    }
+
+    /// Total demotions performed since this observer was created.
+    ///
+    /// Mirrors the `PrefetchRegionDemoted` metric emitted on the same path.
+    /// It exists for the same reason as [`Self::divergences`]: the metrics
+    /// path cannot be observed synchronously, so tests need a direct way to
+    /// confirm the rate limit actually suppressed a demotion.
+    pub fn demotions(&self) -> u64 {
+        self.demotions.load(Ordering::Relaxed)
+    }
+
+    /// Evaluate a completed DDS response.
+    ///
+    /// Cheap and non-blocking on the common path: a cache hit returns before
+    /// any lookup, and a region with no prefetch state returns after one.
+    pub fn observe(&self, tile: TileCoord, cache_hit: bool) {
+        if cache_hit {
+            return;
+        }
+
+        let (lat, lon) = tile.to_lat_lon();
+        let region = DsfRegion::from_lat_lon(lat, lon);
+
+        let Some(state) = self.geo_index.get::<PrefetchedRegion>(&region) else {
+            return;
+        };
+        // InProgress regions are expected to miss — prefetch has not finished.
+        if !(state.is_prefetched() || state.is_no_coverage()) {
+            return;
+        }
+
+        self.divergences.fetch_add(1, Ordering::Relaxed);
+        if let Some(ref metrics) = self.metrics_client {
+            metrics.prefetch_state_diverged();
+        }
+
+        if !self.claim_demotion(region) {
+            return;
+        }
+
+        self.geo_index.remove::<PrefetchedRegion>(&region);
+        self.demotions.fetch_add(1, Ordering::Relaxed);
+        if let Some(ref metrics) = self.metrics_client {
+            metrics.prefetch_region_demoted();
+        }
+
+        tracing::warn!(
+            lat = region.lat,
+            lon = region.lon,
+            tile_row = tile.row,
+            tile_col = tile.col,
+            tile_zoom = tile.zoom,
+            was_no_coverage = state.is_no_coverage(),
+            "Prefetch state contradicted by on-demand generation — region demoted"
+        );
+    }
+
+    /// Returns true if this region may be demoted now, recording the attempt.
+    ///
+    /// The lock is only reached on the divergence path, after both early
+    /// returns, so contention is not a concern.
+    fn claim_demotion(&self, region: DsfRegion) -> bool {
+        let now = Instant::now();
+        let mut log = self.last_demotion.lock().unwrap();
+        match log.get(&region) {
+            Some(last) if now.duration_since(*last) < self.demotion_interval => false,
+            _ => {
+                log.insert(region, now);
+                true
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geo_index::PrefetchedRegion;
+
+    /// A tile whose centre lies inside DsfRegion { lat: 33, lon: -119 }.
+    fn tile_in_33_119() -> TileCoord {
+        crate::coord::to_tile_coords(33.5, -118.5, 12).unwrap()
+    }
+
+    fn region_of(tile: TileCoord) -> DsfRegion {
+        let (lat, lon) = tile.to_lat_lon();
+        DsfRegion::from_lat_lon(lat, lon)
+    }
+
+    #[test]
+    fn test_diverged_prefetched_region_is_demoted() {
+        let geo_index = Arc::new(GeoIndex::new());
+        let tile = tile_in_33_119();
+        let region = region_of(tile);
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
+
+        let observer = PrefetchStateObserver::new(Arc::clone(&geo_index));
+        observer.observe(tile, false);
+
+        assert!(
+            geo_index.get::<PrefetchedRegion>(&region).is_none(),
+            "a Prefetched region contradicted by an on-demand generation must be demoted"
+        );
+    }
+
+    #[test]
+    fn test_diverged_nocoverage_region_is_cleared() {
+        // NoCoverage is the harsher claim: it excludes the region for the
+        // session. A FUSE generation there disproves it outright.
+        let geo_index = Arc::new(GeoIndex::new());
+        let tile = tile_in_33_119();
+        let region = region_of(tile);
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::no_coverage());
+
+        let observer = PrefetchStateObserver::new(Arc::clone(&geo_index));
+        observer.observe(tile, false);
+
+        assert!(geo_index.get::<PrefetchedRegion>(&region).is_none());
+    }
+
+    #[test]
+    fn test_cache_hit_is_not_divergence() {
+        let geo_index = Arc::new(GeoIndex::new());
+        let tile = tile_in_33_119();
+        let region = region_of(tile);
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
+
+        let observer = PrefetchStateObserver::new(Arc::clone(&geo_index));
+        observer.observe(tile, true);
+
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region)
+                .unwrap()
+                .is_prefetched(),
+            "serving a prefetched tile from cache is the system working"
+        );
+    }
+
+    #[test]
+    fn test_in_progress_region_is_not_divergence() {
+        // A region still being prefetched is *expected* to miss.
+        let geo_index = Arc::new(GeoIndex::new());
+        let tile = tile_in_33_119();
+        let region = region_of(tile);
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+
+        let observer = PrefetchStateObserver::new(Arc::clone(&geo_index));
+        observer.observe(tile, false);
+
+        assert!(geo_index
+            .get::<PrefetchedRegion>(&region)
+            .unwrap()
+            .is_in_progress());
+    }
+
+    #[test]
+    fn test_untracked_region_is_not_divergence() {
+        let geo_index = Arc::new(GeoIndex::new());
+        let observer = PrefetchStateObserver::new(Arc::clone(&geo_index));
+        observer.observe(tile_in_33_119(), false);
+        assert_eq!(geo_index.count::<PrefetchedRegion>(), 0);
+    }
+
+    #[test]
+    fn test_demotion_is_rate_limited_but_divergence_is_always_counted() {
+        let geo_index = Arc::new(GeoIndex::new());
+        let tile = tile_in_33_119();
+        let region = region_of(tile);
+
+        let observer = PrefetchStateObserver::new(Arc::clone(&geo_index));
+
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
+        observer.observe(tile, false);
+        assert_eq!(observer.divergences(), 1);
+        assert_eq!(observer.demotions(), 1);
+
+        // Region re-promoted, then diverges again inside the window.
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
+        observer.observe(tile, false);
+
+        assert_eq!(observer.divergences(), 2, "every divergence is counted");
+        assert_eq!(
+            observer.demotions(),
+            1,
+            "the second demotion is rate limited"
+        );
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region)
+                .unwrap()
+                .is_prefetched(),
+            "rate-limited divergence must leave the state alone"
+        );
+    }
+
+    #[test]
+    fn test_demotion_allowed_again_after_the_window() {
+        let geo_index = Arc::new(GeoIndex::new());
+        let tile = tile_in_33_119();
+        let region = region_of(tile);
+
+        let observer = PrefetchStateObserver::new(Arc::clone(&geo_index))
+            .with_demotion_interval(Duration::ZERO);
+
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
+        observer.observe(tile, false);
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
+        observer.observe(tile, false);
+
+        assert_eq!(
+            observer.demotions(),
+            2,
+            "a zero window permits every demotion"
+        );
+    }
+}

--- a/xearthlayer/src/prefetch/state_observer.rs
+++ b/xearthlayer/src/prefetch/state_observer.rs
@@ -5,6 +5,12 @@
 //! this — a gap in the scenery index, a premature promotion, or eviction of
 //! the tile after promotion — and the response is the same for all three:
 //! clear the state so the region is re-prefetched. See #176.
+//!
+//! Re-prefetching only *repairs* the last two. The scenery index is immutable
+//! for the life of the process, so for an index gap the next cycle re-derives
+//! the same empty tile set and re-marks the region `NoCoverage`. The loop is
+//! bounded and safe, but for that cause the observer can only flag the gap in
+//! the log and metrics — never fix it.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/xearthlayer/src/prefetch/state_observer.rs
+++ b/xearthlayer/src/prefetch/state_observer.rs
@@ -16,18 +16,21 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use crate::config::defaults::DEFAULT_PREFETCH_STALE_REGION_TIMEOUT;
 use crate::coord::TileCoord;
 use crate::geo_index::{DsfRegion, GeoIndex, PrefetchedRegion};
 use crate::metrics::MetricsClient;
 
 /// Minimum interval between demotions of the same region.
 ///
-/// Mirrors the default `prefetch.stale_region_timeout`. It is a constant
-/// rather than plumbed config because FUSE has no reason to depend on the
-/// prefetch config, and this bounds a diagnostic response, not a correctness
-/// decision. Eviction inside the retained window can recur, and an unbounded
-/// demote → re-prefetch → evict loop would churn on a long flight.
-const DEFAULT_DEMOTION_INTERVAL: Duration = Duration::from_secs(120);
+/// Derived from the default `prefetch.stale_region_timeout` canonical constant
+/// to maintain a structural link. It is a constant rather than plumbed config
+/// because FUSE has no reason to depend on the prefetch config, and this bounds
+/// a diagnostic response, not a correctness decision. Eviction inside the
+/// retained window can recur, and an unbounded demote → re-prefetch → evict
+/// loop would churn on a long flight.
+const DEFAULT_DEMOTION_INTERVAL: Duration =
+    Duration::from_secs(DEFAULT_PREFETCH_STALE_REGION_TIMEOUT);
 
 pub struct PrefetchStateObserver {
     geo_index: Arc<GeoIndex>,

--- a/xearthlayer/src/service/orchestrator/core.rs
+++ b/xearthlayer/src/service/orchestrator/core.rs
@@ -384,11 +384,12 @@ impl ServiceOrchestrator {
             }
 
             match index.build_from_package(path) {
-                Ok(count) => {
-                    total_tiles += count;
+                Ok(stats) => {
+                    total_tiles += stats.parsed;
                     tracing::debug!(
                         region = %region,
-                        tiles = count,
+                        tiles = stats.parsed,
+                        failed = stats.failed,
                         "Indexed scenery package"
                     );
                 }

--- a/xearthlayer/src/service/orchestrator/prefetch.rs
+++ b/xearthlayer/src/service/orchestrator/prefetch.rs
@@ -39,6 +39,7 @@ impl ServiceOrchestrator {
         let runtime_handle = service.runtime_handle().clone();
 
         let dds_disk_checker = service.dds_disk_checker();
+        let metrics_client = service.metrics_client();
 
         if let Some(memory_cache) = service.memory_cache_bridge() {
             self.start_prefetch_with_cache(
@@ -46,6 +47,7 @@ impl ServiceOrchestrator {
                 dds_client,
                 memory_cache,
                 dds_disk_checker,
+                metrics_client,
             )?;
         } else {
             tracing::warn!("Memory cache not available, prefetch disabled");
@@ -62,6 +64,7 @@ impl ServiceOrchestrator {
         dds_client: Arc<dyn DdsClient>,
         memory_cache: Arc<M>,
         dds_disk_checker: Option<Arc<dyn crate::executor::DdsDiskCacheChecker>>,
+        metrics_client: Option<crate::metrics::MetricsClient>,
     ) -> Result<(), ServiceError> {
         use crate::prefetch::AircraftState as PrefetchAircraftState;
 
@@ -140,6 +143,16 @@ impl ServiceOrchestrator {
         // Wire scenery index if available
         if self.scenery_index.tile_count() > 0 {
             coordinator = coordinator.with_scenery_index(Arc::clone(&self.scenery_index));
+            tracing::info!("Scenery index wired to prefetch (installed-tile lookup enabled)");
+        } else {
+            tracing::warn!(
+                "Scenery index is empty (no ortho scenery installed) — prefetch will be inert"
+            );
+        }
+
+        // Wire metrics client for prefetch telemetry (#176)
+        if let Some(metrics_client) = metrics_client {
+            coordinator = coordinator.with_metrics_client(metrics_client);
         }
 
         // Wire ortho union index for disk-based tile filtering (Issue #39)


### PR DESCRIPTION
## Summary

> **⚠️ This branch is NOT merge-ready on green CI alone.** It changes core prefetch promotion logic and requires live X-Plane 12 validation over multiple 500nm+ flights before sign-off. The PR is open now as a review and testing surface — please fly it. Acceptance criteria are in the Test Plan below.

Region promotion decided whether a DSF region was fully cached by asking which tiles the region *should* contain. There were **two implementations of that question**, and the promotion path was running the wrong one.

Both were born identical in `69658ca` (#58). Twelve hours later `ef47aa1` added a region filter and deduplication — and touched **one file**:

```
 .../src/prefetch/adaptive/coordinator/core.rs | 268 ++++++
 1 file changed
```

The `BoundaryStrategy` copy never got the fix, and `88fde88` (#157) later made it `pub` so the promotion and rescue paths could both call it. **Promotion has been running the pre-fix copy of a function that was fixed five months ago.**

### Three defects, none of which needed an incomplete scenery index

**1. Promotion demanded tiles from neighbouring regions.** A 45nm radius circle around a 1° region centre extends ~15nm past its north and south edges. `promote_completed_regions` required *all* of them on disk — including tiles belonging to adjacent regions that were never submitted for this one. Under a moving prefetch box the leading edge never satisfies that, so the fast path effectively could not fire.

**2. The rescue path promoted on a one-tile sample.** `tiles.first()` — one arbitrary tile, from unordered iteration, deciding a whole region.

Together these mechanically explain #172's observed **61:4 rescue-to-normal promotion ratio**. The fast path was gated on a condition it could not meet, so 61 of 65 promotions were decided by a single-tile sample. #172 attributed that ratio to the `cached_tiles` shadow and fixed it; this cause was never addressed.

Note the composition hazard: each defect looks *conservative* alone ("check more tiles", "keep a safety net"). Composed, they produce the least safe outcome available — the strict check never fires, so the loose one decides everything.

**3. The geometric fallback was a 16-point sample.** `expand_to_tiles(region, 14)` sampled a 4×4 grid of a region that really holds a median of **156** tiles (p95 352, max 1050, measured on a real 11-package install). "All tiles cached" meant "all 16 of 156".

### The original hypothesis was measurably false

#176 was filed on the theory that `.ter` parse failures leave the index incomplete. On a full install the index holds **4,453,034 tiles**, and the eleven independent `read_dir` counts in the cache header sum to exactly 4,453,034 — **parse success is 100% across 4.45M files**. That failure mode has zero occurrences on the only install we can measure.

The observability half of this PR is therefore not bug-hunting. Its job is to keep a verified fact verified, and to make a future malformed package visible.

## Changes

**`SceneryIndex::tiles_in_region` is now the single definition** of a region's tile set, consumed by the submit, promote and rescue paths alike. A `DsfRegion` *is* a grid cell — `cell_key` floors by `cell_size` (default 1.0) and `DsfRegion` floors by 1.0, the same partition — so the default path is one `HashMap` lookup, replacing a 16-key (4×4) cell scan plus per-tile distance maths plus a filter that together recovered exactly the contents of one cell. (Nine is the number of cells a 45nm circle geometrically intersects at mid-latitudes; the deleted query's own `cells_searched` debug field computed sixteen — its `.ceil()` on the upper bound over-scanned a full ring beyond the circle.)

**The rescue path now uses the same full-coverage predicate as the fast path.** The single-tile sample is gone.

**The geometric fallback is deleted.** A region with no indexed tiles is marked `NoCoverage` rather than prefetched from a 16-point guess. This also revives `mark_no_coverage`, previously unreachable below 85° latitude.

**Four dead functions removed** — `tiles_for_region`, `expand_to_tiles`, `land_tiles_near`, `tiles_near_at_zoom`. All were `pub` in a library crate, which is why `clippy -D warnings` never flagged them: rustc treats any `pub` item in a lib as potentially used downstream, and this workspace has no downstream consumer. That is the same mechanism that hid the drifted duplicate after #157 made it `pub`.

**`.ter` parse failures are counted and surfaced.** Per-file logging stays at `debug!` — at 4.45M files a wholesale-malformed package logging per-file at `warn!` would emit millions of lines, the exact flood #209 removed. The visible signal is one aggregated `warn!` per package with a count and up to five sample paths. `scenery-index status` gains a completeness line; on a real install it reads `Indexed: 4453034 of 4453034 .ter files (100.0%)`.

**A 60s `Prefetch sample` line**, on the same cadence as #209's memory sample:

```
Prefetch sample uptime_s=… regions_in_progress=… regions_prefetched=…
                regions_nocoverage=… promotions_normal=… promotions_rescue=…
                state_diverged=… regions_demoted=… fuse_generations=…
```

The per-cycle `debug!` distribution line is unchanged. This exists because **all five flight-test criteria below are now read from this one line**: region state for criteria 3 and 4, previously visible only at `--debug`; the promotion counters for criterion 1; and, since remediation, `fuse_generations` (mirroring the existing `fuse_jobs_submitted` counter) for criterion 5 — previously unreadable at any log level, since per-tile FUSE request logging is `debug!`-only (#209). `--debug` is impractical to run for a whole 500nm flight and is overwritten on the next launch.

**`PrefetchStateObserver`** — when FUSE has to *generate* a tile in a region prefetch marked `Prefetched` or `NoCoverage`, the claim was wrong. Three causes produce that (an index gap, a premature promotion, post-promotion eviction) and the response is identical for all three: clear the state so the region is re-prefetched. This runs synchronously inside `do_request()` (`fuse3/shared.rs`) — `self.on_dds_response(...)` fires immediately before `response.data` is returned — so it is *on* the texture-response path, not off it. It cannot corrupt the served DDS bytes (`response.data` is set before this call and unaffected by it), and the one lock it can take — the demotion rate-limit mutex — is reached only on the divergence branch, after two early returns, so contention there is not a practical concern. Demotion is rate-limited to once per region per 120s — eviction inside the retained window recurs, and an unbounded demote → re-prefetch → evict loop would churn on a long flight — while **every** divergence is counted, so the two numbers can diverge.

It correctly stays silent for `InProgress` regions (expected to miss) and for cache hits (the system working).

## Related Issues

Fixes #176

> **Note on auto-close:** GitHub only acts on a closing keyword when a PR merges into the *default* branch (`main`). This PR targets `develop/0.4.7`, so the keyword above will not fire on merge here — `Fixes #176` is also in commit `8541ee7`'s message, which closes the issue automatically when `develop/0.4.7` reaches `main`.

## Changes since review

Fifteen commits landed after the adversarial review (`3d73a63..f253bb1`), closing gaps the review found in the promotion logic itself, not just in its tests and docs.

**One completeness predicate now serves both promotion paths.** `BoundaryStrategy::region_disk_state` (`e1ce72c`) replaces the two independently-drifted copies that used to live in `promote_completed_regions` (fast path) and `evaluate_stale_regions` (rescue path) — the same copy-drift shape #176 was filed to remove, just one level down. It returns a four-state `RegionDiskState` (`Complete` / `Incomplete` / `NoTiles` / `Unknown`) instead of a `bool`. `Unknown` — no `DdsDiskCacheChecker` and/or no `SceneryIndex` wired — is the important addition: previously the rescue path's `_ => false` treated "no authoritative source to consult" identically to "checked and it's absent," so an unconfigured disk checker could strike a region toward permanent `NoCoverage`. `Unknown` is now left untouched and does not consume a retry. This incidentally fixed a second, previously undocumented copy-drift case: "scenery index absent but a checker present" used to strike toward permanent `NoCoverage` on the rescue path while the fast path treated the identical situation as a harmless no-op (an early return, no side effects).

**Region coverage is now a disjunction, not just the XEL cache.** `cc85bc0` adds a `tile_is_covered` check inside `region_disk_state`: a tile counts as covered if it's in the XEL DDS disk cache **or** ships as a real `.dds` file inside an installed scenery package (`OrthoUnionIndex::dds_tile_exists`, chunk-coordinate lookup). Prefetch's stage-3 filter already skips tiles that exist in an installed package — it never writes them to the XEL cache — so without this, a region entirely covered by package imagery could never be confirmed by promotion and would ratchet to `NoCoverage` over land after `MAX_REGION_ATTEMPTS`. That's exactly the false alarm flight criterion 4 below is watching for.

**Two new cumulative counters.** `97db4c7` adds `promotions_normal` and `promotions_rescue` to the `Prefetch sample` log line above, wired through the same event → client → state → daemon chain as the existing divergence/demotion counters. This is what makes flight criterion 1 measurable at default log level for the first time — see the Test Plan.

**Region strike counts have three exits, and all three now clear or preserve the count correctly (`1e209a3`, `fd89b48`).** `region_attempts` previously only ever incremented. Promotion clears the count on both paths (`1e209a3`) — the strike belongs to the failed episode, not the region, so a region that failed twice, recovered, and was later demoted by `PrefetchStateObserver` shouldn't be retired on one fresh failure using strikes from hours earlier. The retry branch deliberately does **not** clear it: that branch removes the region's `GeoIndex` entry to make it eligible for re-prefetch, and `region_attempts` is the only thing left remembering the region failed last time; clearing it there would make `MAX_REGION_ATTEMPTS` unreachable. The third exit — **retirement** to `NoCoverage` — was missing this entirely until `fd89b48`: a region retired at `MAX_REGION_ATTEMPTS` strikes kept that count, so when `PrefetchStateObserver` later demoted it out of `NoCoverage` (correctly, because it observed the claim was wrong), the region re-entered the prefetch cycle already at the strike ceiling — one single fresh failure re-hit `>= MAX_REGION_ATTEMPTS` and instantly re-retired it, with zero real retries. Because strike-driven retirement only ever fires on regions with indexed tiles (ocean regions take the empty-index path and never touch the counter), every region this hit was, by construction, land — biasing flight criterion 4 toward false alarm. `fd89b48` clears the count on retirement too, so a demoted region gets a fresh set of `MAX_REGION_ATTEMPTS` strikes each time; the observer's own demotion rate limit (one per region per ~120s) bounds how often that can recur, not this counter. The fix also resolves a self-contradictory warning: the retirement log line's fixed text ("after 3 failed attempts") could previously be paired with `attempts=4` from a leftover count — now the two agree.

**Four test gaps closed, each by a test confirmed to fail against the specific break it targets.** `c3b81e9` closes two: the planning-path `NoCoverage` marking had no test that ran a real planning cycle and read `GeoIndex` state — deleting the marking made the new test's submission-count assertion fail; and the two-phase `InProgress`→`Prefetched` commit boundary was unenforced because an existing test's mock played both the filter authority and the promotion authority — replacing the disk-verified promotion with a direct `Prefetched` insert left that test green, which the new test (emptying the plan via the memory-cache filter while the disk checker reports every tile absent) catches. `8da109d` closes two more: `with_metrics_client` had zero test callers, leaving the region-state gauge classification unverified — deleting the `metrics.prefetch_region_state(...)` emission, swapping its argument order, and swapping the `is_in_progress`/`is_prefetched` fold arms each independently made the new test fail (the latter two both producing `expected PrefetchRegionState { in_progress: 1, prefetched: 2, no_coverage: 3 }, got PrefetchRegionState { in_progress: 2, prefetched: 1, no_coverage: 3 }`); and a zoom-mismatch regression test had separately (accidentally) mismatched row/col against the real region tiles, so a checker mutated to ignore the zoom argument entirely would still have failed to promote for the wrong reason — with the fixture corrected to the region's actual tiles (row 1373–1386), that same zoom-blind mutation now promotes and the test correctly catches it.

**Dead code removed.** The `tiles_near` radius query and its `approximate_distance_nm` helper (`8cffa8b`) — the deleted duplicate `tiles_for_region` was literally `tiles_near(centre, 45.0)` mapped to tile coordinates, so leaving `tiles_near` exported kept that drift-prone pattern one call away from returning. And the write-only `cached_tiles` `HashSet` shadow (`bba4a9d`), confirmed write-only before deletion — every remaining use was an insert/clear/retain, or a `.len()` read only for logging and tracing, never for control flow.

**Criterion 5 now has a field.** The final whole-branch review found that the `Prefetch sample` line documented itself as sufficient for "the #176 acceptance criteria" while actually carrying fields for criteria 1–4 only — criterion 5 (on-demand FUSE generations falling during cruise) had nothing to read at default log level, since per-tile FUSE logging was demoted to `debug!` in `ea02c13`. `480cdf9` emits the existing `fuse_jobs_submitted` counter (already aggregated in `AggregatedState`, previously surfaced only to the TUI) as `fuse_generations` on the same line. All five flight criteria now come from one line.

Also landed: a `TempDir` leak in a new test helper, fixed by borrowing instead of leaking (`701a567`); the FUSE-side demotion interval and the coordinator's `stale_region_timeout` default now derive from one canonical constant instead of a comment-documented mirror (`1c473bf`); the design docs (`cea1575`, `b7bdfb6`) were brought up to date with all of the above — including the corrected four-outcome `evaluate_stale_regions` description, the `GeoIndex` layer inventory (`PrefetchedRegion`/`RetainedRegion` were missing), and a retry-count off-by-one (a region gets at most 2 revert-to-absent retries before the third strike retires it, not 3); and, from the final review's cleanup pass (`f253bb1`), the orphaned `AdaptivePrefetchCoordinator::reset()` was deleted — no callers anywhere, and its doc comment's claim to reset state for "teleporting or starting a new flight" had already gone false when `bba4a9d` removed its only substantive statement — alongside three more stale documentation sites, including a `BoundaryStrategy` "Interface" block that showed a fabricated trait impl and a `calculate_prefetch` signature naming the deleted `cached_tiles` shadow.

## Test Plan

### Automated

- [x] `make pre-commit` passes — fmt, clippy `-D warnings`, 2474 passing lib tests (9 ignored), 63 doctests
- [x] **Both regression tests failed before the fix**, with the predicted assertion mismatches. This is the evidence the defect was real rather than a misreading — everything asserted about it came from reading code and `git log`, not from observing a failure
- [x] Promotion is not blocked by a missing tile in an adjacent region (defect 1)
- [x] The rescue path requires full coverage, not one tile (defect 2)
- [x] A region with no indexed tiles is marked `NoCoverage` and submits nothing
- [x] `tiles_in_region` correct for negative coordinates, non-default `grid_cell_size`, and deduplication; sea tiles remain in scope
- [x] The FUSE wiring chain is covered end-to-end (`request_dds_impl → do_request → on_dds_response → observe → GeoIndex`), mutation-verified
- [x] Metric emission asserted over a real channel, so a swapped or deleted emission is caught

### Empirical validation against a real install

- [x] **Region assignment verified across all 4,453,034 cached tiles**: `floor(LOAD_CENTER)` and `floor(TileCoord::to_lat_lon())` produce the same `DsfRegion` for every tile — **0 mismatches**. This is an empirical result, not a structural one: `tiles_in_region` (f32 `.ter` coordinates) and `PrefetchStateObserver` (f64 Mercator centre) are two independent derivations with no code-level link between them, and measurement is the only evidence they agree. It's a strong result — 0 mismatches across the full install — but a future edge case (e.g. a tile centre that lands exactly on a degree boundary under floating-point rounding) isn't ruled out by construction
- [x] Tiles per region measured: p50 156, p95 352, max 1050. Latitude range −56.0…83.7, safely inside `MAX_LAT`

### Flight testing — REQUIRED before merge

Multiple flights of 500nm or greater in X-Plane 12. Measured per flight from the `Prefetch sample` line at default log level:

- [ ] **1. Normal-path promotions dominate rescue-path promotions.** Now directly measurable: compare `promotions_normal` against `promotions_rescue` in the `Prefetch sample` line (both cumulative totals for the flight, like the other counters on that line). Previously this criterion had no counter to read at any log level — it could not actually be judged from a flight log before remediation. Baseline from the #172 LOWW log: 4 normal vs 61 rescue (6% normal). Post-fix `promotions_normal` must be the majority
- [ ] **2. `state_diverged` stays at or near zero.** Non-zero is not automatically a failure — post-promotion cache eviction produces it legitimately — but a cluster in one area needs explaining before sign-off. **This is a cumulative total for the whole flight, not a per-60s rate** (`AggregatedState::reset()` has no production caller)
- [ ] **3. `regions_in_progress` does not grow monotonically.** A ratchet means regions enter `InProgress` and never leave — the failure mode defect 1 produces today
- [ ] **4. `regions_nocoverage` corresponds to ocean.** The riskiest consequence of dropping the geometric fallback: a count rising over land means the empty-cell-means-ocean assumption is wrong. Cross-check against the route
- [ ] **5. On-demand FUSE generations fall during cruise.** Now read from `fuse_generations` on the same `Prefetch sample` line as the others (cumulative since process start), rather than an unmeasured comparison against a pre-change baseline. The user-visible outcome; the others are mechanism

**The signal that something is wrong:** `regions_nocoverage` climbing alongside `Region marked NoCoverage after 3 failed attempts` warnings.

## Checklist

- [x] Code follows the project's SOLID principles and patterns
- [x] Tests added or updated for new/changed behavior
- [x] Documentation updated (`CLAUDE.md`, `docs/dev/adaptive-prefetch-design.md`, `docs/dev/geo-index-design.md`, `docs/dev/memory-telemetry.md`)
- [x] No new warnings from `cargo clippy`

## Notes for the reviewer

**A pre-existing bug this fixes, but not for every patch region.** Patched regions previously received 16 geometric tiles that `filter_patched_regions` discarded — and because the region was then never fully submitted, it was re-planned *every single cycle, forever*. Deleting the geometric fallback fixes this **only when the scenery index has no tiles for the region at all**: `get_tiles_for_region` now marks such a region `NoCoverage` directly instead of manufacturing a 16-tile guess, so it stops re-entering the plan. Patch regions that overlay package coverage — the common case, since that's usually why a patch exists in the first place — aren't covered by that fix: the scenery index still returns real tiles for them, `filter_patched_regions` still discards all of them, and (see below) `mark_fully_filtered_regions` deliberately excludes patch-owned regions from being marked `InProgress`. Such regions keep being re-planned and re-filtered every cycle, exactly as before this PR — the comment on `mark_fully_filtered_regions` in `core.rs` says so directly.

**A second one, found and fixed during final review.** `execute()` is skipped when the plan is empty and `mark_in_progress` only fires inside it, so a region whose planned tiles all filtered out as already-cached was never marked anything — re-planning every 2s indefinitely and making `regions_prefetched` under-report. Pre-existing, but this branch creates a routine path into it via demotion, and an under-reporting gauge would have corrupted criteria 1 and 3 above. `mark_fully_filtered_regions` now marks such regions `InProgress` and lets the disk-verified `promote_completed_regions` confirm them — nothing reaches `Prefetched` without the full-coverage check.

**Patch-owned regions are deliberately excluded from that marking.** Prefetch never puts a patch region's tiles on the XEL DDS disk cache, so promotion could never confirm the claim, and every patch-owned region would reach `NoCoverage` after ~6 minutes with a misleading "failed attempts" warning in the flight log. `PatchCoverage` is a whole-region `GeoIndex` layer, so the exclusion is exact rather than heuristic.

**Coverage, stated honestly.** Measured lib-only at **61.49% on this branch vs 61.12% at the base commit** — the branch improves it, and `state_observer.rs` lands at 27/28 lines. This was measured at `3d73a63`, before the fifteen remediation commits that followed review (which both added tests and deleted code — either can move the number, and deleting well-covered dead code can move it *down* while still improving the codebase); it has not been re-measured since, and this note doesn't claim otherwise. Regardless of the exact current figure, the repository does not meet its own `COVERAGE_MIN=80` and **did not before this branch**, so please don't read the number as a regression. Related: `make coverage-check` prints "Coverage below 80%!" on *any* non-zero tarpaulin exit, including a failed test — it reported that twice during this work without ever computing a percentage. Worth its own chore issue.

**Six tests fail under `cargo tarpaulin`** instrumentation (executor daemon coalescing, `storage_limiter::test_with_defaults`, `test_telemetry_timeout`). Also checked at `3d73a63`, not re-checked since. Verified pre-existing at that point — the same failures occurred on the unmodified base commit. They pass normally in 0.15s.

**No `CHANGELOG.md` entry**, per this repo's convention of compiling the changelog at release-cut time from merged PRs. An empty `[Unreleased]` section is correct here, not an oversight.

**Known limitation worth stating:** when the cause of a divergence is a genuine scenery-index gap, the observer can only *flag* it, never repair it — the index is immutable after build, so the next cycle re-derives the same empty set. The loop is bounded (rate limit plus the `should_prefetch` guard), but don't expect self-healing for that specific cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
