### PR TITLE
chore(release): prepare 0.4.7-alpha.1 and document the preview process

### DIFF
--- a/.github/release-notes/v0.4.7-alpha.1.md
+++ b/.github/release-notes/v0.4.7-alpha.1.md
@@ -1,0 +1,80 @@
+**This is a pre-release for testing.** It is not marked Latest and is not intended for general use. If you want a stable build, use v0.4.6.
+
+Linux x86_64 only — this pre-release ships the tarball. No `.deb`, `.rpm` or AUR package is built for previews.
+
+---
+
+## What we most want tested
+
+### 1. Prefetch keeps up with the aircraft
+
+This is the headline change. Region promotion previously ran a stale duplicate of the logic that decides which tiles belong to a map region, and the effect was that the fast promotion path could effectively never fire — whole regions were being confirmed on the evidence of a single arbitrary tile.
+
+**What to look for:** scenery that is already loaded when you arrive, rather than filling in around you. Purple or white tiles, or terrain that pops in late during cruise, are what we're hunting.
+
+**Best test:** a flight of 500nm or more, at cruise, over terrain you have not flown recently.
+
+### 2. Terrain banding at distance is gone
+
+Generated textures previously declared a 5-level mipmap chain where the full chain is 13 levels. Past the distance where the hardware wanted a coarser level, the texture was undersampled rather than filtered — showing as regular banding along terrain contours at shallow viewing angles. Independent of imagery provider and zoom level.
+
+**What to look for:** look along the terrain rather than down at it, at middle distance, over hills or mountains. If you have seen this banding before, it should be absent. Reports from anyone who saw it previously are especially useful.
+
+### 3. Memory on long flights
+
+We are chasing a memory growth issue on multi-hour flights and this build carries the instrumentation for it. Long-haul flights are genuinely valuable here even if nothing goes wrong.
+
+**What to look for:** `Memory sample` lines in the log. Watch **`vm_mb`** and **`swap_mb`**, not `rss_mb` — resident memory can fall while total commitment keeps rising, because the kernel is paging out rather than the program releasing anything.
+
+---
+
+## How to report
+
+The log is at `~/.xearthlayer/xearthlayer.log`.
+
+> **Copy it before you launch again — it is overwritten on every start.**
+
+XEarthLayer writes a status line every 60 seconds at normal log level. You do not need `--debug`:
+
+```
+Prefetch sample uptime_s=… regions_in_progress=… regions_prefetched=…
+                regions_nocoverage=… promotions_normal=… promotions_rescue=…
+                state_diverged=… regions_demoted=… fuse_generations=…
+```
+
+The most useful report is **the last few of those lines plus your route, aircraft and flight time.** If something looked wrong, the whole log is better.
+
+Briefly, what the fields mean:
+
+| Field | Reading it |
+|---|---|
+| `promotions_normal` vs `promotions_rescue` | normal should dominate — rescue is the fallback path |
+| `regions_prefetched` / `regions_nocoverage` | regions ready, and regions with no scenery coverage (ocean) |
+| `regions_in_progress` | should rise and fall, not climb steadily |
+| `state_diverged` | prefetch believed a region was ready and it was not — should stay near zero |
+| `fuse_generations` | textures built on demand; should stay flat during cruise |
+
+Please include the output of `xearthlayer --version` so we know which build produced the log.
+
+---
+
+## Known issues — please don't report these
+
+**A large number of `Failed to submit job - executor may be shutdown` warnings.** This is misleading text on a normal condition: the work queue is full and the tile will be retried. The executor is fine and nothing is lost. It can account for most lines in the log, and it gets worse at high latitudes. A fix is planned.
+
+**`regions_nocoverage` above open water.** Expected — those regions have no ortho scenery, so prefetch correctly skips them. Over *land* it would be worth reporting.
+
+**Chunk download 404s from the imagery provider.** Some tiles genuinely do not exist at the requested zoom. Affected tiles are served but not cached.
+
+---
+
+## Also in this build
+
+- Cache disk-write statistics are now attributed to the correct tier — previously most of what was reported as chunk data was in fact DDS tile data.
+- Config sizes accept decimals, so a value such as `1.5 GB` can be written and read back.
+- Coverage maps take region colours from the published metadata rather than a hardcoded list, so the map and the legend agree.
+- Per-tile log lines moved to debug level; a long flight previously produced multi-gigabyte logs.
+
+Full detail in [CHANGELOG.md](https://github.com/samsoir/xearthlayer/blob/develop/0.4.7/CHANGELOG.md).
+
+Thanks for testing — flight reports are what make this work.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,27 @@ jobs:
           RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
           VERSION: ${{ needs.verify.outputs.version }}
         run: |
+          # A hand-written notes file for this exact tag wins, if present.
+          # Pre-releases need tester-facing guidance — what to look at, what
+          # noise to ignore, how to report — which does not belong in the
+          # product changelog. Stable tags normally have no such file and
+          # fall through to the CHANGELOG extraction below, unchanged.
+          # RELEASE_TAG becomes a path component here, and on workflow_dispatch
+          # it is caller-supplied, so constrain it to the tag grammar before
+          # use — no slashes, no traversal.
+          if ! printf '%s' "${RELEASE_TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-(dev|alpha|beta|rc)\.[0-9]+)?$'; then
+            echo "Tag '${RELEASE_TAG}' is not a recognised release tag; skipping notes-file lookup."
+            NOTES_FILE=""
+          else
+            NOTES_FILE=".github/release-notes/${RELEASE_TAG}.md"
+          fi
+          if [ -n "${NOTES_FILE}" ] && [ -f "${NOTES_FILE}" ]; then
+            echo "Using hand-written notes: ${NOTES_FILE}"
+            cp "${NOTES_FILE}" release_notes.md
+            cat release_notes.md
+            exit 0
+          fi
+
           # Extract release notes from CHANGELOG.md if available
           if [ -f CHANGELOG.md ]; then
             # Try to extract notes for this version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,7 +4812,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xearthlayer"
-version = "0.4.7-dev.0"
+version = "0.4.7-alpha.1"
 dependencies = [
  "axum",
  "bincode",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "xearthlayer-cli"
-version = "0.4.7-dev.0"
+version = "0.4.7-alpha.1"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [workspace.package]
 # Unstable dev cycle on develop/0.4.7 — pre-release per semver, sorts below 0.4.7.
 # Bumped to a dated X.Y.Z only at stable promotion. See docs/dev/app-release-runbook.md.
-version = "0.4.7-dev.0"
+version = "0.4.7-alpha.1"
 edition = "2021"
 authors = ["XEarthLayer Contributors"]
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -422,8 +422,16 @@ version: ## Show current version
 	@echo "$(BLUE)Current version:$(NC) $(PKG_VERSION)"
 
 .PHONY: bump-version
-bump-version: ## Bump version across all files (VERSION=x.y.z)
+bump-version: ## Bump version across all files (VERSION=x.y.z, STABLE ONLY)
 	@if [ -z "$(VERSION)" ]; then echo "$(RED)Error: VERSION is required. Usage: make bump-version VERSION=0.3.0$(NC)"; exit 1; fi
+	@# RPM forbids '-' in a Version: field (it separates Version from Release), so a
+	@# pre-release identifier would commit an invalid spec. The RPM job is skipped for
+	@# pre-releases, so this fails later — on the next stable build — not now.
+	@case "$(VERSION)" in *-*) \
+		echo "$(RED)Error: '$(VERSION)' is a pre-release identifier.$(NC)"; \
+		echo "$(YELLOW)This target also rewrites pkg/rpm/xearthlayer.spec, and RPM forbids '-' in Version:.$(NC)"; \
+		echo "$(YELLOW)Edit the version in Cargo.toml directly, then run: cargo update -w$(NC)"; \
+		exit 1;; esac
 	@echo "$(BLUE)Bumping version to $(VERSION)...$(NC)"
 	@# Update workspace Cargo.toml
 	@sed -i 's/^version = ".*"/version = "$(VERSION)"/' Cargo.toml
@@ -443,7 +451,8 @@ release-checklist: ## Show release checklist
 	@echo ""
 	@echo "  1. [ ] Ensure all tests pass: make verify"
 	@echo "  2. [ ] Update version: make bump-version VERSION=x.y.z"
-	@echo "  3. [ ] Update CHANGELOG.md with release notes"
+	@echo "         (PRE-RELEASE: edit Cargo.toml by hand instead — see below)"
+	@echo "  3. [ ] Compile CHANGELOG.md Unreleased from PRs since the last tag"
 	@echo "  4. [ ] Commit version bump"
 	@echo "  5. [ ] Push to release branch and verify CI passes"
 	@echo "  6. [ ] Create and push tag: git tag vx.y.z && git push origin vx.y.z"

--- a/docs/dev/app-release-runbook.md
+++ b/docs/dev/app-release-runbook.md
@@ -213,16 +213,36 @@ curl -s https://xearthlayer.app | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+'
 ## CHANGELOG Convention
 
 `CHANGELOG.md` keeps a single `## [Unreleased]` section at the top ([Keep a
-Changelog](https://keepachangelog.com/) format). **All** merged changes are recorded
-there as they land — on `main` or on `develop/0.4.7` — under the usual
+Changelog](https://keepachangelog.com/) format), under the usual
 Added / Changed / Fixed / Removed groups.
 
-- Entries accumulate under `## [Unreleased]` throughout a development cycle.
-- Cutting a **preview** (`-dev.N`, etc.) does **not** move entries out of Unreleased —
-  previews are snapshots of in-progress work, so the notes stay unreleased.
-- Only a **stable release** (a normal `X.Y.Z`, a hotfix, or a `develop` promotion) moves
-  the accumulated entries under a dated `## [X.Y.Z] - YYYY-MM-DD` heading and starts a
-  fresh, empty `## [Unreleased]`.
+**The changelog is compiled when a release is cut, not per-PR.** A feature PR
+leaves `CHANGELOG.md` alone; an empty `## [Unreleased]` section on a feature
+branch is correct and should not be flagged in review. At release-cut time the
+entries are written in one pass from the PRs merged since the last release
+tag:
+
+```bash
+git log v<last>..HEAD --merges --oneline    # the PRs to describe
+```
+
+Two reasons this beats writing entries as they land: every feature PR would
+otherwise conflict on the same few lines, and — more importantly — the
+changelog describes *the product's* history rather than the repository's. One
+user-visible fix that took two PRs to land (a follow-up carrying commits that
+missed the first merge, say) is **one** changelog entry, and that is only
+visible in hindsight.
+
+- Entries accumulate under `## [Unreleased]` across the development cycle,
+  including across multiple previews.
+- Cutting a **preview** (`-alpha.N`, etc.) does **not** move entries out of
+  Unreleased — previews are snapshots of in-progress work.
+- Only a **stable release** (a normal `X.Y.Z`, a hotfix, or a `develop`
+  promotion) moves the accumulated entries under a dated
+  `## [X.Y.Z] - YYYY-MM-DD` heading and starts a fresh, empty `## [Unreleased]`.
+
+Write entries from the reader's side — what changed for someone running the
+software, and why it matters — not a restatement of the diff.
 
 ## Unstable / Preview Release
 
@@ -248,6 +268,40 @@ in the tag and: (a) marks the GitHub Release `--prerelease --latest=false`, and 
 the `.deb`/`.rpm`/AUR jobs. `website-sync.yml` never fires because it only triggers on a
 `release/*` merge to `main`, which a preview never performs.
 
+### Identifier progression
+
+Increment the trailing number within a stage, then advance the stage as the
+line matures. Never reuse an identifier — a tag is immutable once testers have
+it.
+
+```
+0.4.7-alpha.1 → alpha.2 → … → beta.1 → beta.2 → … → rc.1 → … → 0.4.7
+```
+
+`-dev.N` is for throwaway internal snapshots; use `-alpha.N` onwards for
+anything handed to testers.
+
+### Release notes
+
+The workflow prefers a hand-written notes file for the exact tag:
+
+```
+.github/release-notes/v0.4.7-alpha.1.md
+```
+
+If that file exists it becomes the release body verbatim. Otherwise the
+workflow falls back to extracting the matching `## [VERSION]` section from
+`CHANGELOG.md`, and failing that to the bare string `Release <tag>`.
+
+**Previews should always ship a notes file.** A preview's audience needs
+tester-facing guidance — what to look at, what noise to ignore, how to report,
+which log line carries the evidence — and none of that belongs in the product
+changelog. `## [Unreleased]` will never match a preview version anyway, so
+without a notes file a preview publishes as a one-line body.
+
+Stable releases normally have no notes file and fall through to the CHANGELOG
+extraction, unchanged.
+
 ### Steps
 
 ```bash
@@ -256,25 +310,46 @@ git checkout develop/0.4.7
 git pull origin develop/0.4.7
 
 # 2. Bump the pre-release identifier in Cargo.toml, then sync the lockfile
-#    [workspace.package] version = "0.4.7-dev.N"
-#    (increment N per preview: dev.0, dev.1, …; advance to -alpha/-beta/-rc as the
-#    line matures)
+#    [workspace.package] version = "0.4.7-alpha.N"
 cargo update -w
+```
 
-# 3. Record changes under the CHANGELOG "Unreleased" heading (do NOT date a section)
+> **Do not use `make bump-version` for a preview.** It also rewrites
+> `pkg/rpm/xearthlayer.spec`, and RPM forbids `-` in a `Version:` field (it
+> separates Version from Release), so it would commit an invalid spec. The RPM
+> job is skipped for previews so nothing fails at the time — it fails later, on
+> the next stable release built from the committed spec. Edit `Cargo.toml`
+> directly. (`build-rpm` rewrites the version from the tag at build time, so the
+> spec's committed value is only ever a latent hazard, never the source of
+> truth.)
 
-# 4. Verify, commit, and push on develop
+```bash
+# 3. Compile CHANGELOG "Unreleased" from PRs merged since the last release tag
+#    (see CHANGELOG Convention above). Do NOT date a section for a preview.
+
+# 4. Write the tester-facing notes for this exact tag
+#    .github/release-notes/v0.4.7-alpha.N.md
+
+# 5. Verify, commit, and push on develop
 make pre-commit
-git add Cargo.toml Cargo.lock CHANGELOG.md
-git commit -m "chore(release): 0.4.7-dev.N"
+git add Cargo.toml Cargo.lock CHANGELOG.md .github/release-notes/
+git commit -m "chore(release): 0.4.7-alpha.N"
 git push origin develop/0.4.7
 
-# 5. Tag from develop and push — this triggers the release workflow
-git tag v0.4.7-dev.N
-git push origin v0.4.7-dev.N
+# 6. Tag from develop and push — this triggers the release workflow
+git tag v0.4.7-alpha.N
+git push origin v0.4.7-alpha.N
 ```
 
 There is no release PR and no merge step: the preview lives entirely on `develop/0.4.7`.
+
+Confirm the binary agrees with the tag before announcing it — nothing in CI
+cross-checks them, and the version testers paste into bug reports comes from
+`Cargo.toml`, not from the tag:
+
+```bash
+xearthlayer --version   # must match the tag, e.g. 0.4.7-alpha.1
+```
 
 ### Verify
 
@@ -288,6 +363,9 @@ gh release list --limit 5
 
 # Confirm only the tarball was attached (no .deb/.rpm/AUR)
 gh release view v0.4.7-dev.N --json assets --jq '.assets[].name'
+
+# Confirm the notes file was used, not the one-line fallback
+gh release view v0.4.7-alpha.N --json body --jq '.body' | head -5
 ```
 
 ## Hotfix Release


### PR DESCRIPTION
## Summary

Prepares `develop/0.4.7` for the first tester-facing pre-release, and documents the process so the next one is mechanical.

Three changes, plus two guards against traps found while doing it.

## Version → `0.4.7-alpha.1`

Bumps the workspace version and lockfile. Progression from here is `alpha.N → beta.N → rc.N → 0.4.7`, incrementing within a stage and never reusing an identifier.

**Deliberately does not touch `pkg/rpm/xearthlayer.spec`.** RPM forbids `-` in a `Version:` field — it separates Version from Release — so a pre-release identifier commits an invalid spec. The RPM job is skipped for previews, so it would not fail now; it would fail on the next *stable* release built from the committed spec.

`make bump-version` now rejects any version containing `-` and says why, instead of writing it silently:

```
$ make bump-version VERSION=0.4.7-alpha.2
Error: '0.4.7-alpha.2' is a pre-release identifier.
This target also rewrites pkg/rpm/xearthlayer.spec, and RPM forbids '-' in Version:.
Edit the version in Cargo.toml directly, then run: cargo update -w
```

## Release notes → `.github/release-notes/<tag>.md`

The publish job greps `CHANGELOG.md` for a `## [VERSION]` heading and falls back to the bare string `Release <tag>`. A preview version never matches `## [Unreleased]`, so previews would publish a one-line body.

The notes step now prefers a hand-written file for the exact tag, falling back to the existing CHANGELOG extraction and then to the bare line. Stable tags normally have no such file and are unaffected.

Adds `.github/release-notes/v0.4.7-alpha.1.md`, focused on the three tent-poles:

1. **Prefetch keeping up with the aircraft** ([#176](https://github.com/samsoir/xearthlayer/issues/176)) — framed as what a tester sees, not what changed internally
2. **Terrain banding at distance** ([#212](https://github.com/samsoir/xearthlayer/issues/212)) — with instructions on how to look for it
3. **Memory on long flights** ([#209](https://github.com/samsoir/xearthlayer/issues/209)) — and to watch `vm_mb`/`swap_mb`, not `rss_mb`

It also carries a **"known issues — please don't report these"** section. Testers will otherwise open the log and find thousands of `Failed to submit job - executor may be shutdown` lines on a perfectly normal backpressure condition, plus `regions_nocoverage` over open water, which looks exactly like a coverage bug unless you know the rule.

### Security note

The tag becomes a path component in that lookup, and on `workflow_dispatch` it is caller-supplied. It is constrained to the release-tag grammar before use; anything else logs and falls through to the CHANGELOG path. Verified against `../../etc/passwd` and a command-injection attempt — both rejected.

## Runbook

`docs/dev/app-release-runbook.md`'s CHANGELOG section said **all merged changes are recorded as they land**. That is the opposite of practice. It now documents the actual convention — compiled at release-cut from the PRs merged since the last tag — including *why*: the changelog describes the product's history, not the repository's, so one user-visible fix that took two PRs to land is one entry.

Also adds the identifier progression, the notes-file mechanism, the RPM caveat, and a step to confirm `xearthlayer --version` matches the tag before announcing. Nothing in CI cross-checks those, and that string is what testers paste into bug reports — a mismatch makes an alpha report indistinguishable from any local build off `develop/0.4.7`.

## Test Plan

- [x] `make pre-commit` green — fmt, clippy `-D warnings`, 2484 tests
- [x] Binary reports the new version: `xearthlayer --version` → `xearthlayer 0.4.7-alpha.1`
- [x] `release.yml` parses as valid YAML
- [x] Notes-step logic simulated across four tags: `v0.4.7-alpha.1` → uses the file; `v0.4.6` → accepted, no file, falls through to CHANGELOG; `../../etc/passwd` and `v0.4.7-alpha.1; rm -rf /` → both rejected
- [x] `make bump-version` rejects `0.4.7-alpha.2`; stable versions still accepted
- [x] `pkg/rpm/xearthlayer.spec` confirmed untouched

## After merge

```bash
git tag v0.4.7-alpha.1 && git push origin v0.4.7-alpha.1
```

That triggers the release workflow: Linux tarball only, marked `--prerelease --latest=false`, with the notes file as the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
