### PR TITLE
fix(prefetch): gate region eviction to Cruise, matching retention (#176)

### DIFF
--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -1051,7 +1051,19 @@ impl AdaptivePrefetchCoordinator {
         }
         // Evict PrefetchedRegion entries for regions outside the retained window,
         // making them eligible for re-prefetch when the aircraft returns.
-        BoundaryStrategy::evict_non_retained(&geo_index);
+        //
+        // Gated to Cruise to match the retention update in `update()`, which is
+        // cruise-only by design. The retained set is only authoritative while it
+        // is being maintained: after landing it freezes at whatever the last
+        // cruise cycle computed, and evicting against a frozen set removes
+        // regions the ground box still covers. Those regions then re-plan, filter
+        // out as already-cached, are marked InProgress, are promoted, and are
+        // evicted again — a silent loop that inflated `promotions_normal` by
+        // ~1170 after landing on acceptance flight 1 (#176). Retention and
+        // eviction must share a phase, or the pair is not a pair.
+        if matches!(self.phase_detector.current_phase(), FlightPhase::Cruise) {
+            BoundaryStrategy::evict_non_retained(&geo_index);
+        }
 
         // Per-maintenance-cycle instrumentation (#172 Part 4): report
         // region-state distribution. A healthy system shows normal-path

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -3520,6 +3520,109 @@ mod tests {
         );
     }
 
+    // Acceptance flight 1 (PANC->PABR, 2026-08-14) found `promotions_normal`
+    // climbing ~165/min for seven minutes after the aircraft parked at the
+    // destination: no prefetch cycles logged, no batches submitted, no rescue
+    // promotions, `tiles_done` frozen, and every region gauge static
+    // (in_progress=0, prefetched=22, nocoverage=20). ~1170 promotions that
+    // moved nothing, inflating the flight's headline figure from 206 to 1376.
+    //
+    // A stationary aircraft over terrain that is already fully cached has
+    // nothing left to promote. Once the region distribution has settled,
+    // further cycles at the same position must not emit promotions — the
+    // counter measures regions promoted, and re-promoting a region that is
+    // already `Prefetched` is not work.
+    #[tokio::test]
+    async fn test_static_position_does_not_inflate_promotion_count() {
+        use crate::geo_index::{GeoIndex, RetainedRegion};
+        use crate::metrics::{MetricEvent, MetricsClient};
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let client = Arc::new(CapLimitedDdsClient::new(100_000));
+        // Every tile already on the DDS disk: the filter pipeline empties every
+        // plan, and the same checker is what promotion consults.
+        let checker: Arc<dyn DdsDiskCacheChecker> = Arc::new(AlwaysHitDiskChecker);
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let config = AdaptivePrefetchConfig {
+            mode: PrefetchMode::Aggressive,
+            ramp_duration: std::time::Duration::from_secs(0),
+            ..Default::default()
+        };
+        let mut coord = AdaptivePrefetchCoordinator::new(config)
+            .with_calibration(test_calibration())
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_client(Arc::clone(&client) as Arc<dyn DdsClient>)
+            .with_dds_disk_checker(Arc::clone(&checker))
+            .with_scenery_index(wide_scenery_index_at_50_10())
+            .with_metrics_client(MetricsClient::new(tx));
+
+        // Ground phase, parked. Acceptance flight 1's spike began within 30s of
+        // `Flight phase transition from=cruise to=ground` on landing at PABR, so
+        // the reproduction has to be in Ground, not Cruise.
+        let state = ground_state(50.0, 10.0);
+        assert_eq!(
+            coord.phase_detector.current_phase(),
+            FlightPhase::Ground,
+            "Precondition: the churn was observed in Ground phase",
+        );
+
+        // The aircraft has just landed, so retention carries whatever the last
+        // *cruise* cycle left behind — retention updates are cruise-only
+        // (see the `matches!(phase, FlightPhase::Cruise)` guard in `update`),
+        // but `evict_non_retained` runs every maintenance pass regardless of
+        // phase. Seed a retained set that does not cover the ground box to
+        // reproduce that post-landing state. A cold ground start leaves the
+        // layer empty, `evict_non_retained` no-ops, and the churn cannot occur
+        // — which is why a cold-start reproduction of this test passes.
+        geo_index.insert::<RetainedRegion>(DsfRegion::new(50, 10), RetainedRegion);
+
+        // Settle: let every region in the box reach `Prefetched`.
+        for _ in 0..4 {
+            coord.process_telemetry(&state).await;
+        }
+        assert!(
+            count_prefetched_regions(&geo_index) > 0,
+            "Precondition: the box must have settled into Prefetched regions",
+        );
+
+        let settled_prefetched = count_prefetched_regions(&geo_index);
+        let promoted = |rx: &mut tokio::sync::mpsc::UnboundedReceiver<MetricEvent>| -> usize {
+            std::iter::from_fn(|| rx.try_recv().ok())
+                .filter_map(|e| match e {
+                    MetricEvent::PrefetchRegionsPromotedNormal { count } => Some(count),
+                    _ => None,
+                })
+                .sum()
+        };
+        // Discard everything emitted while settling. Asserted non-zero so a
+        // future change that stops promoting entirely cannot make this test
+        // pass vacuously.
+        let settle_promotions = promoted(&mut rx);
+        assert!(
+            settle_promotions > 0,
+            "Precondition: the settle phase must actually exercise promotion",
+        );
+
+        // Aircraft has not moved and nothing has been evicted or invalidated,
+        // so there is no new region to confirm.
+        for _ in 0..6 {
+            coord.process_telemetry(&state).await;
+        }
+
+        let extra = promoted(&mut rx);
+        assert_eq!(
+            extra, 0,
+            "A stationary aircraft over fully-cached terrain must not keep \
+             promoting: {extra} further promotions were counted across 6 cycles \
+             with {settled_prefetched} regions already Prefetched. \
+             `promotions_normal` counts promotion events, so a region that \
+             re-enters InProgress is counted again and the flight-test figure \
+             for acceptance criterion 1 inflates without bound.",
+        );
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Two-phase commit boundary (#223 remediation, F6)
     //


### PR DESCRIPTION
## Summary

PR #223 merged at `f253bb1`. Two commits made after that point were never pushed and so were **not** included in the merge — this PR carries them forward unchanged.

They matter because **acceptance flight 2 validated a build that contains them.** The release binary flown to Perth was built seven minutes after the fix commit; `develop/0.4.7` as merged does not have it. Without this PR, a release cut from `develop/0.4.7` ships the behaviour flight 1 diagnosed and flight 2 proved fixed.

## The defect

Acceptance flight 1 (PANC→PABR) recorded `promotions_normal` climbing ~165/min for seven minutes after the aircraft parked: no prefetch cycles logged, no batches submitted, no rescue promotions, `tiles_done` frozen, and every region gauge static. ~1170 promotions that moved nothing, inflating the flight's criterion-1 figure from **206 to 1376** — in the counter added to measure that criterion.

Three individually-correct decisions compose into a loop:

1. Retention updates are **cruise-only** (the `matches!(phase, FlightPhase::Cruise)` guard in `update`), deliberately — on the ground there is no "behind" to retain, and updating there would evict legitimate far-away state such as prewarm output.
2. `evict_non_retained` had **no matching guard** and ran every maintenance pass in every phase, against whatever retained set was last computed.
3. The ground box uses the full `box_extent`, so it can cover regions outside whatever retention cruise last left behind.

After landing, retention freezes at its final cruise value while eviction keeps running against it. Regions inside the ground box but outside that frozen set are evicted → become absent → are re-planned → filter out entirely as already-cached → are marked `InProgress` → are promoted → are evicted again.

The loop is silent: `tiles_planned` is the **post-filter** count, so a cycle whose plan is emptied by the filter logs no cycle summary, and both the marking and the promotion log at `debug`.

## The fix

Eviction is gated to Cruise, so retention and eviction share a phase. The retained set governs eviction only while it is being maintained. Ground behaviour now matches a cold ground start, where the layer is empty and `evict_non_retained` already no-ops.

## Changes

- `test(prefetch)` — reproduces the churn. **This commit is deliberately red**; the fix follows in the next commit. It needs history to fail: a cold ground start leaves `RetainedRegion` empty and eviction no-ops, so two earlier reproduction attempts (static cruise, cold static ground) passed. The seeded `RetainedRegion` line is what makes it fail, and the comment says so.
- `fix(prefetch)` — the phase gate.

## Test Plan

- [x] `make pre-commit` green on this branch — fmt, clippy `-D warnings`, 2475 lib tests, 63 doctests
- [x] Test observed failing before the fix: **378 promotions across 6 stationary cycles with 1 region actually Prefetched**
- [x] Test passes after the fix; no other test affected
- [x] **Validated in flight.** Acceptance flight 2 (KDEN→Perth, 6h08m, 3h36m real cruise): 19 minutes parked after landing, six consecutive samples, `promotions_normal` frozen at 238. The same condition added ~1170 on flight 1.

Flight 2 also passed all five acceptance criteria on the fixed build:

| # | Criterion | Result |
|---|---|---|
| 1 | Normal promotions dominate rescue | 238 normal / **0** rescue |
| 2 | `state_diverged` near zero | **0** across 6h08m |
| 3 | `regions_in_progress` no ratchet | peak 16, final 0 |
| 4 | `regions_nocoverage` = ocean | **0** red-flag warnings |
| 5 | On-demand generation falls in cruise | flat at 2219 for 5h53m |

## Related Issues

Follow-up to #176 / PR #223.

## Notes for the reviewer

**Not addressed here, each pre-existing and worth its own issue:**
- The ground box uses the full `box_extent` (6.5°) rather than `box_min_extent`, giving a ~450nm box around a stationary aircraft.
- `status_updater.rs` maps `FlightPhase::Ground` to `PrefetchMode::Radial`, a strategy deleted post-#172; the engine runs `ground_box`, so the TUI label is stale.
- `submitter.rs` collapses `TrySendError::Full` into the same `None` as `::Closed`, so routine backpressure is logged as `executor may be shutdown`. Severity scales with latitude: 21,987 occurrences at 71°N vs 4,003 at 32°S.
- `gc_evicted_mb` stayed 0 for an entire 6h flight while DDS disk usage visibly fell by 30–38 GB at a time.

**No `CHANGELOG.md` entry**, per this repo's convention of compiling the changelog at release-cut time from merged PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
