### PR TITLE
fix(prefetch): retire only NoTiles regions to NoCoverage (#226)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
     - `GeoLayer` trait - Marker trait for storable layer types (`Clone + Send + Sync + 'static`)
     - `PatchCoverage` - Layer type indicating a region is owned by a scenery patch
     - `RetainedRegion` - Layer type tracking regions in the SceneryWindow's retained set
-    - `PrefetchedRegion` - Layer type tracking prefetch state per region (InProgress, Prefetched, NoCoverage)
+    - `PrefetchedRegion` - Layer type tracking prefetch state per region (InProgress, Prefetched, NoCoverage, Deferred)
+    - **Region retirement (#226)**: `NoCoverage` is reachable *only* when the scenery index attributes zero tiles to a region. A region with indexed tiles that is merely slow or stuck is `Deferred` — a non-terminal state that expires on a 20/30/40/60s ladder — so its tiles stay retryable
     - Locking: `RwLock<HashMap<TypeId, DashMap>>` — rare write locks, concurrent reads via DashMap shards
     - `populate()` provides atomic bulk loading (builds outside lock, swaps in)
     - Used by FUSE (`is_geo_filtered`), prewarm, and prefetch for patch region exclusion and prefetch state tracking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
     - `PrefetchBox` - Heading-biased sliding box (speed-proportional extent, proportional 80/20 bias, cruise phase)
     - `ExtentCalculator` - Speed-proportional box extent: clamped linear ramp 3.5° at 40kt to 6.5° at 450kt
     - `SceneryWindow` - Window config and dimensions holder
-    - `BoundaryStrategy` - Region lifecycle management (InProgress/Prefetched/NoCoverage)
+    - `BoundaryStrategy` - Region lifecycle management (InProgress/Prefetched/NoCoverage/Deferred)
     - `PhaseDetector` - Ground/Cruise flight phase state machine; reset via `on_ground` from AircraftState on telemetry resume
     - `PerformanceCalibrator` - Measures throughput during initial load for mode selection
     - `SimState` - Direct sim state detection via X-Plane Web API (paused, on_ground, scenery_loading, replay)

--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -256,7 +256,7 @@ This follows a **two-phase commit** pattern:
    | `RegionDiskState` | Outcome |
    |--------------------|---------|
    | `Complete` | Promote straight to `Prefetched` (the rescue path; see [Region Tile-Set SSOT](#region-tile-set-ssot) below); clear the region's strike count |
-   | `Incomplete { covered, total }` | **Progress-based, not time-based.** If `covered` grew since the previous evaluation, the region is advancing: clear strikes, revert to *absent* and retry immediately. If `covered` did not grow, it's a strike: increment the strike count and mark `Deferred { retry_after: now + deferral_for(strikes) }` |
+   | `Incomplete { coverage }` | Exact `covered`/`total` counts on this path — it asks for `CoverageDetail::ExactCounts`. **Progress-based, not time-based.** If `covered` grew since the previous evaluation, the region is advancing: clear strikes, revert to *absent* and retry immediately. If `covered` did not grow, it's a strike: increment the strike count and mark `Deferred { retry_after: now + deferral_for(strikes) }` |
    | `NoTiles` | The *only* path to `NoCoverage` — the scenery index attributes zero tiles to this region, which is definitive on first look (the index is fully built before the coordinator sees it). Retire to `NoCoverage`, clear the region's strike count |
    | `Unknown` | No authoritative source to consult (no `DdsDiskCacheChecker` and/or no `SceneryIndex`) → left `InProgress` untouched; this does **not** count as a strike, since "cannot tell" must not be treated the same as "checked and it is absent" |
 
@@ -321,6 +321,27 @@ answer feeds a decision whose terminal outcome is permanent exclusion
 no `SceneryIndex` wired) must stay distinguishable from "we checked and it is
 absent" (`Incomplete`/`NoTiles`), or a region could be retired to `NoCoverage`
 on a cycle where it was never actually checked.
+
+**How thoroughly it scans is a parameter, not a second function.** Callers pass
+a `CoverageDetail`. The rescue path asks for `ExactCounts` because `covered` is
+what separates an advancing region from a stuck one, and it can afford the full
+scan: it only ever looks at regions already stale for `stale_region_timeout`
+(120s). `promote_completed_regions` asks for `FirstMissOnly` and stops at the
+first absent tile, because it discards the counts and runs on every coordinator
+cycle (2s) over every `InProgress` region. The difference is not academic: when
+the XEL DDS cache misses, the disjunction below falls through to
+`OrthoUnionIndex::dds_tile_exists`, which tries four filename prefixes and —
+because `textures/` is in `LAZY_DIRECTORIES` and is never indexed — resolves
+each by `stat()`ing every installed source, so one absent tile costs roughly
+4 × N_sources syscalls. Counting a cold region's whole tile set every 2s steals
+CPU from the executor in exactly the backlog condition this machinery exists to
+relieve.
+
+A `FirstMissOnly` answer reports `Incomplete { coverage: TileCoverage::NotCounted }`.
+The variant carries no payload, so "not counted" cannot be mistaken for the
+observation `covered: 0` — a fabricated zero would read as "nothing has
+arrived" and drive a strike. `TileCoverage::counts()` returns an `Option`,
+forcing every reader to handle the absence explicitly.
 
 **Coverage is a disjunction.** A tile counts as covered if it is present in
 the XEL DDS disk cache (`DdsDiskCacheChecker`) **or** ships inside an

--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -236,14 +236,15 @@ If non-empty → expand to DDS tiles, filter, submit
 
 ### Region States (GeoIndex PrefetchedRegion layer)
 
-Each DSF region in the XEL Window has one of four states:
+Each DSF region in the XEL Window has one of five states:
 
 | State | Meaning | Prefetch Behaviour |
 |-------|---------|-------------------|
 | *absent* | Never evaluated | Include in target diff → submit |
 | `InProgress` | Tiles submitted, awaiting completion | Skip bulk submission (prevents duplicate work) |
 | `Prefetched` | All tiles confirmed cached | Exclude from target diff entirely |
-| `NoCoverage` | No scenery data in this DSF region | Exclude from target diff, skip silently |
+| `NoCoverage` | Scenery index attributes zero tiles to this region | Exclude from target diff, skip silently |
+| `Deferred { retry_after }` | Has indexed tiles but made no progress; non-terminal | Excluded from target diff until `retry_after`, then eligible again — the one state that *expires* |
 
 This follows a **two-phase commit** pattern:
 1. **Reserve**: Region marked `InProgress` when tiles are submitted (prevents duplicate bulk submissions)
@@ -251,15 +252,41 @@ This follows a **two-phase commit** pattern:
 3. **Timeout**: If `InProgress` exceeds `stale_region_timeout`, `evaluate_stale_regions`
    consults `BoundaryStrategy::region_disk_state` — the same completeness predicate the
    fast path uses — and picks one of four outcomes:
-   - Disk shows every tile present → promote straight to `Prefetched` (the rescue path;
-     see [Region Tile-Set SSOT](#region-tile-set-ssot) below)
-   - Disk shows tiles missing, under `MAX_REGION_ATTEMPTS` (3) → reverts to *absent* for
-     re-evaluation next cycle, incrementing the region's strike count
-   - Disk shows tiles missing, at `MAX_REGION_ATTEMPTS` → retired to `NoCoverage`
-     **permanently for the session** — this is the event flight-test criterion 4 keys on
-   - No authoritative source to consult (no `DdsDiskCacheChecker` and/or no
-     `SceneryIndex`) → left `InProgress` untouched; this does **not** count as a retry,
-     since "cannot tell" must not be treated the same as "checked and it is absent"
+
+   | `RegionDiskState` | Outcome |
+   |--------------------|---------|
+   | `Complete` | Promote straight to `Prefetched` (the rescue path; see [Region Tile-Set SSOT](#region-tile-set-ssot) below); clear the region's strike count |
+   | `Incomplete { covered, total }` | **Progress-based, not time-based.** If `covered` grew since the previous evaluation, the region is advancing: clear strikes, revert to *absent* and retry immediately. If `covered` did not grow, it's a strike: increment the strike count and mark `Deferred { retry_after: now + deferral_for(strikes) }` |
+   | `NoTiles` | The *only* path to `NoCoverage` — the scenery index attributes zero tiles to this region, which is definitive on first look (the index is fully built before the coordinator sees it). Retire to `NoCoverage`, clear the region's strike count |
+   | `Unknown` | No authoritative source to consult (no `DdsDiskCacheChecker` and/or no `SceneryIndex`) → left `InProgress` untouched; this does **not** count as a strike, since "cannot tell" must not be treated the same as "checked and it is absent" |
+
+   `Incomplete` reaches `NoCoverage` by no path — this is the fix for #226. Before it,
+   `Incomplete` and `NoTiles` shared a retirement arm keyed on a fixed count of three
+   timing-based strikes, so three consecutive slow evaluations could permanently retire a
+   region that genuinely had scenery, just slow to complete. Real field evidence: two
+   Baden-Württemberg regions were retired to `NoCoverage` this way, then disproved
+   2m43s later when on-demand FUSE generation served tiles from the very regions
+   prefetch had given up on.
+
+   **The deferral ladder** (`DEFERRAL_LADDER` in
+   `xearthlayer/src/prefetch/adaptive/coordinator/core.rs`) is **20s / 30s / 40s / 60s**,
+   1-based on the strike count; the 60s entry repeats for every strike beyond the
+   fourth — the ladder never grows past it. The 60s ceiling is a hard requirement, not
+   a tuning knob: it comes directly from the 2m43s field evidence above — the window in
+   which a region is skipped with nothing in flight must stay well inside the gap
+   between "prefetch gives up" and "the sim demands it anyway".
+
+   **`Deferred` re-enters through the planner, not through `evaluate_stale_regions`.**
+   A `Deferred` region's `GeoIndex` entry is left in place (unlike the `Incomplete`
+   advancing case, which removes it outright); `PrefetchedRegion::should_prefetch`
+   is the gate that lets it back in once `retry_after` passes, at which point the
+   normal target-diff submission path picks it up like any other absent region.
+   `evaluate_stale_regions` never revisits it directly — a `Deferred` region is not
+   `InProgress`, so `is_stale()` (which is `InProgress`-only; see
+   `test_deferred_is_never_stale`) never matches it. Submission is lossy — a plan can
+   drop regions under backpressure — so relying on `evaluate_stale_regions` to also
+   re-drive `Deferred` regions would risk a region that never actually gets
+   re-submitted.
 
 A region can reach step 1 without submitting anything. When the filter
 pipeline removes a region's *entire* planned tile set as already cached, there
@@ -308,23 +335,40 @@ lookups use different coordinate systems: the XEL DDS cache is keyed by
 (`tile.chunk_origin()`) — mixing them up silently returns "not covered" for
 every tile (the #172 keying bug).
 
-**Strike counts survive the retry branch, not the promote branch.** A
-region's `region_attempts` strike count is cleared on promotion (both the
-fast path and the rescue path) but deliberately left untouched on the retry
-branch of `evaluate_stale_regions`. This looks backwards until you notice
-what the retry branch does: it *removes* the region's `PrefetchedRegion`
-entry from the `GeoIndex` so the region is eligible for re-prefetch — and
-that removal is exactly what makes `region_attempts` (a separate
-`HashMap<DsfRegion, u8>` on the coordinator, not stored in the `GeoIndex`)
-the only thing that still remembers the region failed last time. Clearing it
-on retry, by naive symmetry with the promote branch, would make
-`MAX_REGION_ATTEMPTS` unreachable: every retry would restart the count at
-zero and a region that never succeeds would retry forever instead of
-eventually being retired to `NoCoverage`. Promotion clears it for the
-opposite reason — a promoted region's failure history belongs to the episode
-that failed, not to the region, so a region that recovers and is later
-demoted by `PrefetchStateObserver` should not be retired to `NoCoverage`
-after a single fresh failure.
+**Strikes are progress-based, and the strike count lives on the coordinator,
+not in the `GeoIndex`.** `region_retry: HashMap<DsfRegion, RegionRetryState>`
+(`xearthlayer/src/prefetch/adaptive/coordinator/core.rs`) tracks, per region,
+`strikes: u8` and `last_covered: usize` — the covered-tile count observed at
+the *previous* evaluation, deliberately a latest-observation, not a
+high-water mark, because the DDS disk cache's GC daemon can evict tiles and
+make coverage regress; a peak would blind progress detection until coverage
+climbed back past it. A strike means "the covered count did not increase
+since last time" — not "took too long" — so a region under a large backlog
+that is genuinely, slowly advancing never strikes, and one that is truly
+stuck (0 new tiles landing) strikes every evaluation.
+
+`region_retry` is cleared in exactly three places, and each is a case where
+the strike history stops being relevant to what happens next:
+- **`Complete`** (both the fast path and the rescue path) — a promoted
+  region's failure history belongs to the episode that failed, not to the
+  region, so a region that recovers and is later demoted by
+  `PrefetchStateObserver` should not resume the old episode's strike count.
+- **`NoTiles`** retirement to `NoCoverage` — for the same reason: if the
+  observer later disproves `NoCoverage` (a FUSE generation succeeds there),
+  the region re-enters with a clean slate.
+- **The advancing arm of `Incomplete`** (`covered > last_covered`) — strikes
+  reset to 0 in place, because the region is making progress and the ladder
+  should not carry over from before it started advancing.
+
+It is deliberately **not** cleared on the stuck arm of `Incomplete` (the
+strike increments instead) or when `PrefetchStateObserver` clears a
+`Deferred` region's `GeoIndex` entry after an on-demand FUSE generation (see
+[Demotion](#demotion-closing-the-loop-on-wrong-claims) below) — the observer
+only holds a `GeoIndex` handle and structurally cannot reach
+`region_retry`, and that absence of a reset is intentional: a region
+demand-cleared mid-episode is still the same ongoing episode, not a fresh
+one, so the 20/30/40/60s ladder keeps escalating across repeated
+demand-driven clears rather than flattening back to 20s every time.
 
 ### Demotion: Closing the Loop on Wrong Claims
 
@@ -346,6 +390,22 @@ NoCoverage ──┘        (region re-enters the prefetch cycle)
 still running — and cache hits are exempt, since serving from cache is the
 system working, not a divergence.
 
+`Deferred` gets separate, milder handling (#226): an on-demand FUSE
+generation there clears the region's `GeoIndex` entry immediately — demand
+beats backoff, since a deferred region was never claimed *ready* in the
+first place — but this does **not** count as a divergence: no
+`prefetch_state_diverged` metric, no `prefetch_region_demoted` metric, and no
+`120s` rate limit. It is a repair, not evidence of a wrong claim. This does
+not license a longer deferral ladder: by the time FUSE asks for the tile,
+the miss has already happened. See `test_fuse_miss_clears_deferral_without_counting_divergence`
+in `xearthlayer/src/prefetch/state_observer.rs`.
+
+Note also that this clear does not reset the coordinator's `region_retry`
+strike count — see [Strike counts](#region-tile-set-ssot) above: the
+observer only holds a `GeoIndex` handle and cannot reach `region_retry`,
+and that is intentional, so the ladder keeps escalating across repeated
+demand-driven clears of the same episode.
+
 Re-entering the prefetch cycle only *repairs* two of the three causes. The
 scenery index is immutable for the life of the process, so where the cause is
 an index gap the next cycle re-derives the same empty tile set and re-marks
@@ -361,16 +421,36 @@ unbounded demote → re-prefetch → evict loop would churn on a long flight; th
 rate limit exists so the diagnostic doesn't become the noise it's meant to
 surface.
 
-The daemon aggregates both counters and logs them on the same 60s cadence as
-the memory sample. They are cumulative totals since process start, because
-`AggregatedState::reset()` — which does zero them — has no production caller;
-wire it up and these become totals since the last reset:
+The daemon aggregates these and logs them on the same 60s cadence as the
+memory sample. The counters among them are cumulative totals since process
+start, because `AggregatedState::reset()` — which does zero them — has no
+production caller; wire it up and these become totals since the last reset:
 
 ```
 INFO Prefetch sample uptime_s=... regions_in_progress=... regions_prefetched=...
-     regions_nocoverage=... promotions_normal=... promotions_rescue=...
-     state_diverged=... regions_demoted=... fuse_generations=...
+     regions_nocoverage=... regions_deferred_active=... promotions_normal=...
+     promotions_rescue=... state_diverged=... regions_demoted=...
+     regions_deferred=... fuse_generations=...
 ```
+
+**Two of these fields differ only by suffix and are easy to misread against
+each other — read this before reading a flight log:**
+- `regions_deferred_active` is a **gauge**: how many regions are `Deferred`
+  *right now*, assigned wholesale from the `PrefetchRegionState` event each
+  maintenance cycle, exactly like `regions_in_progress`, `regions_prefetched`,
+  and `regions_nocoverage` above it. It goes up and down.
+- `regions_deferred` is a **counter**: how many deferrals have *occurred*
+  in total since process start, incremented once per stuck-`Incomplete`
+  evaluation (`MetricEvent::PrefetchRegionDeferred`), same convention as
+  `promotions_normal`/`promotions_rescue`/`state_diverged`/`regions_demoted`
+  below it. It only goes up.
+
+Misreading `regions_deferred_active` as the counter (or vice versa) matters
+in practice: `regions_nocoverage` non-zero over land is an acceptance
+criterion for #226, and `regions_deferred`/`regions_deferred_active`
+non-zero but bounded is the expected healthy signal for a region that is
+slow rather than absent. Confusing a climbing counter for a stuck gauge (or
+the reverse) produces a false alarm in either direction.
 
 `fuse_generations` mirrors `fuse_jobs_submitted` (aggregated from
 `MetricEvent::JobSubmitted { is_fuse: true }`) — the only default-level
@@ -1083,12 +1163,14 @@ SimState (X-Plane Web API)
 If some tiles in a submitted region fail:
 - Region stays `InProgress`
 - After `stale_region_timeout` (120s), `region_disk_state` reports `Incomplete` — see
-  [Region States](#region-states-geoindex-prefetchedregion-layer) above — and the
-  region's strike count increments. While the count stays under
-  `MAX_REGION_ATTEMPTS` (3) the region reverts to *absent* for retry; the strike that
-  reaches 3 retires it to `NoCoverage` instead of granting another retry — so a region
-  gets at most 2 revert-to-absent retries before retirement, not 3
-- Next evaluation cycle (while retries remain): target diff finds the region, re-submits
+  [Region States](#region-states-geoindex-prefetchedregion-layer) above. If the covered
+  count grew since the previous evaluation, strikes clear and the region reverts to
+  *absent* for immediate retry. If it did not grow, that's a strike: the region is
+  marked `Deferred` on the 20/30/40/60s ladder (the ceiling repeats indefinitely) and
+  excluded from the target diff until `retry_after` passes — it is **never** retired to
+  `NoCoverage` for this reason, however many consecutive strikes it accumulates
+- Once `retry_after` passes (or immediately, on the advancing-strike path): target diff
+  finds the region again, re-submits
 - Four-tier filter handles individual tile dedup (only failed tiles re-submitted)
 
 ---
@@ -1102,7 +1184,7 @@ If some tiles in a submitted region fail:
 | `BoundaryMonitor` | Trigger at correct distance; no trigger when far; urgency calculation; both edges (north/south or east/west) |
 | `SceneryWindow` | Window derivation from tracker bounds (config-locked dimensions); retention inference with buffer; world rebuild detection; `Assumed` → `Ready` transition |
 | `BoundaryStrategy` | Row generation for lat crossing; column generation for lon crossing; diagonal (both monitors); set difference with XEL Window; depth ordering; `NoCoverage` handling; eviction of non-retained regions and cached tiles |
-| `RegionState` | Two-phase commit: absent → InProgress → Prefetched; timeout revert; NoCoverage; eviction on window departure |
+| `RegionState` | Two-phase commit: absent → InProgress → Prefetched; timeout revert; `NoTiles` → `NoCoverage`; progress-based strikes → `Deferred` on the 20/30/40/60s ladder; `Deferred` expiry via `should_prefetch`; eviction on window departure |
 | `GeoIndex layers` | RetainedRegion add/remove; PrefetchedRegion state transitions |
 
 ### Integration Tests

--- a/docs/dev/geo-index-design.md
+++ b/docs/dev/geo-index-design.md
@@ -217,19 +217,33 @@ pub struct RetainedRegion;
 
 #### `PrefetchedRegion`
 
-Tracks prefetch state per DSF region: `InProgress`, `Prefetched`, or
-`NoCoverage`, plus the `Instant` the state was set (used for staleness
-checks). Regions absent from the layer are "never evaluated" — eligible for
-prefetch. Written by two concurrent sources: the prefetch coordinator
+Tracks prefetch state per DSF region: `InProgress`, `Prefetched`,
+`NoCoverage`, or `Deferred { retry_after }`, plus the `Instant` the state was
+set (used for staleness checks). Regions absent from the layer are "never
+evaluated" — eligible for prefetch. `NoCoverage` is reachable *only* when the
+scenery index attributes zero tiles to a region (#226) — a region with
+indexed tiles that is merely slow or stuck goes to `Deferred` instead, a
+non-terminal state that expires on a 20/30/40/60s ladder rather than being
+retired.
+
+Because `Deferred` is the one state that expires on its own, `should_prefetch`
+is no longer a bare `!contains()` check: it returns `true` for an absent
+region as before, but for a present entry it must additionally check whether
+a `Deferred` region's `retry_after` has passed — `InProgress`, `Prefetched`,
+and `NoCoverage` are still an unconditional `false`.
+
+Written by two concurrent sources: the prefetch coordinator
 (`AdaptivePrefetchCoordinator`, via `BoundaryStrategy`) and the FUSE-side
 `PrefetchStateObserver`, which demotes a `Prefetched`/`NoCoverage` region
-when FUSE has to generate a tile on demand there. See
-`docs/dev/adaptive-prefetch-design.md` for the full state machine
-(two-phase commit, stale-region rescue, demotion).
+when FUSE has to generate a tile on demand there, and separately clears a
+`Deferred` region's entry outright on the same trigger (not counted as a
+demotion — see `docs/dev/adaptive-prefetch-design.md`). See that document for
+the full state machine (two-phase commit, progress-based strikes, the
+deferral ladder, stale-region rescue, demotion).
 
 ```rust
 pub struct PrefetchedRegion {
-    state: RegionState,   // InProgress | Prefetched | NoCoverage
+    state: RegionState,   // InProgress | Prefetched | NoCoverage | Deferred { retry_after: Instant }
     since: Instant,
 }
 ```

--- a/xearthlayer/src/cache/adapters/dds_disk_bridge.rs
+++ b/xearthlayer/src/cache/adapters/dds_disk_bridge.rs
@@ -77,7 +77,10 @@ impl DdsDiskCacheChecker for DdsDiskCacheBridge {
     fn tile_exists_blocking(&self, row: u32, col: u32, zoom: u8) -> bool {
         // Genuinely sync now — no runtime round-trip. This also means the
         // method is safe to call outside a tokio runtime, which it was not
-        // before (`block_in_place` panics on a current-thread runtime).
+        // before: outside any runtime at all, `Handle::current()` panics;
+        // inside a current-thread runtime, `block_in_place` panics instead.
+        // Either way, the old implementation could not be called safely from
+        // here — this one has no runtime dependency to trip either panic.
         let tile = TileCoord { row, col, zoom };
         self.client.contains_sync(&tile)
     }

--- a/xearthlayer/src/cache/adapters/dds_disk_bridge.rs
+++ b/xearthlayer/src/cache/adapters/dds_disk_bridge.rs
@@ -75,26 +75,20 @@ impl DdsDiskCacheChecker for DdsDiskCacheBridge {
     }
 
     fn tile_exists_blocking(&self, row: u32, col: u32, zoom: u8) -> bool {
-        // Delegates to the async `tile_exists` via `block_in_place` so
-        // the sync callsite is free of the runtime-handle dance. Moving
-        // the hack into the trait impl encapsulates it here — callers
-        // (e.g. `promote_completed_regions`) can treat this as a plain
-        // sync method.
-        //
-        // TODO(#175): specialise with a truly sync path by exposing
-        // an index-only check through the `Cache` trait. The DashMap
-        // lookup backing `lru_index` is already sync; the async wrapper
-        // is gratuitous for hot-path existence checks.
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(self.tile_exists(row, col, zoom))
-        })
+        // Genuinely sync now — no runtime round-trip. This also means the
+        // method is safe to call outside a tokio runtime, which it was not
+        // before (`block_in_place` panics on a current-thread runtime).
+        let tile = TileCoord { row, col, zoom };
+        self.client.contains_sync(&tile)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::{CacheService, ServiceCacheConfig};
+    use crate::cache::config::DiskProviderConfig;
+    use crate::cache::{CacheService, DiskCacheProvider, DiskTier, ServiceCacheConfig};
+    use std::time::Duration;
     use tempfile::TempDir;
 
     async fn create_disk_bridge() -> (DdsDiskCacheBridge, CacheService, TempDir) {
@@ -209,5 +203,32 @@ mod tests {
         );
 
         service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_tile_exists_blocking_matches_async_contains() {
+        // `DdsDiskCacheBridge::new` takes an `Arc<dyn Cache>`; build the disk
+        // provider with the same `DiskProviderConfig` shape used by
+        // `disk.rs::create_test_provider`, but with `tier: DiskTier::Dds`.
+        let temp_dir = TempDir::new().unwrap();
+        let provider = DiskCacheProvider::start(DiskProviderConfig {
+            directory: temp_dir.path().to_path_buf(),
+            max_size_bytes: 10 * 1024 * 1024,
+            gc_interval: Duration::from_secs(3600),
+            provider_name: "test".to_string(),
+            metrics_client: None,
+            tier: DiskTier::Dds,
+        })
+        .await
+        .unwrap();
+        let bridge = DdsDiskCacheBridge::new(provider);
+
+        assert!(!bridge.tile_exists_blocking(12754, 5279, 15));
+        bridge.put(12754, 5279, 15, vec![0u8; 64]).await;
+        assert!(bridge.tile_exists_blocking(12754, 5279, 15));
+        assert_eq!(
+            bridge.contains(12754, 5279, 15).await,
+            bridge.tile_exists_blocking(12754, 5279, 15)
+        );
     }
 }

--- a/xearthlayer/src/cache/clients/tile.rs
+++ b/xearthlayer/src/cache/clients/tile.rs
@@ -83,6 +83,12 @@ impl TileCacheClient {
         self.cache.contains(&key).await.unwrap_or(false)
     }
 
+    /// Check whether a tile exists, synchronously. See `Cache::contains_sync`.
+    pub fn contains_sync(&self, tile: &TileCoord) -> bool {
+        let key = Self::tile_to_key(tile);
+        self.cache.contains_sync(&key)
+    }
+
     /// Delete a tile from the cache.
     ///
     /// # Arguments

--- a/xearthlayer/src/cache/providers/disk.rs
+++ b/xearthlayer/src/cache/providers/disk.rs
@@ -408,6 +408,12 @@ impl Cache for DiskCacheProvider {
         Box::pin(async move { Ok(in_index) })
     }
 
+    fn contains_sync(&self, key: &str) -> bool {
+        // Index-only, exactly like `contains()` — see the comment there for
+        // why there is no filesystem verify.
+        self.lru_index.contains(key)
+    }
+
     fn size_bytes(&self) -> u64 {
         self.lru_index.total_size()
     }
@@ -519,6 +525,28 @@ mod tests {
         provider.set("key1", vec![1]).await.unwrap();
 
         assert!(provider.contains("key1").await.unwrap());
+
+        provider.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_contains_sync_agrees_with_contains() {
+        let (_dir, provider) = create_test_provider(10 * 1024 * 1024).await;
+        let key = "tile:15:12754:5279";
+
+        assert!(!provider.contains_sync(key), "absent key must be false");
+        assert_eq!(
+            provider.contains(key).await.unwrap(),
+            provider.contains_sync(key)
+        );
+
+        provider.set(key, vec![0u8; 64]).await.unwrap();
+
+        assert!(provider.contains_sync(key), "present key must be true");
+        assert_eq!(
+            provider.contains(key).await.unwrap(),
+            provider.contains_sync(key)
+        );
 
         provider.shutdown().await;
     }

--- a/xearthlayer/src/cache/providers/memory.rs
+++ b/xearthlayer/src/cache/providers/memory.rs
@@ -138,6 +138,10 @@ impl Cache for MemoryCacheProvider {
         Box::pin(async move { Ok(self.cache.contains_key(&key)) })
     }
 
+    fn contains_sync(&self, key: &str) -> bool {
+        self.cache.contains_key(key)
+    }
+
     fn size_bytes(&self) -> u64 {
         self.cache.weighted_size()
     }
@@ -245,6 +249,20 @@ mod tests {
         provider.set("key1", vec![1]).await.unwrap();
 
         assert!(provider.contains("key1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_memory_contains_sync_agrees_with_contains() {
+        let provider = MemoryCacheProvider::new(1_000_000, None);
+        let key = "tile:15:12754:5279";
+
+        assert!(!provider.contains_sync(key));
+        provider.set(key, vec![0u8; 64]).await.unwrap();
+        assert!(provider.contains_sync(key));
+        assert_eq!(
+            provider.contains(key).await.unwrap(),
+            provider.contains_sync(key)
+        );
     }
 
     #[tokio::test]

--- a/xearthlayer/src/cache/traits.rs
+++ b/xearthlayer/src/cache/traits.rs
@@ -170,6 +170,17 @@ pub trait Cache: Send + Sync {
     /// * `key` - The cache key to check
     fn contains(&self, key: &str) -> BoxFuture<'_, Result<bool, ServiceCacheError>>;
 
+    /// Check if a key exists, synchronously.
+    ///
+    /// Both providers already answer this from an in-memory map — moka's
+    /// `contains_key` and `LruIndex::contains` are each sync — so the
+    /// `BoxFuture` returned by `contains()` is pure overhead for a caller
+    /// that is itself sync. Prefetch's region-completeness scan calls this
+    /// several hundred times per region per cycle; going through the async
+    /// wrapper there cost a `block_in_place` + `block_on` + `Box::pin`
+    /// allocation per tile. Resolves TODO(#175).
+    fn contains_sync(&self, key: &str) -> bool;
+
     /// Get the current size of the cache in bytes.
     ///
     /// For memory caches, this is the weighted size of all entries.

--- a/xearthlayer/src/debug_map/api.rs
+++ b/xearthlayer/src/debug_map/api.rs
@@ -6,7 +6,9 @@
 use serde::Serialize;
 
 use crate::aircraft_position::AircraftPositionProvider;
-use crate::geo_index::{PatchCoverage, PrefetchedRegion, RetainedRegion};
+use crate::geo_index::{
+    PatchCoverage, PrefetchedRegion, RegionState as PrefetchLifecycleState, RetainedRegion,
+};
 use crate::prefetch::BoxBoundsSnapshot;
 
 use super::state::DebugMapState;
@@ -114,7 +116,7 @@ fn is_zero(v: &u32) -> bool {
 }
 
 /// Region state for map colour coding.
-#[derive(Serialize, Clone, PartialEq)]
+#[derive(Serialize, Clone, Copy, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RegionState {
     /// Prefetch submitted, awaiting completion.
@@ -131,6 +133,10 @@ pub enum RegionState {
     FuseLoaded,
     /// Mix of prefetch and on-demand loading.
     Mixed,
+    /// Has coverage, but prefetch could not complete it and backed off;
+    /// eligible for retry once its deadline passes. See
+    /// `geo_index::RegionState::Deferred` (#226).
+    Deferred,
 }
 
 /// Pipeline statistics.
@@ -216,12 +222,17 @@ fn collect_regions(state: &DebugMapState) -> Vec<RegionInfo> {
     // one tile completed — that distinction is what this layer enforces.
     if let Some(ref geo_index) = state.geo_index {
         for (region, prefetched) in geo_index.iter::<PrefetchedRegion>() {
-            let region_state = if prefetched.is_in_progress() {
-                RegionState::InProgress
-            } else if prefetched.is_prefetched() {
-                RegionState::Prefetched
-            } else {
-                RegionState::NoCoverage
+            // Exhaustive match over the lifecycle enum, not an `is_*()`
+            // if/else chain with a trailing catch-all `else` — that shape is
+            // exactly what let a `Deferred` region silently render as
+            // `NoCoverage` (over land) before #226's fix at the metrics fold
+            // was applied here too. A future fifth variant now fails to
+            // compile instead of falling through.
+            let region_state = match prefetched.state() {
+                PrefetchLifecycleState::InProgress => RegionState::InProgress,
+                PrefetchLifecycleState::Prefetched => RegionState::Prefetched,
+                PrefetchLifecycleState::NoCoverage => RegionState::NoCoverage,
+                PrefetchLifecycleState::Deferred { .. } => RegionState::Deferred,
             };
             region_map.insert(
                 (region.lat, region.lon),
@@ -472,5 +483,55 @@ mod tests {
         let json = serde_json::to_string(&snapshot).unwrap();
         assert!(json.contains("\"aircraft\":null"));
         assert!(json.contains("\"regions\":[]"));
+    }
+
+    fn empty_debug_map_state(
+        geo_index: Option<std::sync::Arc<crate::geo_index::GeoIndex>>,
+    ) -> DebugMapState {
+        use crate::aircraft_position::web_api::SharedSimState;
+        use crate::aircraft_position::SharedAircraftPosition;
+        use crate::prefetch::SharedPrefetchStatus;
+        use std::sync::RwLock;
+        use tokio::sync::broadcast;
+
+        let (tx, _rx) = broadcast::channel(16);
+        let aggregator = crate::aircraft_position::StateAggregator::new(tx);
+
+        DebugMapState {
+            aircraft_position: SharedAircraftPosition::new(aggregator),
+            sim_state: SharedSimState::new(RwLock::new(Default::default())),
+            geo_index,
+            prefetch_status: SharedPrefetchStatus::new(),
+            tile_activity: crate::debug_map::activity::TileActivityTracker::new(),
+        }
+    }
+
+    #[test]
+    fn test_deferred_region_renders_as_deferred_not_no_coverage() {
+        // Regression guard for #226's second catch-all site: a Deferred
+        // region has coverage and is only backing off, so rendering it as
+        // NoCoverage on the debug map would read as missing scenery over
+        // land — the exact defect the exhaustive match at collect_regions
+        // exists to prevent (mirrors the fix already made in the metrics
+        // fold).
+        let geo_index = std::sync::Arc::new(crate::geo_index::GeoIndex::new());
+        let region = crate::geo_index::DsfRegion::new(48, 15);
+        geo_index.insert::<PrefetchedRegion>(
+            region,
+            PrefetchedRegion::deferred(
+                std::time::Instant::now() + std::time::Duration::from_secs(30),
+            ),
+        );
+
+        let state = empty_debug_map_state(Some(geo_index));
+        let regions = collect_regions(&state);
+
+        assert_eq!(regions.len(), 1);
+        assert_eq!(regions[0].state, RegionState::Deferred);
+        assert_ne!(
+            regions[0].state,
+            RegionState::NoCoverage,
+            "a Deferred region must never render as NoCoverage"
+        );
     }
 }

--- a/xearthlayer/src/debug_map/map.html
+++ b/xearthlayer/src/debug_map/map.html
@@ -37,6 +37,7 @@
   <div class="legend-item"><span class="legend-swatch" style="background:#f44336"></span> FUSE loaded (X-Plane waited)</div>
   <div class="legend-item"><span class="legend-swatch" style="background:#FF9800"></span> Mixed (prefetch + FUSE)</div>
   <div class="legend-item"><span class="legend-swatch" style="background:#9E9E9E"></span> No Coverage</div>
+  <div class="legend-item"><span class="legend-swatch" style="background:#00BCD4"></span> Deferred (backing off)</div>
   <div class="legend-item"><span class="legend-swatch" style="background:#9C27B0"></span> Patched</div>
   <div class="legend-item"><span class="legend-swatch" style="background:transparent;border:2px solid #2196F3"></span> Retained</div>
   <div class="legend-item"><span class="legend-swatch" style="background:transparent;border:2px dashed #03A9F4"></span> Prefetch Box</div>
@@ -78,6 +79,7 @@ const REGION_COLORS = {
   retained:    { color: '#2196F3', fillColor: 'transparent', fillOpacity: 0, weight: 2 },
   fuse_loaded: { color: '#f44336', fillColor: '#f44336', fillOpacity: 0.35, weight: 1 },
   mixed:       { color: '#FF9800', fillColor: '#FF9800', fillOpacity: 0.3, weight: 1 },
+  deferred:    { color: '#00BCD4', fillColor: '#00BCD4', fillOpacity: 0.25, weight: 1 },
 };
 
 function updateStats(data) {

--- a/xearthlayer/src/geo_index/layers.rs
+++ b/xearthlayer/src/geo_index/layers.rs
@@ -83,6 +83,15 @@ pub enum RegionState {
     Prefetched,
     /// No scenery data exists for this region.
     NoCoverage,
+    /// Has coverage, could not be completed yet; skipped until `retry_after`.
+    ///
+    /// Deliberately NOT terminal. A region here is retried once the deadline
+    /// passes, which keeps its tiles available to a future provider-fallback
+    /// feature — see the spec's "Governing constraint" section.
+    Deferred {
+        /// The instant at which this region becomes eligible for prefetch again.
+        retry_after: Instant,
+    },
 }
 
 impl PrefetchedRegion {
@@ -110,6 +119,24 @@ impl PrefetchedRegion {
         }
     }
 
+    /// Create a `Deferred` state that becomes eligible again at `retry_after`.
+    pub fn deferred(retry_after: Instant) -> Self {
+        Self {
+            state: RegionState::Deferred { retry_after },
+            since: Instant::now(),
+        }
+    }
+
+    /// Returns `true` if this region is in the `Deferred` state.
+    pub fn is_deferred(&self) -> bool {
+        matches!(self.state, RegionState::Deferred { .. })
+    }
+
+    /// The raw lifecycle state.
+    pub fn state(&self) -> RegionState {
+        self.state
+    }
+
     /// Returns `true` if this region is in the `InProgress` state.
     pub fn is_in_progress(&self) -> bool {
         self.state == RegionState::InProgress
@@ -135,11 +162,18 @@ impl PrefetchedRegion {
 
     /// Returns `true` if the given region should be prefetched.
     ///
-    /// A region should be prefetched only if it is absent from the index
-    /// (no entry means never evaluated). Any present state (`InProgress`,
-    /// `Prefetched`, or `NoCoverage`) means the region should be skipped.
+    /// Absent means never evaluated — eligible. `InProgress`, `Prefetched` and
+    /// `NoCoverage` are all skipped. `Deferred` is skipped only until its
+    /// deadline passes; this is the one state that expires, which is why this
+    /// can no longer be a bare `!contains()`.
     pub fn should_prefetch(index: &super::GeoIndex, region: &super::DsfRegion) -> bool {
-        !index.contains::<PrefetchedRegion>(region)
+        match index.get::<PrefetchedRegion>(region) {
+            None => true,
+            Some(entry) => match entry.state() {
+                RegionState::Deferred { retry_after } => Instant::now() >= retry_after,
+                _ => false,
+            },
+        }
     }
 }
 
@@ -247,6 +281,44 @@ mod tests {
         // NoCoverage → should NOT prefetch
         index.insert::<PrefetchedRegion>(region, PrefetchedRegion::no_coverage());
         assert!(!PrefetchedRegion::should_prefetch(&index, &region));
+    }
+
+    #[test]
+    fn test_deferred_region_becomes_prefetchable_when_retry_after_passes() {
+        use std::time::Duration;
+
+        let index = GeoIndex::new();
+        let region = DsfRegion::new(47, 8);
+
+        // Still deferred.
+        index.insert::<PrefetchedRegion>(
+            region,
+            PrefetchedRegion::deferred(Instant::now() + Duration::from_secs(60)),
+        );
+        assert!(
+            !PrefetchedRegion::should_prefetch(&index, &region),
+            "a region still inside its deferral window must not be planned"
+        );
+
+        // Deferral elapsed.
+        index.insert::<PrefetchedRegion>(
+            region,
+            PrefetchedRegion::deferred(Instant::now() - Duration::from_secs(1)),
+        );
+        assert!(
+            PrefetchedRegion::should_prefetch(&index, &region),
+            "a region whose deferral has elapsed must become eligible again"
+        );
+    }
+
+    #[test]
+    fn test_deferred_is_never_stale() {
+        use std::time::Duration;
+
+        // `evaluate_stale_regions` must not see Deferred regions — they re-enter
+        // the machine through the planner so the tiles are genuinely re-submitted.
+        let r = PrefetchedRegion::deferred(Instant::now() - Duration::from_secs(600));
+        assert!(!r.is_stale(Duration::from_secs(1)));
     }
 
     // Compile-time assertions for trait bounds

--- a/xearthlayer/src/geo_index/layers.rs
+++ b/xearthlayer/src/geo_index/layers.rs
@@ -66,6 +66,10 @@ impl GeoLayer for RetainedRegion {}
 /// - `InProgress`: tiles submitted to executor, awaiting cache confirmation
 /// - `Prefetched`: all tiles confirmed in cache
 /// - `NoCoverage`: no scenery data exists for this region (skip silently)
+/// - `Deferred`: has coverage but did not complete; skipped until `retry_after`
+///
+/// `Prefetched` and `NoCoverage` are terminal; `Deferred` is not — see
+/// [`RegionState::Deferred`].
 ///
 /// Regions not in the index are considered "absent" (eligible for prefetch).
 #[derive(Debug, Clone)]
@@ -154,8 +158,15 @@ impl PrefetchedRegion {
 
     /// Returns `true` if this `InProgress` region has exceeded the staleness timeout.
     ///
-    /// Only `InProgress` regions can be stale; `Prefetched` and `NoCoverage` are
-    /// terminal states and never expire.
+    /// Only `InProgress` regions can be stale. `Prefetched` and `NoCoverage`
+    /// are terminal states and never expire.
+    ///
+    /// `Deferred` is excluded too, and that exclusion is load-bearing rather
+    /// than incidental: a `Deferred` region *does* expire, but on its own
+    /// `retry_after` deadline, consumed by [`Self::should_prefetch`]. If it
+    /// were also reported stale here, `evaluate_stale_regions` would re-judge
+    /// it on every maintenance cycle and add a strike each time, collapsing the
+    /// escalating backoff ladder that deferral exists to provide.
     pub fn is_stale(&self, timeout: std::time::Duration) -> bool {
         self.state == RegionState::InProgress && self.since.elapsed() >= timeout
     }

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -414,6 +414,12 @@ impl MetricsClient {
     pub fn prefetch_region_deferred(&self) {
         self.send(MetricEvent::PrefetchRegionDeferred);
     }
+
+    /// Record that a region's deferral was cleared by on-demand generation.
+    #[inline]
+    pub fn prefetch_deferral_cleared(&self) {
+        self.send(MetricEvent::PrefetchDeferralCleared);
+    }
 }
 
 impl std::fmt::Debug for MetricsClient {

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -370,11 +370,18 @@ impl MetricsClient {
 
     /// Reports the current region-state distribution (gauge).
     #[inline]
-    pub fn prefetch_region_state(&self, in_progress: usize, prefetched: usize, no_coverage: usize) {
+    pub fn prefetch_region_state(
+        &self,
+        in_progress: usize,
+        prefetched: usize,
+        no_coverage: usize,
+        deferred: usize,
+    ) {
         self.send(MetricEvent::PrefetchRegionState {
             in_progress,
             prefetched,
             no_coverage,
+            deferred,
         });
     }
 

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -401,6 +401,12 @@ impl MetricsClient {
     pub fn prefetch_region_promoted_rescue(&self) {
         self.send(MetricEvent::PrefetchRegionPromotedRescue);
     }
+
+    /// Record that a region was deferred for making no progress.
+    #[inline]
+    pub fn prefetch_region_deferred(&self) {
+        self.send(MetricEvent::PrefetchRegionDeferred);
+    }
 }
 
 impl std::fmt::Debug for MetricsClient {

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -347,6 +347,9 @@ impl MetricsDaemon {
             MetricEvent::PrefetchRegionDemoted => {
                 self.state.prefetch_regions_demoted += 1;
             }
+            MetricEvent::PrefetchRegionDeferred => {
+                self.state.prefetch_regions_deferred += 1;
+            }
             MetricEvent::PrefetchRegionsPromotedNormal { count } => {
                 self.state.prefetch_promotions_normal += count as u64;
             }
@@ -430,6 +433,10 @@ impl MetricsDaemon {
             promotions_rescue = state.prefetch_promotions_rescue,
             state_diverged = state.prefetch_state_diverged,
             regions_demoted = state.prefetch_regions_demoted,
+            // #226: how often a region was skipped for making no progress.
+            // Non-zero under a cold-cache backlog is expected; climbing
+            // without bound is not.
+            regions_deferred = state.prefetch_regions_deferred,
             // Criterion 5's user-visible outcome (the others above are
             // mechanism): on-demand FUSE generations should fall during
             // cruise. Per-tile FUSE logging is debug-only (#209), so this
@@ -1196,6 +1203,35 @@ mod tests {
             sample.get("fuse_generations").map(String::as_str),
             Some("2"),
             "fuse_generations must carry state.fuse_jobs_submitted"
+        );
+    }
+
+    #[test]
+    fn test_prefetch_sample_reports_regions_deferred() {
+        // regions_deferred is a COUNTER, unlike the region-state gauges
+        // above: it accumulates across the daemon's own event stream rather
+        // than being assigned wholesale from GeoIndex each cycle, so it
+        // must reset while the gauges must not.
+        let (mut daemon, _tx) = create_daemon();
+        daemon.state.prefetch_regions_deferred = 7;
+        daemon.state.prefetch_regions_nocoverage = 3;
+
+        let events = capture_events(|| daemon.log_prefetch_sample());
+        let sample =
+            find_prefetch_sample(&events).expect("log_prefetch_sample must emit a sample line");
+        assert_eq!(
+            sample.get("regions_deferred").map(String::as_str),
+            Some("7")
+        );
+
+        daemon.state.reset();
+        assert_eq!(
+            daemon.state.prefetch_regions_deferred, 0,
+            "counter must reset"
+        );
+        assert_eq!(
+            daemon.state.prefetch_regions_nocoverage, 3,
+            "gauge must NOT reset"
         );
     }
 

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -443,11 +443,16 @@ impl MetricsDaemon {
             regions_demoted = state.prefetch_regions_demoted,
             // #226: how often a region was skipped for making no progress.
             // Cumulative since process start — `AggregatedState::reset()` has
-            // no production caller — so it only ever climbs, and does so on
-            // every maintenance cycle while any region is stuck. Read the rate
-            // of change between samples, not the absolute value: a flat value
-            // across successive lines is the healthy signal. Non-zero under a
-            // cold-cache backlog is expected.
+            // no production caller — so it only ever climbs. It does NOT climb
+            // every maintenance cycle: a stuck region is moved to `Deferred`
+            // immediately, and `is_stale()` only re-evaluates `InProgress`
+            // regions, so the region sits off-cycle until its deferral expires
+            // (the 20/30/40/60s ladder), gets re-planned back to `InProgress`,
+            // and ages another `stale_region_timeout` (default 120s) before it
+            // can increment again. Realistic floor is ~140s per region per
+            // increment. Read the rate of change between samples, not the
+            // absolute value: a flat value across successive lines is the
+            // healthy signal. Non-zero under a cold-cache backlog is expected.
             regions_deferred = state.prefetch_regions_deferred,
             // Criterion 5's user-visible outcome (the others above are
             // mechanism): on-demand FUSE generations should fall during

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -432,18 +432,22 @@ impl MetricsDaemon {
             regions_prefetched = state.prefetch_regions_prefetched,
             regions_nocoverage = state.prefetch_regions_nocoverage,
             // #226: how many regions are deferred RIGHT NOW (gauge). Distinct
-            // from `regions_deferred` below, which counts deferrals that
-            // occurred during the interval. Without this, deferred regions
-            // would be invisible in the sample line — or, worse, counted as
-            // `regions_nocoverage` and read as missing scenery.
+            // from `regions_deferred` below, which is a cumulative count of
+            // every deferral since process start. Without this, deferred
+            // regions would be invisible in the sample line — or, worse,
+            // counted as `regions_nocoverage` and read as missing scenery.
             regions_deferred_active = state.prefetch_regions_deferred_active,
             promotions_normal = state.prefetch_promotions_normal,
             promotions_rescue = state.prefetch_promotions_rescue,
             state_diverged = state.prefetch_state_diverged,
             regions_demoted = state.prefetch_regions_demoted,
             // #226: how often a region was skipped for making no progress.
-            // Non-zero under a cold-cache backlog is expected; climbing
-            // without bound is not.
+            // Cumulative since process start — `AggregatedState::reset()` has
+            // no production caller — so it only ever climbs, and does so on
+            // every maintenance cycle while any region is stuck. Read the rate
+            // of change between samples, not the absolute value: a flat value
+            // across successive lines is the healthy signal. Non-zero under a
+            // cold-cache backlog is expected.
             regions_deferred = state.prefetch_regions_deferred,
             // Criterion 5's user-visible outcome (the others above are
             // mechanism): on-demand FUSE generations should fall during
@@ -1224,7 +1228,11 @@ mod tests {
         // regions_deferred is a COUNTER, unlike the region-state gauges
         // above: it accumulates across the daemon's own event stream rather
         // than being assigned wholesale from GeoIndex each cycle, so it
-        // must reset while the gauges must not.
+        // belongs in `reset()` while the gauges do not.
+        //
+        // `reset()` has no production caller today, so in a running process
+        // the counter is cumulative since start. This asserts the `reset()`
+        // contract for the field, not a per-interval window in the log.
         let (mut daemon, _tx) = create_daemon();
         daemon.state.prefetch_regions_deferred = 7;
         daemon.state.prefetch_regions_nocoverage = 3;

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -1270,6 +1270,37 @@ mod tests {
     }
 
     #[test]
+    fn test_prefetch_region_deferred_event_increments_the_counter_only() {
+        // Closes the daemon end of the `regions_deferred` chain (#226 review
+        // I-3). The sample-line test seeds the field directly, so it cannot
+        // tell whether `process_event` routes this variant anywhere at all —
+        // and the most plausible mis-wiring, incrementing the *gauge*
+        // `prefetch_regions_deferred_active`, would leave the counter
+        // permanently zero while the sample line still looked populated.
+        let (mut daemon, _tx) = create_daemon();
+        daemon.state.prefetch_regions_deferred_active = 4;
+
+        daemon.process_event(MetricEvent::PrefetchRegionDeferred);
+        daemon.process_event(MetricEvent::PrefetchRegionDeferred);
+
+        assert_eq!(
+            daemon.state.prefetch_regions_deferred, 2,
+            "each event must increment the counter"
+        );
+        assert_eq!(
+            daemon.state.prefetch_regions_deferred_active, 4,
+            "the event must leave the gauge alone — it is assigned wholesale \
+             from the GeoIndex by PrefetchRegionState"
+        );
+        // The neighbouring prefetch counters share a shape; a copy-paste in
+        // the match arm would land in one of them.
+        assert_eq!(daemon.state.prefetch_regions_demoted, 0);
+        assert_eq!(daemon.state.prefetch_state_diverged, 0);
+        assert_eq!(daemon.state.prefetch_promotions_normal, 0);
+        assert_eq!(daemon.state.prefetch_promotions_rescue, 0);
+    }
+
+    #[test]
     fn test_prefetch_region_state_is_a_gauge_not_a_counter() {
         // Regression guard: a second PrefetchRegionState event must replace
         // the previous values, not add to them. If this were mistakenly

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -333,6 +333,7 @@ impl MetricsDaemon {
                 in_progress,
                 prefetched,
                 no_coverage,
+                deferred,
             } => {
                 // Gauge: assigns, does not increment. The coordinator reports
                 // the full distribution each maintenance cycle, so the latest
@@ -340,6 +341,7 @@ impl MetricsDaemon {
                 self.state.prefetch_regions_in_progress = in_progress;
                 self.state.prefetch_regions_prefetched = prefetched;
                 self.state.prefetch_regions_nocoverage = no_coverage;
+                self.state.prefetch_regions_deferred_active = deferred;
             }
             MetricEvent::PrefetchStateDiverged => {
                 self.state.prefetch_state_diverged += 1;
@@ -429,6 +431,12 @@ impl MetricsDaemon {
             regions_in_progress = state.prefetch_regions_in_progress,
             regions_prefetched = state.prefetch_regions_prefetched,
             regions_nocoverage = state.prefetch_regions_nocoverage,
+            // #226: how many regions are deferred RIGHT NOW (gauge). Distinct
+            // from `regions_deferred` below, which counts deferrals that
+            // occurred during the interval. Without this, deferred regions
+            // would be invisible in the sample line — or, worse, counted as
+            // `regions_nocoverage` and read as missing scenery.
+            regions_deferred_active = state.prefetch_regions_deferred_active,
             promotions_normal = state.prefetch_promotions_normal,
             promotions_rescue = state.prefetch_promotions_rescue,
             state_diverged = state.prefetch_state_diverged,
@@ -1147,7 +1155,7 @@ mod tests {
         let (mut daemon, tx) = create_daemon();
         let client = MetricsClient::new(tx);
 
-        client.prefetch_region_state(3, 7, 2);
+        client.prefetch_region_state(3, 7, 2, 5);
         client.prefetch_state_diverged();
         client.prefetch_state_diverged();
         client.prefetch_region_demoted();
@@ -1173,6 +1181,11 @@ mod tests {
         assert_eq!(
             sample.get("regions_nocoverage").map(String::as_str),
             Some("2")
+        );
+        assert_eq!(
+            sample.get("regions_deferred_active").map(String::as_str),
+            Some("5"),
+            "the deferred gauge must be its own field, distinct from regions_nocoverage"
         );
         assert_eq!(sample.get("state_diverged").map(String::as_str), Some("2"));
         assert_eq!(sample.get("regions_demoted").map(String::as_str), Some("1"));
@@ -1215,6 +1228,7 @@ mod tests {
         let (mut daemon, _tx) = create_daemon();
         daemon.state.prefetch_regions_deferred = 7;
         daemon.state.prefetch_regions_nocoverage = 3;
+        daemon.state.prefetch_regions_deferred_active = 4;
 
         let events = capture_events(|| daemon.log_prefetch_sample());
         let sample =
@@ -1222,6 +1236,13 @@ mod tests {
         assert_eq!(
             sample.get("regions_deferred").map(String::as_str),
             Some("7")
+        );
+        // Same subject, different semantics — the two must never collapse
+        // into one field. Distinct seeded values make a mix-up visible.
+        assert_eq!(
+            sample.get("regions_deferred_active").map(String::as_str),
+            Some("4"),
+            "the gauge is a separate field from the counter"
         );
 
         daemon.state.reset();
@@ -1232,6 +1253,11 @@ mod tests {
         assert_eq!(
             daemon.state.prefetch_regions_nocoverage, 3,
             "gauge must NOT reset"
+        );
+        assert_eq!(
+            daemon.state.prefetch_regions_deferred_active, 4,
+            "the deferred gauge is externally derived from GeoIndex, so it \
+             must NOT reset either"
         );
     }
 
@@ -1247,19 +1273,26 @@ mod tests {
             in_progress: 5,
             prefetched: 10,
             no_coverage: 1,
+            deferred: 4,
         });
         assert_eq!(daemon.state.prefetch_regions_in_progress, 5);
         assert_eq!(daemon.state.prefetch_regions_prefetched, 10);
         assert_eq!(daemon.state.prefetch_regions_nocoverage, 1);
+        assert_eq!(daemon.state.prefetch_regions_deferred_active, 4);
 
         daemon.process_event(MetricEvent::PrefetchRegionState {
             in_progress: 2,
             prefetched: 3,
             no_coverage: 0,
+            deferred: 0,
         });
         assert_eq!(daemon.state.prefetch_regions_in_progress, 2);
         assert_eq!(daemon.state.prefetch_regions_prefetched, 3);
         assert_eq!(daemon.state.prefetch_regions_nocoverage, 0);
+        assert_eq!(
+            daemon.state.prefetch_regions_deferred_active, 0,
+            "the deferred gauge must be assigned, not accumulated"
+        );
     }
 
     #[test]

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -352,6 +352,9 @@ impl MetricsDaemon {
             MetricEvent::PrefetchRegionDeferred => {
                 self.state.prefetch_regions_deferred += 1;
             }
+            MetricEvent::PrefetchDeferralCleared => {
+                self.state.prefetch_deferrals_cleared += 1;
+            }
             MetricEvent::PrefetchRegionsPromotedNormal { count } => {
                 self.state.prefetch_promotions_normal += count as u64;
             }
@@ -454,6 +457,13 @@ impl MetricsDaemon {
             // absolute value: a flat value across successive lines is the
             // healthy signal. Non-zero under a cold-cache backlog is expected.
             regions_deferred = state.prefetch_regions_deferred,
+            // #226: how often the sim demanded a tile inside a region that
+            // was still Deferred, clearing the deferral early. The post-fix
+            // analogue of `regions_demoted` — measures whether the
+            // 20/30/40/60s ladder is well-tuned, not whether prefetch's state
+            // was wrong. Cumulative since process start, same as
+            // `regions_deferred` above.
+            deferrals_cleared = state.prefetch_deferrals_cleared,
             // Criterion 5's user-visible outcome (the others above are
             // mechanism): on-demand FUSE generations should fall during
             // cruise. Per-tile FUSE logging is debug-only (#209), so this
@@ -1242,6 +1252,7 @@ mod tests {
         daemon.state.prefetch_regions_deferred = 7;
         daemon.state.prefetch_regions_nocoverage = 3;
         daemon.state.prefetch_regions_deferred_active = 4;
+        daemon.state.prefetch_deferrals_cleared = 5;
 
         let events = capture_events(|| daemon.log_prefetch_sample());
         let sample =
@@ -1249,6 +1260,11 @@ mod tests {
         assert_eq!(
             sample.get("regions_deferred").map(String::as_str),
             Some("7")
+        );
+        assert_eq!(
+            sample.get("deferrals_cleared").map(String::as_str),
+            Some("5"),
+            "deferrals_cleared must be its own field, distinct from regions_deferred"
         );
         // Same subject, different semantics — the two must never collapse
         // into one field. Distinct seeded values make a mix-up visible.
@@ -1261,6 +1277,10 @@ mod tests {
         daemon.state.reset();
         assert_eq!(
             daemon.state.prefetch_regions_deferred, 0,
+            "counter must reset"
+        );
+        assert_eq!(
+            daemon.state.prefetch_deferrals_cleared, 0,
             "counter must reset"
         );
         assert_eq!(
@@ -1299,6 +1319,37 @@ mod tests {
         );
         // The neighbouring prefetch counters share a shape; a copy-paste in
         // the match arm would land in one of them.
+        assert_eq!(daemon.state.prefetch_regions_demoted, 0);
+        assert_eq!(daemon.state.prefetch_state_diverged, 0);
+        assert_eq!(daemon.state.prefetch_promotions_normal, 0);
+        assert_eq!(daemon.state.prefetch_promotions_rescue, 0);
+        assert_eq!(daemon.state.prefetch_deferrals_cleared, 0);
+    }
+
+    #[test]
+    fn test_prefetch_deferral_cleared_event_increments_the_counter_only() {
+        // Closes the daemon end of the `deferrals_cleared` chain (#226,
+        // mirroring PrefetchRegionDeferred above end to end). The most
+        // plausible mis-wiring is routing this into the *gauge*
+        // `prefetch_regions_deferred_active`, which would leave the counter
+        // permanently zero while the gauge looked populated.
+        let (mut daemon, _tx) = create_daemon();
+        daemon.state.prefetch_regions_deferred_active = 4;
+
+        daemon.process_event(MetricEvent::PrefetchDeferralCleared);
+        daemon.process_event(MetricEvent::PrefetchDeferralCleared);
+
+        assert_eq!(
+            daemon.state.prefetch_deferrals_cleared, 2,
+            "each event must increment the counter"
+        );
+        assert_eq!(
+            daemon.state.prefetch_regions_deferred_active, 4,
+            "the event must leave the gauge alone"
+        );
+        // The neighbouring prefetch counters share a shape; a copy-paste in
+        // the match arm would land in one of them.
+        assert_eq!(daemon.state.prefetch_regions_deferred, 0);
         assert_eq!(daemon.state.prefetch_regions_demoted, 0);
         assert_eq!(daemon.state.prefetch_state_diverged, 0);
         assert_eq!(daemon.state.prefetch_promotions_normal, 0);

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -251,6 +251,9 @@ pub enum MetricEvent {
     /// A region's state was cleared in response to observed divergence.
     PrefetchRegionDemoted,
 
+    /// A region was deferred after making no progress since the last evaluation.
+    PrefetchRegionDeferred,
+
     /// Regions promoted from `InProgress` to `Prefetched` via the normal
     /// completion path (all tiles in the region confirmed present).
     ///
@@ -306,6 +309,7 @@ impl MetricEvent {
             Self::PrefetchRegionState { .. } => "prefetch_region_state",
             Self::PrefetchStateDiverged => "prefetch_state_diverged",
             Self::PrefetchRegionDemoted => "prefetch_region_demoted",
+            Self::PrefetchRegionDeferred => "prefetch_region_deferred",
             Self::PrefetchRegionsPromotedNormal { .. } => "prefetch_regions_promoted_normal",
             Self::PrefetchRegionPromotedRescue => "prefetch_region_promoted_rescue",
         }

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -261,6 +261,16 @@ pub enum MetricEvent {
     /// A region was deferred after making no progress since the last evaluation.
     PrefetchRegionDeferred,
 
+    /// A region's deferral was cleared because X-Plane demanded a tile there.
+    ///
+    /// The post-fix analogue of [`Self::PrefetchRegionDemoted`]: prefetch gave
+    /// up on the region (deferred it), then the sim asked for tiles inside it
+    /// anyway. Counted, not logged above `debug!` — it fires once per
+    /// FUSE-generated tile in the region, which is too frequent for the
+    /// default log level — so this counter is the only default-level signal
+    /// for whether the 20/30/40/60s deferral ladder is well-tuned (#226).
+    PrefetchDeferralCleared,
+
     /// Regions promoted from `InProgress` to `Prefetched` via the normal
     /// completion path (all tiles in the region confirmed present).
     ///
@@ -317,6 +327,7 @@ impl MetricEvent {
             Self::PrefetchStateDiverged => "prefetch_state_diverged",
             Self::PrefetchRegionDemoted => "prefetch_region_demoted",
             Self::PrefetchRegionDeferred => "prefetch_region_deferred",
+            Self::PrefetchDeferralCleared => "prefetch_deferral_cleared",
             Self::PrefetchRegionsPromotedNormal { .. } => "prefetch_regions_promoted_normal",
             Self::PrefetchRegionPromotedRescue => "prefetch_region_promoted_rescue",
         }

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -239,6 +239,13 @@ pub enum MetricEvent {
         prefetched: usize,
         /// Regions with no ortho scenery.
         no_coverage: usize,
+        /// Regions currently deferred for making no progress (#226).
+        ///
+        /// Deliberately its own bucket rather than folded into
+        /// `no_coverage`: `regions_nocoverage` non-zero only over water is an
+        /// acceptance criterion, and a deferred land region counted there
+        /// would be exactly the false alarm #226 exists to remove.
+        deferred: usize,
     },
 
     /// FUSE generated a tile in a region prefetch claimed was handled.

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -262,16 +262,17 @@ pub struct AggregatedState {
     pub prefetch_regions_nocoverage: usize,
     /// Regions currently deferred for making no progress (gauge, #226).
     ///
-    /// Distinct from [`Self::prefetch_regions_deferred`], which is a counter
-    /// of how many deferrals have *occurred* in the interval. This is how
-    /// many regions are deferred *right now*.
+    /// Distinct from [`Self::prefetch_regions_deferred`], which is a
+    /// cumulative count of how many deferrals have *occurred* since process
+    /// start. This is how many regions are deferred *right now*.
     pub prefetch_regions_deferred_active: usize,
     /// Total observed divergences between prefetch state and reality (counter).
     pub prefetch_state_diverged: u64,
     /// Total regions demoted in response to divergence (counter).
     pub prefetch_regions_demoted: u64,
-    /// Total regions deferred for making no progress since the last
-    /// evaluation (counter).
+    /// Total regions deferred for making no progress, cumulative since
+    /// process start (counter). `reset()` has no production caller, so this
+    /// is never windowed.
     pub prefetch_regions_deferred: u64,
     /// Total regions promoted via the normal completion path (counter).
     pub prefetch_promotions_normal: u64,

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -264,6 +264,9 @@ pub struct AggregatedState {
     pub prefetch_state_diverged: u64,
     /// Total regions demoted in response to divergence (counter).
     pub prefetch_regions_demoted: u64,
+    /// Total regions deferred for making no progress since the last
+    /// evaluation (counter).
+    pub prefetch_regions_deferred: u64,
     /// Total regions promoted via the normal completion path (counter).
     pub prefetch_promotions_normal: u64,
     /// Total regions promoted via the rescue path (counter).
@@ -330,6 +333,7 @@ impl AggregatedState {
             prefetch_regions_nocoverage: 0,
             prefetch_state_diverged: 0,
             prefetch_regions_demoted: 0,
+            prefetch_regions_deferred: 0,
             prefetch_promotions_normal: 0,
             prefetch_promotions_rescue: 0,
         }
@@ -390,6 +394,7 @@ impl AggregatedState {
         // them here would misreport "no regions" until the next cycle.
         self.prefetch_state_diverged = 0;
         self.prefetch_regions_demoted = 0;
+        self.prefetch_regions_deferred = 0;
         self.prefetch_promotions_normal = 0;
         self.prefetch_promotions_rescue = 0;
     }

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -274,6 +274,12 @@ pub struct AggregatedState {
     /// process start (counter). `reset()` has no production caller, so this
     /// is never windowed.
     pub prefetch_regions_deferred: u64,
+    /// Total region deferrals cleared by on-demand FUSE generation, cumulative
+    /// since process start (counter, #226). The post-fix analogue of
+    /// `prefetch_regions_demoted`: measures how often the sim outruns the
+    /// deferral ladder rather than how often prefetch's state was simply
+    /// wrong.
+    pub prefetch_deferrals_cleared: u64,
     /// Total regions promoted via the normal completion path (counter).
     pub prefetch_promotions_normal: u64,
     /// Total regions promoted via the rescue path (counter).
@@ -342,6 +348,7 @@ impl AggregatedState {
             prefetch_state_diverged: 0,
             prefetch_regions_demoted: 0,
             prefetch_regions_deferred: 0,
+            prefetch_deferrals_cleared: 0,
             prefetch_promotions_normal: 0,
             prefetch_promotions_rescue: 0,
         }
@@ -404,6 +411,7 @@ impl AggregatedState {
         self.prefetch_state_diverged = 0;
         self.prefetch_regions_demoted = 0;
         self.prefetch_regions_deferred = 0;
+        self.prefetch_deferrals_cleared = 0;
         self.prefetch_promotions_normal = 0;
         self.prefetch_promotions_rescue = 0;
     }

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -260,6 +260,12 @@ pub struct AggregatedState {
     pub prefetch_regions_prefetched: usize,
     /// Regions with no ortho scenery (gauge).
     pub prefetch_regions_nocoverage: usize,
+    /// Regions currently deferred for making no progress (gauge, #226).
+    ///
+    /// Distinct from [`Self::prefetch_regions_deferred`], which is a counter
+    /// of how many deferrals have *occurred* in the interval. This is how
+    /// many regions are deferred *right now*.
+    pub prefetch_regions_deferred_active: usize,
     /// Total observed divergences between prefetch state and reality (counter).
     pub prefetch_state_diverged: u64,
     /// Total regions demoted in response to divergence (counter).
@@ -331,6 +337,7 @@ impl AggregatedState {
             prefetch_regions_in_progress: 0,
             prefetch_regions_prefetched: 0,
             prefetch_regions_nocoverage: 0,
+            prefetch_regions_deferred_active: 0,
             prefetch_state_diverged: 0,
             prefetch_regions_demoted: 0,
             prefetch_regions_deferred: 0,
@@ -386,7 +393,8 @@ impl AggregatedState {
         self.fuse_requests_active = 0;
         self.fuse_requests_waiting = 0;
         self.peak_bytes_per_second = 0.0;
-        // prefetch_regions_{in_progress,prefetched,nocoverage} are NOT reset:
+        // prefetch_regions_{in_progress,prefetched,nocoverage,deferred_active}
+        // are NOT reset:
         // like chunk_disk_cache_size_bytes/dds_disk_cache_size_bytes/
         // chunk_index_entries above, they are externally-derived gauges
         // (assigned wholesale from GeoIndex each maintenance cycle), not

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -16,13 +16,17 @@ use crate::prefetch::SceneryIndex;
 ///
 /// Handles region state transitions (InProgress → Prefetched) and
 /// retention-based eviction. Staleness is handled by the coordinator's
-/// `evaluate_stale_regions`, which checks the DDS disk before deciding
-/// whether a stale region should be promoted, retried, or — after
-/// `MAX_REGION_ATTEMPTS` retries — retired to `NoCoverage` permanently
-/// for the session. A fourth outcome exists alongside those three: when
-/// [`RegionDiskState::Unknown`] reports no authoritative source to
-/// consult, the region is left untouched and the attempt does not count
-/// against the retry limit.
+/// `evaluate_stale_regions`, which dispatches on [`RegionDiskState`]:
+/// [`RegionDiskState::Complete`] promotes, [`RegionDiskState::Incomplete`]
+/// either retries immediately (coverage advanced) or defers on an escalating
+/// ladder (coverage stuck), and [`RegionDiskState::NoTiles`] — the only path
+/// to `NoCoverage` — retires the region on the first look, since the scenery
+/// index is fully built before the coordinator receives it. When
+/// [`RegionDiskState::Unknown`] reports no authoritative source to consult,
+/// the region is left untouched and no strike is recorded.
+///
+/// An `Incomplete` region is never retired, however long it takes: see #226,
+/// where timing-based strikes retired regions that had indexed coverage.
 pub struct BoundaryStrategy;
 
 /// What the authoritative DDS disk cache can tell us about a region.

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -203,16 +203,22 @@ impl BoundaryStrategy {
 
     /// Evict `PrefetchedRegion` entries for regions no longer in the retained window.
     ///
-    /// Removes `Prefetched` and `NoCoverage` entries whose DSF region is not
-    /// present in the `RetainedRegion` layer. `InProgress` entries are preserved
-    /// because they represent actively running prefetch jobs.
+    /// Removes `Prefetched`, `Deferred`, and `NoCoverage` entries whose DSF
+    /// region is not present in the `RetainedRegion` layer. `InProgress`
+    /// entries are preserved because they represent actively running
+    /// prefetch jobs.
     ///
-    /// Returns 0 (no-op) when the `RetainedRegion` layer is empty, indicating
-    /// retention tracking is not yet active.
-    pub fn evict_non_retained(geo_index: &GeoIndex) -> usize {
+    /// Returns an empty `Vec` (no-op) when the `RetainedRegion` layer is
+    /// empty, indicating retention tracking is not yet active.
+    ///
+    /// Returns the evicted regions so the caller can prune any per-region
+    /// bookkeeping (e.g. the coordinator's `region_retry` map) it holds
+    /// alongside the index — this function is a static taking only
+    /// `&GeoIndex` and cannot reach that bookkeeping itself.
+    pub fn evict_non_retained(geo_index: &GeoIndex) -> Vec<DsfRegion> {
         let retained = geo_index.regions::<RetainedRegion>();
         if retained.is_empty() {
-            return 0; // Retention not active yet
+            return Vec::new(); // Retention not active yet
         }
 
         let retained_set: std::collections::HashSet<DsfRegion> = retained.into_iter().collect();
@@ -224,15 +230,17 @@ impl BoundaryStrategy {
             .map(|(dsf, _)| dsf)
             .collect();
 
-        let evicted = to_evict.len();
         for region in &to_evict {
             geo_index.remove::<PrefetchedRegion>(region);
         }
 
-        if evicted > 0 {
-            tracing::debug!(evicted, "Evicted non-retained PrefetchedRegion entries");
+        if !to_evict.is_empty() {
+            tracing::debug!(
+                evicted = to_evict.len(),
+                "Evicted non-retained PrefetchedRegion entries"
+            );
         }
-        evicted
+        to_evict
     }
 }
 
@@ -879,7 +887,9 @@ mod tests {
 
         let evicted = BoundaryStrategy::evict_non_retained(&geo_index);
 
-        assert_eq!(evicted, 2);
+        assert_eq!(evicted.len(), 2);
+        assert!(evicted.contains(&DsfRegion::new(48, 7)));
+        assert!(evicted.contains(&DsfRegion::new(52, 5)));
         assert!(geo_index.contains::<PrefetchedRegion>(&DsfRegion::new(50, 7)));
         assert!(geo_index.contains::<PrefetchedRegion>(&DsfRegion::new(51, 7)));
         assert!(!geo_index.contains::<PrefetchedRegion>(&DsfRegion::new(48, 7)));
@@ -901,7 +911,7 @@ mod tests {
 
         let evicted = BoundaryStrategy::evict_non_retained(&geo_index);
 
-        assert_eq!(evicted, 1); // Only Prefetched, not InProgress
+        assert_eq!(evicted, vec![DsfRegion::new(51, 7)]); // Only Prefetched, not InProgress
         assert!(geo_index.contains::<PrefetchedRegion>(&DsfRegion::new(50, 7)));
         assert!(!geo_index.contains::<PrefetchedRegion>(&DsfRegion::new(51, 7)));
     }
@@ -918,7 +928,7 @@ mod tests {
 
         // Should not evict anything — retention not active means we can't determine
         // what's outside the window
-        assert_eq!(evicted, 0);
+        assert!(evicted.is_empty());
         assert!(geo_index.contains::<PrefetchedRegion>(&DsfRegion::new(50, 7)));
         assert!(geo_index.contains::<PrefetchedRegion>(&DsfRegion::new(51, 7)));
     }

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -38,14 +38,70 @@ pub struct BoundaryStrategy;
 pub enum RegionDiskState {
     /// Every tile the scenery index attributes to this region is present.
     Complete,
-    /// At least one attributed tile is absent. Carries the counts so callers
-    /// can tell a region that is *advancing* from one that is *stuck* — the
-    /// distinction #226 turned on.
-    Incomplete { covered: usize, total: usize },
+    /// At least one attributed tile is absent. See [`TileCoverage`] for why
+    /// the counts are not unconditionally present.
+    Incomplete { coverage: TileCoverage },
     /// The scenery index attributes no tiles to this region.
     NoTiles,
     /// No authoritative source to consult — no checker and/or no index.
     Unknown,
+}
+
+/// How much an `Incomplete` answer knows about the region's tile counts.
+///
+/// This is an enum rather than `Option<(usize, usize)>` or a pair of zeroes
+/// because "not counted" must be *unrepresentable as a plausible count*.
+/// `Incomplete { covered: 0, total: 0 }` from a short-circuiting scan would
+/// read as a real observation ("nothing has arrived, and the region is
+/// empty") and would drive `evaluate_stale_regions` straight into a strike —
+/// exactly the class of silently-wrong number #226 exists to remove.
+/// [`TileCoverage::NotCounted`] carries no payload, so there is no number to
+/// misread, and [`TileCoverage::counts`] forces every reader to acknowledge
+/// its absence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TileCoverage {
+    /// Every tile was checked. `covered < total` by construction.
+    Exact { covered: usize, total: usize },
+    /// The scan stopped at the first missing tile, so no counts exist.
+    /// Produced only for [`CoverageDetail::FirstMissOnly`] callers, which by
+    /// definition discard the counts.
+    NotCounted,
+}
+
+impl TileCoverage {
+    /// The `(covered, total)` pair, or `None` when the scan short-circuited.
+    pub fn counts(&self) -> Option<(usize, usize)> {
+        match self {
+            Self::Exact { covered, total } => Some((*covered, *total)),
+            Self::NotCounted => None,
+        }
+    }
+}
+
+/// How thoroughly [`BoundaryStrategy::region_disk_state`] should scan a
+/// region's tile set.
+///
+/// One function, one behaviour, parameterised — not two functions that can
+/// drift apart, which is the defect #176 was filed to remove.
+///
+/// The parameter exists because the per-tile check is not free. When the XEL
+/// DDS cache misses, `tile_is_covered` falls through to
+/// `OrthoUnionIndex::dds_tile_exists`, which tries 4 filename prefixes and —
+/// because `textures/` is in `LAZY_DIRECTORIES` and is deliberately never
+/// indexed — resolves each by `stat()`ing every installed source. An absent
+/// tile therefore costs ~4 × N_sources syscalls, and
+/// [`BoundaryStrategy::promote_completed_regions`] runs over every
+/// `InProgress` region on a 2-second cycle. Counting tiles it then discards
+/// would steal CPU from the executor under exactly the cold-cache backlog
+/// this code exists to relieve.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageDetail {
+    /// Stop at the first missing tile. For callers that only need the
+    /// `Complete` / not-`Complete` distinction.
+    FirstMissOnly,
+    /// Check every tile and report exact counts. For callers that must tell
+    /// an *advancing* region from a *stuck* one.
+    ExactCounts,
 }
 
 impl BoundaryStrategy {
@@ -66,6 +122,7 @@ impl BoundaryStrategy {
         scenery_index: Option<&Arc<SceneryIndex>>,
         dds_disk_checker: Option<&Arc<dyn DdsDiskCacheChecker>>,
         ortho_union_index: Option<&Arc<OrthoUnionIndex>>,
+        detail: CoverageDetail,
     ) -> RegionDiskState {
         let (Some(index), Some(checker)) = (scenery_index, dds_disk_checker) else {
             return RegionDiskState::Unknown;
@@ -74,20 +131,42 @@ impl BoundaryStrategy {
         if tiles.is_empty() {
             return RegionDiskState::NoTiles;
         }
-        // Counts rather than short-circuiting: the caller needs `covered` to
-        // distinguish a slow region from a stuck one. Affordable because
-        // `tile_exists_blocking` is a sync map lookup as of #226 (see
-        // TODO(#175) resolution); it was a runtime round-trip per tile before.
-        let total = tiles.len();
-        let covered = tiles
-            .iter()
-            .filter(|t| Self::tile_is_covered(t, checker, ortho_union_index))
-            .count();
 
-        if covered == total {
-            RegionDiskState::Complete
-        } else {
-            RegionDiskState::Incomplete { covered, total }
+        match detail {
+            // Cheap path. `all` stops at the first missing tile, which is all
+            // `promote_completed_regions` needs — see [`CoverageDetail`] for
+            // why the difference is not academic.
+            CoverageDetail::FirstMissOnly => {
+                if tiles
+                    .iter()
+                    .all(|t| Self::tile_is_covered(t, checker, ortho_union_index))
+                {
+                    RegionDiskState::Complete
+                } else {
+                    RegionDiskState::Incomplete {
+                        coverage: TileCoverage::NotCounted,
+                    }
+                }
+            }
+            // Full scan: `evaluate_stale_regions` needs `covered` to tell a
+            // slow region from a stuck one. It runs only over regions stale
+            // for longer than `stale_region_timeout` (120s), so the cost is
+            // bounded in a way the every-cycle path is not.
+            CoverageDetail::ExactCounts => {
+                let total = tiles.len();
+                let covered = tiles
+                    .iter()
+                    .filter(|t| Self::tile_is_covered(t, checker, ortho_union_index))
+                    .count();
+
+                if covered == total {
+                    RegionDiskState::Complete
+                } else {
+                    RegionDiskState::Incomplete {
+                        coverage: TileCoverage::Exact { covered, total },
+                    }
+                }
+            }
         }
     }
 
@@ -146,7 +225,13 @@ impl BoundaryStrategy {
     /// tiles belong to this region" shared with the submit and rescue
     /// paths (#176) — and queries the `DdsDiskCacheChecker` for each tile.
     /// A region is promoted to `Prefetched` only when **every** one of its
-    /// tiles is present on disk (check-all with short-circuit on first miss).
+    /// tiles is covered.
+    ///
+    /// Scans with [`CoverageDetail::FirstMissOnly`]: this runs on every
+    /// coordinator cycle (2s) over every `InProgress` region, and the
+    /// `covered`/`total` counts are discarded here anyway. Only the rescue
+    /// path pays for exact counts. See [`CoverageDetail`] for the syscall
+    /// arithmetic that makes the difference matter.
     ///
     /// If either `dds_disk_checker` or `scenery_index` is `None`, promotion
     /// is skipped — there is no authoritative source to consult, or no way
@@ -179,6 +264,7 @@ impl BoundaryStrategy {
                 scenery_index,
                 dds_disk_checker,
                 ortho_union_index,
+                CoverageDetail::FirstMissOnly,
             ) {
                 RegionDiskState::Complete => {
                     geo_index.insert::<PrefetchedRegion>(*region, PrefetchedRegion::prefetched());
@@ -675,7 +761,13 @@ mod tests {
         let index = make_scenery_index_for_region(50, 9, 16);
         let region = DsfRegion { lat: 50, lon: 9 };
         assert_eq!(
-            BoundaryStrategy::region_disk_state(region, Some(&index), None, None),
+            BoundaryStrategy::region_disk_state(
+                region,
+                Some(&index),
+                None,
+                None,
+                CoverageDetail::ExactCounts
+            ),
             RegionDiskState::Unknown,
             "no checker means we cannot tell — must not be reported as Incomplete"
         );
@@ -688,7 +780,13 @@ mod tests {
         // A region the index knows nothing about.
         let region = DsfRegion { lat: -40, lon: 170 };
         assert_eq!(
-            BoundaryStrategy::region_disk_state(region, Some(&index), Some(&checker), None),
+            BoundaryStrategy::region_disk_state(
+                region,
+                Some(&index),
+                Some(&checker),
+                None,
+                CoverageDetail::ExactCounts
+            ),
             RegionDiskState::NoTiles
         );
     }
@@ -728,11 +826,22 @@ mod tests {
         let checker: Arc<dyn DdsDiskCacheChecker> =
             MockDiskChecker::with_tile_coords(vec![tiles[0], tiles[1]]);
 
-        let state = BoundaryStrategy::region_disk_state(region, Some(&index), Some(&checker), None);
+        let state = BoundaryStrategy::region_disk_state(
+            region,
+            Some(&index),
+            Some(&checker),
+            None,
+            CoverageDetail::ExactCounts,
+        );
 
         assert_eq!(
             state,
-            RegionDiskState::Incomplete { covered: 2, total: 3 },
+            RegionDiskState::Incomplete {
+                coverage: TileCoverage::Exact {
+                    covered: 2,
+                    total: 3
+                }
+            },
             "must report how many of the region's tiles are present, not just that it is incomplete"
         );
     }
@@ -753,7 +862,8 @@ mod tests {
                 region,
                 Some(&index),
                 Some(&test_checker(&all)),
-                None
+                None,
+                CoverageDetail::ExactCounts
             ),
             RegionDiskState::Complete
         );
@@ -764,12 +874,184 @@ mod tests {
                 region,
                 Some(&index),
                 Some(&test_checker(&all_but_one)),
-                None
+                None,
+                CoverageDetail::ExactCounts
             ),
             RegionDiskState::Incomplete {
-                covered: tiles.len() - 1,
-                total: tiles.len()
+                coverage: TileCoverage::Exact {
+                    covered: tiles.len() - 1,
+                    total: tiles.len()
+                }
             }
+        );
+    }
+
+    // =========================================================================
+    // CoverageDetail short-circuit (#226 review C-1)
+    // =========================================================================
+
+    /// A checker that reports every tile absent and counts how many times it
+    /// was asked. Counting is the only way to observe short-circuiting: both
+    /// details agree on the *verdict*, and it is the syscall count that the
+    /// 2-second promotion cycle cannot afford.
+    struct CountingDiskChecker {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl CountingDiskChecker {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            })
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl DdsDiskCacheChecker for CountingDiskChecker {
+        fn tile_exists(
+            &self,
+            _row: u32,
+            _col: u32,
+            _zoom: u8,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async move { false })
+        }
+
+        fn tile_exists_blocking(&self, _row: u32, _col: u32, _zoom: u8) -> bool {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            false
+        }
+    }
+
+    /// Build a scenery index holding exactly three tiles in (47, 8), none of
+    /// which any checker will report as present.
+    fn three_tile_index() -> (Arc<SceneryIndex>, DsfRegion) {
+        let index = Arc::new(SceneryIndex::with_defaults());
+        let region = DsfRegion::new(47, 8);
+        for (row, col, lat, lon) in [
+            (1000u32, 2000u32, 47.1f32, 8.1f32),
+            (3000, 4000, 47.4, 8.4),
+            (5000, 6000, 47.7, 8.7),
+        ] {
+            index.add_tile(SceneryTile {
+                row,
+                col,
+                chunk_zoom: 16,
+                lat,
+                lon,
+                is_sea: false,
+            });
+        }
+        assert_eq!(
+            index.tiles_in_region(region).len(),
+            3,
+            "fixture precondition: exactly 3 tiles"
+        );
+        (index, region)
+    }
+
+    #[test]
+    fn test_first_miss_only_stops_at_the_first_absent_tile() {
+        // The hot path: `promote_completed_regions` runs every 2s over every
+        // InProgress region, and each absent tile costs ~4 x N_sources stats
+        // once it falls through to the OrthoUnionIndex. Counting tiles it then
+        // discards is the amplification C-1 removes.
+        let (index, region) = three_tile_index();
+        let counting = CountingDiskChecker::new();
+        let checker: Arc<dyn DdsDiskCacheChecker> = counting.clone();
+
+        let state = BoundaryStrategy::region_disk_state(
+            region,
+            Some(&index),
+            Some(&checker),
+            None,
+            CoverageDetail::FirstMissOnly,
+        );
+
+        assert_eq!(
+            state,
+            RegionDiskState::Incomplete {
+                coverage: TileCoverage::NotCounted
+            },
+            "a short-circuited scan must not report counts it never computed"
+        );
+        assert_eq!(
+            counting.calls(),
+            1,
+            "must stop at the first missing tile, not scan all 3"
+        );
+    }
+
+    #[test]
+    fn test_exact_counts_scans_every_tile() {
+        // The contrast case: the rescue path genuinely needs `covered`, and
+        // pays a full scan for it.
+        let (index, region) = three_tile_index();
+        let counting = CountingDiskChecker::new();
+        let checker: Arc<dyn DdsDiskCacheChecker> = counting.clone();
+
+        let state = BoundaryStrategy::region_disk_state(
+            region,
+            Some(&index),
+            Some(&checker),
+            None,
+            CoverageDetail::ExactCounts,
+        );
+
+        assert_eq!(
+            state,
+            RegionDiskState::Incomplete {
+                coverage: TileCoverage::Exact {
+                    covered: 0,
+                    total: 3
+                }
+            }
+        );
+        assert_eq!(
+            counting.calls(),
+            3,
+            "exact counts require checking every tile"
+        );
+    }
+
+    #[test]
+    fn test_first_miss_only_still_confirms_a_complete_region() {
+        // Short-circuiting must not weaken the promotion verdict: a complete
+        // region has no first miss, so every tile is checked and the answer is
+        // identical to the exact-count scan.
+        let index = make_scenery_index_for_region(50, 9, 16);
+        let region = DsfRegion { lat: 50, lon: 9 };
+        let tiles = index.tiles_in_region(region);
+        let checker = test_checker(&tiles);
+
+        assert_eq!(
+            BoundaryStrategy::region_disk_state(
+                region,
+                Some(&index),
+                Some(&checker),
+                None,
+                CoverageDetail::FirstMissOnly
+            ),
+            RegionDiskState::Complete
+        );
+    }
+
+    #[test]
+    fn test_not_counted_carries_no_readable_counts() {
+        // The mechanism itself: "not counted" must be impossible to misread as
+        // an observation. `counts()` is the only accessor and it returns None.
+        assert_eq!(TileCoverage::NotCounted.counts(), None);
+        assert_eq!(
+            TileCoverage::Exact {
+                covered: 2,
+                total: 5
+            }
+            .counts(),
+            Some((2, 5))
         );
     }
 
@@ -838,6 +1120,7 @@ mod tests {
                 Some(&index),
                 Some(&empty_xel_cache),
                 Some(&ortho),
+                CoverageDetail::ExactCounts,
             ),
             RegionDiskState::Complete
         );
@@ -857,11 +1140,14 @@ mod tests {
                 region,
                 Some(&index),
                 Some(&test_checker(&[])),
-                Some(&ortho)
+                Some(&ortho),
+                CoverageDetail::ExactCounts
             ),
             RegionDiskState::Incomplete {
-                covered: 0,
-                total: tiles.len()
+                coverage: TileCoverage::Exact {
+                    covered: 0,
+                    total: tiles.len()
+                }
             }
         );
     }

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -200,7 +200,7 @@ impl BoundaryStrategy {
     /// Mark a region as having no scenery coverage.
     pub fn mark_no_coverage(&self, region: &DsfRegion, geo_index: &GeoIndex) {
         geo_index.insert::<PrefetchedRegion>(*region, PrefetchedRegion::no_coverage());
-        tracing::debug!(
+        tracing::info!(
             lat = region.lat,
             lon = region.lon,
             "boundary: marked NoCoverage"

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -34,8 +34,10 @@ pub struct BoundaryStrategy;
 pub enum RegionDiskState {
     /// Every tile the scenery index attributes to this region is present.
     Complete,
-    /// At least one attributed tile is absent.
-    Incomplete,
+    /// At least one attributed tile is absent. Carries the counts so callers
+    /// can tell a region that is *advancing* from one that is *stuck* — the
+    /// distinction #226 turned on.
+    Incomplete { covered: usize, total: usize },
     /// The scenery index attributes no tiles to this region.
     NoTiles,
     /// No authoritative source to consult — no checker and/or no index.
@@ -68,16 +70,20 @@ impl BoundaryStrategy {
         if tiles.is_empty() {
             return RegionDiskState::NoTiles;
         }
-        // Short-circuits on first miss. A tile counts as covered if either
-        // the XEL DDS disk cache or an installed package already has it —
-        // see `tile_is_covered`.
-        if tiles
+        // Counts rather than short-circuiting: the caller needs `covered` to
+        // distinguish a slow region from a stuck one. Affordable because
+        // `tile_exists_blocking` is a sync map lookup as of #226 (see
+        // TODO(#175) resolution); it was a runtime round-trip per tile before.
+        let total = tiles.len();
+        let covered = tiles
             .iter()
-            .all(|t| Self::tile_is_covered(t, checker, ortho_union_index))
-        {
+            .filter(|t| Self::tile_is_covered(t, checker, ortho_union_index))
+            .count();
+
+        if covered == total {
             RegionDiskState::Complete
         } else {
-            RegionDiskState::Incomplete
+            RegionDiskState::Incomplete { covered, total }
         }
     }
 
@@ -174,7 +180,7 @@ impl BoundaryStrategy {
                     geo_index.insert::<PrefetchedRegion>(*region, PrefetchedRegion::prefetched());
                     promoted.push(*region);
                 }
-                RegionDiskState::Incomplete
+                RegionDiskState::Incomplete { .. }
                 | RegionDiskState::NoTiles
                 | RegionDiskState::Unknown => {
                     continue;
@@ -676,6 +682,50 @@ mod tests {
     }
 
     #[test]
+    fn test_region_disk_state_reports_covered_and_total() {
+        // Index with 3 tiles in the region; mark 2 of them present on disk.
+        let index = Arc::new(SceneryIndex::with_defaults());
+        let region = DsfRegion::new(47, 8);
+        index.add_tile(SceneryTile {
+            row: 1000,
+            col: 2000,
+            chunk_zoom: 16,
+            lat: 47.1,
+            lon: 8.1,
+            is_sea: false,
+        });
+        index.add_tile(SceneryTile {
+            row: 3000,
+            col: 4000,
+            chunk_zoom: 16,
+            lat: 47.4,
+            lon: 8.4,
+            is_sea: false,
+        });
+        index.add_tile(SceneryTile {
+            row: 5000,
+            col: 6000,
+            chunk_zoom: 16,
+            lat: 47.7,
+            lon: 8.7,
+            is_sea: false,
+        });
+        let tiles = index.tiles_in_region(region);
+        assert_eq!(tiles.len(), 3, "fixture precondition: exactly 3 tiles");
+
+        let checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(vec![tiles[0], tiles[1]]);
+
+        let state = BoundaryStrategy::region_disk_state(region, Some(&index), Some(&checker), None);
+
+        assert_eq!(
+            state,
+            RegionDiskState::Incomplete { covered: 2, total: 3 },
+            "must report how many of the region's tiles are present, not just that it is incomplete"
+        );
+    }
+
+    #[test]
     fn test_region_disk_state_complete_and_incomplete() {
         let index = make_scenery_index_for_region(50, 9, 16);
         let region = DsfRegion { lat: 50, lon: 9 };
@@ -704,7 +754,10 @@ mod tests {
                 Some(&test_checker(&all_but_one)),
                 None
             ),
-            RegionDiskState::Incomplete
+            RegionDiskState::Incomplete {
+                covered: tiles.len() - 1,
+                total: tiles.len()
+            }
         );
     }
 
@@ -783,6 +836,8 @@ mod tests {
         // Guards the disjunction against becoming a tautology.
         let index = make_scenery_index_for_region(50, 9, 16);
         let region = DsfRegion { lat: 50, lon: 9 };
+        let tiles = index.tiles_in_region(region);
+        assert!(!tiles.is_empty(), "fixture precondition");
         let temp = tempfile::TempDir::new().unwrap();
         let ortho = make_ortho_index_with_chunk_tiles(&temp, vec![]);
         assert_eq!(
@@ -792,7 +847,10 @@ mod tests {
                 Some(&test_checker(&[])),
                 Some(&ortho)
             ),
-            RegionDiskState::Incomplete
+            RegionDiskState::Incomplete {
+                covered: 0,
+                total: tiles.len()
+            }
         );
     }
 

--- a/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
+++ b/xearthlayer/src/prefetch/adaptive/boundary_strategy.rs
@@ -1055,6 +1055,42 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_promote_completed_regions_uses_first_miss_only() {
+        // Regression guard for #226 final review: the final review round
+        // mutated `promote_completed_regions`'s call site from
+        // `CoverageDetail::FirstMissOnly` back to `ExactCounts` and the full
+        // suite passed green — nothing observed that the cheap scan was
+        // actually requested at the call site the C-1 fix depends on. This
+        // test drives `promote_completed_regions` itself (not
+        // `region_disk_state` directly) so a regression at that call site
+        // fails it.
+        let geo_index = GeoIndex::new();
+        let (index, region) = three_tile_index();
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+
+        let counting = CountingDiskChecker::new();
+        let checker: Arc<dyn DdsDiskCacheChecker> = counting.clone();
+
+        let promoted = BoundaryStrategy::promote_completed_regions(
+            &geo_index,
+            Some(&checker),
+            Some(&index),
+            None,
+        );
+
+        assert!(
+            promoted.is_empty(),
+            "region has no tiles on disk, must not promote"
+        );
+        assert_eq!(
+            counting.calls(),
+            1,
+            "promote_completed_regions must scan with FirstMissOnly and stop \
+             at the first absent tile, not ExactCounts over all 3"
+        );
+    }
+
     // =========================================================================
     // region_disk_state + OrthoUnionIndex coverage (#176 Task 2 / #223 F2)
     // =========================================================================

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -754,8 +754,10 @@ impl AdaptivePrefetchCoordinator {
     /// the DDS disk — X-Plane is served them by the patch through FUSE
     /// passthrough. Marking one `InProgress` would be a claim prefetch is
     /// working on it, which `promote_completed_regions` could never confirm;
-    /// the region would go stale and be retired to `NoCoverage` with a
-    /// misleading "failed attempts" warning in the flight log. Patch
+    /// the region would go stale, and since #226 an `Incomplete` region is
+    /// never retired, it would cycle in `Deferred` forever — striking and
+    /// re-deferring on an escalating ladder against tiles that were never
+    /// going to arrive. Patch
     /// ownership is a whole-region property in the `GeoIndex`, so this
     /// exclusion is exact rather than a heuristic. Such regions keep being
     /// re-planned and filtered each cycle, as they were before this change.

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -49,7 +49,7 @@ struct RegionRetryState {
     last_covered: usize,
 }
 
-use crate::geo_index::{DsfRegion, GeoIndex, PatchCoverage, PrefetchedRegion};
+use crate::geo_index::{DsfRegion, GeoIndex, PatchCoverage, PrefetchedRegion, RegionState};
 use crate::ortho_union::OrthoUnionIndex;
 use crate::prefetch::state::{AircraftState, SharedPrefetchStatus};
 use crate::prefetch::SceneryIndex;
@@ -1117,19 +1117,22 @@ impl AdaptivePrefetchCoordinator {
         // scenery, which is precisely the false alarm this fix removes. It is
         // also the acceptance criterion's own instrument: `regions_nocoverage`
         // must be non-zero only over water.
+        //
+        // An exhaustive `match` rather than an if/else-if chain: the chain's
+        // trailing `else` meant "no_coverage", so a new `RegionState` variant
+        // would be reported as ocean with no compiler error. That is not
+        // hypothetical — `Deferred` landed in exactly that catch-all when it
+        // was introduced on this branch, and corrupted the acceptance
+        // instrument until it was caught. The compiler now refuses to build
+        // a fifth variant into `regions_nocoverage` by default.
         let (in_progress, prefetched, no_coverage, deferred) =
             geo_index.iter::<PrefetchedRegion>().into_iter().fold(
                 (0usize, 0usize, 0usize, 0usize),
-                |(ip, p, nc, d), (_, r)| {
-                    if r.is_in_progress() {
-                        (ip + 1, p, nc, d)
-                    } else if r.is_prefetched() {
-                        (ip, p + 1, nc, d)
-                    } else if r.is_deferred() {
-                        (ip, p, nc, d + 1)
-                    } else {
-                        (ip, p, nc + 1, d)
-                    }
+                |(ip, p, nc, d), (_, r)| match r.state() {
+                    RegionState::InProgress => (ip + 1, p, nc, d),
+                    RegionState::Prefetched => (ip, p + 1, nc, d),
+                    RegionState::NoCoverage => (ip, p, nc + 1, d),
+                    RegionState::Deferred { .. } => (ip, p, nc, d + 1),
                 },
             );
         tracing::debug!(

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -1099,7 +1099,9 @@ impl AdaptivePrefetchCoordinator {
         // ~1170 after landing on acceptance flight 1 (#176). Retention and
         // eviction must share a phase, or the pair is not a pair.
         if matches!(self.phase_detector.current_phase(), FlightPhase::Cruise) {
-            BoundaryStrategy::evict_non_retained(&geo_index);
+            for region in BoundaryStrategy::evict_non_retained(&geo_index) {
+                self.region_retry.remove(&region);
+            }
         }
 
         // Per-maintenance-cycle instrumentation (#172 Part 4): report
@@ -2614,6 +2616,57 @@ mod tests {
                 .unwrap_or(true),
             "one fresh failure after an observer-driven demotion must not \
              re-retire the region"
+        );
+    }
+
+    // `region_retry` is cleared on the three retirement/promotion exits, but
+    // `evict_non_retained` removes `Deferred` (and other terminal) entries
+    // from the GeoIndex without the coordinator's involvement — it is a
+    // static taking only `&GeoIndex`. Left unpruned, a region that leaves the
+    // retained window and later returns resumes at its old `strikes`, so its
+    // first fresh no-progress evaluation defers 40-60s instead of 20s.
+    #[test]
+    fn test_retry_state_is_pruned_when_region_is_evicted() {
+        use crate::geo_index::RetainedRegion;
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let kept = DsfRegion::new(47, 8);
+        let dropped = DsfRegion::new(10, 10);
+
+        // Retention must be non-empty or `evict_non_retained` returns early
+        // and this test passes vacuously. This trap cost three failed
+        // reproductions during #223 — do not remove this line.
+        geo_index.insert::<RetainedRegion>(kept, RetainedRegion);
+
+        geo_index.insert::<PrefetchedRegion>(
+            dropped,
+            PrefetchedRegion::deferred(Instant::now() + Duration::from_secs(60)),
+        );
+
+        let mut coord =
+            AdaptivePrefetchCoordinator::with_defaults().with_geo_index(Arc::clone(&geo_index));
+        // Eviction runs only in Cruise (the guard at core.rs:1101). Set the
+        // phase directly rather than driving `update()` — the detector has
+        // hysteresis, so a single update may not transition and the test
+        // would silently no-op.
+        coord.phase_detector.reset_to_cruise();
+        coord.region_retry.insert(
+            dropped,
+            RegionRetryState {
+                strikes: 2,
+                last_covered: 5,
+            },
+        );
+
+        coord.run_region_maintenance();
+
+        assert!(
+            !coord.region_retry.contains_key(&dropped),
+            "retry bookkeeping must not outlive the region's entry in the index"
+        );
+        assert!(
+            coord.region_retry.is_empty() || !coord.region_retry.contains_key(&dropped),
+            "only the evicted region's state is pruned"
         );
     }
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -1145,7 +1145,7 @@ impl AdaptivePrefetchCoordinator {
                 // No tiles indexed: the region can never be confirmed, so
                 // retiring it after repeated attempts is correct — this
                 // preserves pre-#223 behavior.
-                RegionDiskState::Incomplete | RegionDiskState::NoTiles => {
+                RegionDiskState::Incomplete { .. } | RegionDiskState::NoTiles => {
                     let attempts = self.region_attempts.entry(region).or_insert(0);
                     *attempts += 1;
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -2783,6 +2783,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_stuck_region_emits_prefetch_region_deferred_event() {
+        use crate::metrics::MetricEvent;
+
+        // Closes the coordinator end of the `regions_deferred` chain (#226
+        // review I-3). The metrics-daemon sample test seeds
+        // `state.prefetch_regions_deferred` directly, so it stays green even
+        // if this event is never constructed anywhere in production — and
+        // `regions_deferred` is the instrument a flight-test criterion is
+        // read off. Nothing else observes this emission.
+        let index = make_scenery_index(50, 9, 16);
+        let region = DsfRegion::new(50, 9);
+        assert!(
+            !index.tiles_in_region(region).is_empty(),
+            "Precondition: the region has indexed tiles, so the strike path \
+             is reachable at all"
+        );
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let empty_checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(std::iter::empty::<TileCoord>());
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(Arc::clone(&empty_checker))
+            .with_metrics_client(MetricsClient::new(tx));
+        coord.config.stale_region_timeout = std::time::Duration::ZERO;
+
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
+
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region)
+                .is_some_and(|s| s.is_deferred()),
+            "Precondition: the evaluation must actually have deferred the region"
+        );
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, MetricEvent::PrefetchRegionDeferred))
+                .count(),
+            1,
+            "a deferral must emit exactly one PrefetchRegionDeferred; got {events:?}"
+        );
+
+        // Discriminator: the event must be tied to the deferral, not emitted
+        // on every evaluation. Seed full coverage and promote instead.
+        let full_checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(index.tiles_in_region(region).into_iter());
+        coord.dds_disk_checker = Some(full_checker);
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region)
+                .is_some_and(|s| s.is_prefetched()),
+            "Precondition: the second evaluation must have promoted the region"
+        );
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::PrefetchRegionDeferred)),
+            "a promotion must not emit PrefetchRegionDeferred; got {events:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_run_region_maintenance_emits_region_state_gauge() {
         use crate::metrics::MetricEvent;
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -54,7 +54,7 @@ use crate::ortho_union::OrthoUnionIndex;
 use crate::prefetch::state::{AircraftState, SharedPrefetchStatus};
 use crate::prefetch::SceneryIndex;
 
-use super::super::boundary_strategy::{BoundaryStrategy, RegionDiskState};
+use super::super::boundary_strategy::{BoundaryStrategy, CoverageDetail, RegionDiskState};
 use super::super::calibration::{PerformanceCalibration, StrategyMode};
 use super::super::config::{AdaptivePrefetchConfig, PrefetchMode};
 use super::super::phase_detector::{FlightPhase, PhaseDetector};
@@ -1185,6 +1185,11 @@ impl AdaptivePrefetchCoordinator {
                 self.scenery_index.as_ref(),
                 self.dds_disk_checker.as_ref(),
                 self.ortho_union_index.as_ref(),
+                // The rescue path is the one caller that needs exact counts:
+                // `covered` is what separates an advancing region from a stuck
+                // one. It only pays for them because it runs over regions that
+                // have already been stale for `stale_region_timeout`.
+                CoverageDetail::ExactCounts,
             ) {
                 RegionDiskState::Complete => {
                     // Tiles generated successfully — promote based on the
@@ -1208,7 +1213,21 @@ impl AdaptivePrefetchCoordinator {
                 // NoCoverage: the index saying "there are tiles here" is
                 // positive evidence of coverage, and #226 was caused by
                 // treating this case as if it were NoTiles.
-                RegionDiskState::Incomplete { covered, total } => {
+                RegionDiskState::Incomplete { coverage } => {
+                    // Unreachable: this call site asks for `ExactCounts`. If a
+                    // future edit changes that, degrade to the `Unknown`
+                    // behaviour — leave the region alone and record no strike —
+                    // rather than inventing a count. A fabricated `0` would
+                    // read as "nothing has arrived" and strike a region that
+                    // may be nearly complete.
+                    let Some((covered, total)) = coverage.counts() else {
+                        tracing::warn!(
+                            lat = region.lat,
+                            lon = region.lon,
+                            "Stale region evaluated without tile counts — skipping"
+                        );
+                        continue;
+                    };
                     let entry = self.region_retry.entry(region).or_default();
 
                     if covered > entry.last_covered {

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use tokio_util::sync::CancellationToken;
 
@@ -13,8 +14,36 @@ use crate::coord::TileCoord;
 use crate::executor::{DaemonMemoryCache, DdsClient, DdsDiskCacheChecker};
 use crate::metrics::MetricsClient;
 
-/// Maximum demotion attempts before marking a region as NoCoverage.
-const MAX_REGION_ATTEMPTS: u8 = 3;
+/// Deferral applied after each consecutive no-progress evaluation.
+///
+/// The last entry repeats for every further strike. The 60s ceiling is a hard
+/// requirement, not a tuning knob: field evidence (#226) had the sim demanding
+/// tiles from a region 2m43s after prefetch gave up on it, so the window in
+/// which a region is skipped with nothing in flight must stay well inside that.
+const DEFERRAL_LADDER: [Duration; 4] = [
+    Duration::from_secs(20),
+    Duration::from_secs(30),
+    Duration::from_secs(40),
+    Duration::from_secs(60),
+];
+
+/// Deferral for the Nth consecutive no-progress evaluation (`strikes` is 1-based).
+fn deferral_for(strikes: u8) -> Duration {
+    let idx = (strikes.saturating_sub(1) as usize).min(DEFERRAL_LADDER.len() - 1);
+    DEFERRAL_LADDER[idx]
+}
+
+/// Per-region retry bookkeeping for regions that are not yet complete.
+///
+/// `last_covered` is what makes a strike mean "made no progress" rather than
+/// "took too long" — under a large prefetch backlog the latter says nothing
+/// about whether scenery exists.
+#[derive(Debug, Clone, Copy, Default)]
+struct RegionRetryState {
+    strikes: u8,
+    last_covered: usize,
+}
+
 use crate::geo_index::{DsfRegion, GeoIndex, PatchCoverage, PrefetchedRegion};
 use crate::ortho_union::OrthoUnionIndex;
 use crate::prefetch::state::{AircraftState, SharedPrefetchStatus};
@@ -164,12 +193,15 @@ pub struct AdaptivePrefetchCoordinator {
     /// before deciding to promote (tiles exist) or demote (tiles missing) the region.
     dds_disk_checker: Option<Arc<dyn DdsDiskCacheChecker>>,
 
-    /// Tracks demotion attempts per region to prevent infinite retry loops.
+    /// Per-region retry bookkeeping for stale regions that are not yet complete.
     ///
-    /// Incremented each time an InProgress region is demoted (tiles not on disk after
-    /// stale timeout). After [`MAX_REGION_ATTEMPTS`] demotions, the region is marked
-    /// NoCoverage and permanently excluded for this session.
-    region_attempts: std::collections::HashMap<DsfRegion, u8>,
+    /// A strike is recorded when a stale `Incomplete` region has gained no new
+    /// tile coverage since the previous look; observing progress clears it.
+    /// Strikes gate an escalating deferral ([`deferral_for`]) — they never
+    /// retire a region. Retirement to `NoCoverage` is reachable only from
+    /// [`RegionDiskState::NoTiles`], which is definitive on the first look
+    /// (#226).
+    region_retry: std::collections::HashMap<DsfRegion, RegionRetryState>,
 
     /// Mapping of planned tiles to their source DSF region for the current
     /// in-flight plan. Populated by the cruise branch of [`update()`] and
@@ -238,7 +270,7 @@ impl AdaptivePrefetchCoordinator {
             scenery_index: None,
             pending_tiles: Vec::new(),
             dds_disk_checker: None,
-            region_attempts: std::collections::HashMap::new(),
+            region_retry: std::collections::HashMap::new(),
             current_plan_regions: std::collections::HashMap::new(),
             metrics_client: None,
         }
@@ -1043,7 +1075,7 @@ impl AdaptivePrefetchCoordinator {
             // is later demoted by the FUSE observer can be retired to NoCoverage
             // after a single fresh failure.
             for region in &promoted {
-                self.region_attempts.remove(region);
+                self.region_retry.remove(region);
             }
             if let Some(ref metrics) = self.metrics_client {
                 metrics.prefetch_regions_promoted_normal(promoted.len());
@@ -1095,13 +1127,24 @@ impl AdaptivePrefetchCoordinator {
         }
     }
 
-    /// Evaluate stale InProgress regions and decide: promote, demote, or NoCoverage.
+    /// Evaluate stale InProgress regions against the transition table.
     ///
-    /// For each InProgress region that has exceeded the stale timeout:
-    /// 1. Check if tiles exist on DDS disk cache → promote to Prefetched
-    /// 2. If tiles not on disk, check attempt counter:
-    ///    - Under limit → remove from GeoIndex (allows retry on next cycle)
-    ///    - At limit → mark NoCoverage (permanently excluded this session)
+    /// The outcome is a function of what the authoritative sources say about
+    /// the region ([`RegionDiskState`]), not of how long it has taken:
+    ///
+    /// | Observation  | Outcome                                              |
+    /// |--------------|------------------------------------------------------|
+    /// | `Complete`   | promote to `Prefetched`, clear retry state            |
+    /// | `Incomplete` | advancing → retry now; stuck → strike + `Deferred`    |
+    /// | `NoTiles`    | retire to `NoCoverage`, clear retry state             |
+    /// | `Unknown`    | leave untouched, no strike                            |
+    ///
+    /// `Incomplete` reaches `NoCoverage` by no path. The scenery index
+    /// attributing tiles to a region is positive evidence that scenery exists
+    /// there, and #226 was caused by treating a slow region as if it were an
+    /// empty one: `Incomplete` and `NoTiles` shared a retirement arm, so three
+    /// timing-based strikes permanently retired two Baden-Wurttemberg regions
+    /// that on-demand generation disproved 2m43s later.
     fn evaluate_stale_regions(&mut self, geo_index: &GeoIndex) {
         let stale: Vec<DsfRegion> = geo_index
             .iter::<PrefetchedRegion>()
@@ -1132,7 +1175,7 @@ impl AdaptivePrefetchCoordinator {
                     geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::prefetched());
                     // See the fast-path promotion comment in `run_region_maintenance`:
                     // the strike count belongs to the failed episode, not the region.
-                    self.region_attempts.remove(&region);
+                    self.region_retry.remove(&region);
                     if let Some(ref metrics) = self.metrics_client {
                         metrics.prefetch_region_promoted_rescue();
                     }
@@ -1142,61 +1185,87 @@ impl AdaptivePrefetchCoordinator {
                         "Stale InProgress region promoted — tiles found on DDS disk"
                     );
                 }
-                // No tiles indexed: the region can never be confirmed, so
-                // retiring it after repeated attempts is correct — this
-                // preserves pre-#223 behavior.
-                RegionDiskState::Incomplete { .. } | RegionDiskState::NoTiles => {
-                    let attempts = self.region_attempts.entry(region).or_insert(0);
-                    *attempts += 1;
 
-                    if *attempts >= MAX_REGION_ATTEMPTS {
-                        // Exhausted retries — mark permanently excluded
-                        geo_index
-                            .insert::<PrefetchedRegion>(region, PrefetchedRegion::no_coverage());
-                        tracing::warn!(
-                            lat = region.lat,
-                            lon = region.lon,
-                            attempts = *attempts,
-                            "Region marked NoCoverage after {} failed attempts",
-                            MAX_REGION_ATTEMPTS
-                        );
-                        // Clear the strike count for the retired episode,
-                        // mirroring both promotion arms above. Without this,
-                        // a region the observer later demotes out of
-                        // NoCoverage (see `state_observer.rs::observe`) would
-                        // re-enter the prefetch cycle still carrying the old
-                        // count, so one single fresh failure would re-hit
-                        // `>= MAX_REGION_ATTEMPTS` and re-retire it instantly
-                        // — zero real retries. Clearing here gives a demoted
-                        // region a fresh set of `MAX_REGION_ATTEMPTS` strikes
-                        // each time it's demoted; the observer's per-region
-                        // demotion rate limit (one per `demotion_interval`)
-                        // is what bounds that loop, not this counter.
-                        self.region_attempts.remove(&region);
-                    } else {
-                        // Remove from GeoIndex to allow retry on next cycle.
-                        //
-                        // Do NOT clear `region_attempts` here. This removal is
-                        // deliberate — it makes the region eligible for
-                        // re-prefetching — and `region_attempts` is the only
-                        // thing that remembers the strike across it. Clearing
-                        // on this branch (by symmetry with the promote branch
-                        // above) would make `MAX_REGION_ATTEMPTS` unreachable:
-                        // every retry would start the count over, and a region
-                        // that never succeeds would retry forever instead of
-                        // eventually being retired to `NoCoverage`.
+                // Has indexed tiles but not all of them yet. NEVER retires to
+                // NoCoverage: the index saying "there are tiles here" is
+                // positive evidence of coverage, and #226 was caused by
+                // treating this case as if it were NoTiles.
+                RegionDiskState::Incomplete { covered, total } => {
+                    let entry = self.region_retry.entry(region).or_default();
+
+                    if covered > entry.last_covered {
+                        // Advancing. Not stuck — clear the record and retry now.
+                        entry.strikes = 0;
+                        entry.last_covered = covered;
                         geo_index.remove::<PrefetchedRegion>(&region);
-                        tracing::info!(
+                        tracing::debug!(
                             lat = region.lat,
                             lon = region.lon,
-                            attempt = *attempts,
-                            max = MAX_REGION_ATTEMPTS,
-                            "Stale InProgress region demoted for retry"
+                            covered,
+                            total,
+                            "Stale InProgress region advancing — retrying"
                         );
+                    } else {
+                        entry.strikes = entry.strikes.saturating_add(1);
+                        let strikes = entry.strikes;
+                        let deferral = deferral_for(strikes);
+                        geo_index.insert::<PrefetchedRegion>(
+                            region,
+                            PrefetchedRegion::deferred(Instant::now() + deferral),
+                        );
+                        if let Some(ref metrics) = self.metrics_client {
+                            metrics.prefetch_region_deferred();
+                        }
+                        // WARN once, then debug — a permanently holed region
+                        // would otherwise emit this every ~3 minutes forever.
+                        // `covered`/`total` is the diagnostic: "387 of 400"
+                        // means a few tiles are 404ing, "0 of 400" means
+                        // nothing is arriving at all.
+                        if strikes == 1 {
+                            tracing::warn!(
+                                lat = region.lat,
+                                lon = region.lon,
+                                covered,
+                                total,
+                                strikes,
+                                deferral_s = deferral.as_secs(),
+                                "Region making no progress — deferred"
+                            );
+                        } else {
+                            tracing::debug!(
+                                lat = region.lat,
+                                lon = region.lon,
+                                covered,
+                                total,
+                                strikes,
+                                deferral_s = deferral.as_secs(),
+                                "Region still making no progress — deferred"
+                            );
+                        }
                     }
                 }
-                // Unanswerable. Leave the claim standing and do not consume
-                // a retry; the next cycle may have a checker.
+
+                // The only path to NoCoverage. Definitive on the first look:
+                // the scenery index is fully built before the coordinator
+                // receives it, so a second opinion would be identical.
+                //
+                // The retry state is cleared here for the same reason as on
+                // the promotion arms (#223 Finding B): a region the FUSE
+                // observer later demotes out of NoCoverage must re-enter the
+                // cycle with a clean slate, not still carrying the strikes of
+                // the episode that retired it.
+                RegionDiskState::NoTiles => {
+                    geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::no_coverage());
+                    self.region_retry.remove(&region);
+                    tracing::info!(
+                        lat = region.lat,
+                        lon = region.lon,
+                        "Region has no indexed tiles — marked NoCoverage"
+                    );
+                }
+
+                // Unanswerable. Leave the claim standing and do not consume a
+                // strike; the next cycle may have a checker.
                 RegionDiskState::Unknown => continue,
             }
         }
@@ -2117,7 +2186,8 @@ mod tests {
         // Before: `_ => false` counted a failed attempt, and three of these
         // retired the region to NoCoverage permanently. After: Unknown is not
         // evidence of absence, so the region keeps its InProgress claim and no
-        // attempt is recorded.
+        // strike is recorded. Post-#226 this also guards against a refactor
+        // quietly folding Unknown into the Incomplete (strike + defer) arm.
         let index = make_scenery_index_covering(50..=50, 9..=9, 16);
         let geo_index = Arc::new(GeoIndex::new());
         let region = DsfRegion { lat: 50, lon: 9 };
@@ -2129,7 +2199,8 @@ mod tests {
         // deliberately no .with_dds_disk_checker(...)
         coord.config.stale_region_timeout = std::time::Duration::ZERO; // force staleness
 
-        for _ in 0..MAX_REGION_ATTEMPTS + 1 {
+        // Repeat well past the old three-strike retirement limit.
+        for _ in 0..4 {
             coord.evaluate_stale_regions(&geo_index);
         }
 
@@ -2139,8 +2210,149 @@ mod tests {
             "region must remain InProgress; Unknown is not evidence of absence"
         );
         assert!(
-            !coord.region_attempts.contains_key(&region),
-            "an unanswerable check must not consume a retry"
+            !coord.region_retry.contains_key(&region),
+            "an unanswerable observation must not count against the region"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Region retirement transition table (#226)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// #226: a region the scenery index says HAS tiles must never be retired as
+    /// ocean, no matter how long its tiles take. Field evidence: 47N/8E and
+    /// 48N/8E (Baden-Wurttemberg) retired after 3 strikes, then disproved by
+    /// on-demand generation 2m43s later.
+    #[tokio::test]
+    async fn test_incomplete_region_never_becomes_no_coverage() {
+        let index = make_scenery_index(47, 8, 16);
+        let region = DsfRegion::new(47, 8);
+        assert!(
+            !index.tiles_in_region(region).is_empty(),
+            "Precondition: the index attributes tiles to this region, so every \
+             evaluation observes Incomplete rather than NoTiles"
+        );
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let empty_checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(std::iter::empty::<TileCoord>());
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(empty_checker);
+        // Force staleness rather than sleeping.
+        coord.config.stale_region_timeout = std::time::Duration::ZERO;
+
+        // Asserted every iteration, not just at the end: the invariant is that
+        // the region is never NoCoverage at ANY point. An end-state-only check
+        // is unsound here because the pre-#226 code retired on a 3-cycle and
+        // cleared its own counter, so the final sample could land on a
+        // non-retired phase of the cycle and hide the defect.
+        for i in 0..10 {
+            geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+            coord.evaluate_stale_regions(&geo_index);
+
+            let state = geo_index.get::<PrefetchedRegion>(&region);
+            assert!(
+                state.map(|s| !s.is_no_coverage()).unwrap_or(true),
+                "a region with indexed tiles must never reach NoCoverage \
+                 (reached it on evaluation {})",
+                i + 1
+            );
+        }
+    }
+
+    /// NoTiles is definitive on the first look — the scenery index is fully
+    /// built before the coordinator receives it, so retrying adds no
+    /// information.
+    #[tokio::test]
+    async fn test_no_tiles_region_retires_on_first_evaluation() {
+        // Index covers (50,9) only; the region under test is elsewhere, so
+        // `tiles_in_region` is empty => NoTiles.
+        let index = make_scenery_index(50, 9, 16);
+        let region = DsfRegion::new(20, 20);
+        assert!(
+            index.tiles_in_region(region).is_empty(),
+            "Precondition: the index attributes no tiles to this region"
+        );
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(std::iter::empty::<TileCoord>());
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(checker);
+        coord.config.stale_region_timeout = std::time::Duration::ZERO;
+
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
+
+        assert!(
+            geo_index
+                .get::<PrefetchedRegion>(&region)
+                .is_some_and(|s| s.is_no_coverage()),
+            "NoTiles must retire immediately, not after three strikes"
+        );
+    }
+
+    /// A slow-but-advancing region must not accumulate strikes. This is the
+    /// direct answer to the reported diagnosis: the counter measured
+    /// throughput, not coverage.
+    #[tokio::test]
+    async fn test_progress_resets_strikes() {
+        let index = make_scenery_index(50, 9, 16);
+        let region = DsfRegion::new(50, 9);
+        let tiles = index.tiles_in_region(region);
+        assert!(
+            tiles.len() >= 2,
+            "Precondition: at least two tiles, so seeding one still leaves the \
+             region Incomplete rather than Complete"
+        );
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let empty_checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(std::iter::empty::<TileCoord>());
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(empty_checker);
+        coord.config.stale_region_timeout = std::time::Duration::ZERO;
+
+        // First evaluation: 0 of N -> strike 1.
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
+        assert_eq!(coord.region_retry.get(&region).unwrap().strikes, 1);
+
+        // A tile lands, then evaluate again: 1 of N -> strikes reset.
+        let partial_checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(std::iter::once(tiles[0]));
+        coord.dds_disk_checker = Some(partial_checker);
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
+        assert_eq!(
+            coord.region_retry.get(&region).unwrap().strikes,
+            0,
+            "a region that gained coverage since the last look is advancing, not stuck"
+        );
+        assert_eq!(coord.region_retry.get(&region).unwrap().last_covered, 1);
+    }
+
+    /// The ladder, including that it stops growing at the fourth rung.
+    #[test]
+    fn test_deferral_ladder() {
+        assert_eq!(deferral_for(1), Duration::from_secs(20));
+        assert_eq!(deferral_for(2), Duration::from_secs(30));
+        assert_eq!(deferral_for(3), Duration::from_secs(40));
+        assert_eq!(deferral_for(4), Duration::from_secs(60));
+        assert_eq!(deferral_for(5), Duration::from_secs(60), "caps at 60s");
+        assert_eq!(
+            deferral_for(200),
+            Duration::from_secs(60),
+            "no overflow, still capped"
         );
     }
 
@@ -2175,16 +2387,16 @@ mod tests {
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
         coord.evaluate_stale_regions(&geo_index);
         assert_eq!(
-            coord.region_attempts.get(&region),
-            Some(&1),
-            "Precondition: first stale failure recorded"
+            coord.region_retry.get(&region).map(|r| r.strikes),
+            Some(1),
+            "Precondition: first stale no-progress evaluation recorded"
         );
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
         coord.evaluate_stale_regions(&geo_index);
         assert_eq!(
-            coord.region_attempts.get(&region),
-            Some(&2),
-            "Precondition: second stale failure recorded (below MAX_REGION_ATTEMPTS)"
+            coord.region_retry.get(&region).map(|r| r.strikes),
+            Some(2),
+            "Precondition: second stale no-progress evaluation recorded"
         );
 
         // Phase 2: checker seeded with the region's tiles -> promote via the
@@ -2202,7 +2414,7 @@ mod tests {
             "Precondition: region promoted via the fast path"
         );
         assert!(
-            !coord.region_attempts.contains_key(&region),
+            !coord.region_retry.contains_key(&region),
             "Promotion must clear the strike count from the failed episode"
         );
 
@@ -2222,21 +2434,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_demoted_no_coverage_region_gets_fresh_strikes_after_retirement() {
-        // Regression for #223 Finding B: strike counts were cleared on both
-        // promotion paths but never on retirement to NoCoverage. A region
-        // demoted out of NoCoverage by `PrefetchStateObserver` (simulated
-        // here by removing its GeoIndex entry, exactly as the observer
-        // does — see `state_observer.rs::observe`) re-entered the prefetch
-        // cycle still carrying its old strike count, so a single fresh
-        // failure retired it again immediately: zero real retries.
-        let index = make_scenery_index(50, 9, 16);
+    async fn test_retirement_clears_retry_state_so_demotion_starts_fresh() {
+        // Regression for #223 Finding B, carried forward to the #226 state
+        // machine. The original defect: strike counts were cleared on both
+        // promotion paths but never on retirement, so a region demoted out of
+        // NoCoverage by `PrefetchStateObserver` re-entered the cycle still
+        // carrying the strikes of the episode that retired it.
+        //
+        // #226 removed retirement-by-strikes, so the old "re-retires
+        // instantly" symptom is now unreachable by construction. The
+        // invariant behind it is not: retirement must still clear the
+        // region's retry bookkeeping, or a demoted region resumes part-way up
+        // the deferral ladder and is skipped for 40-60s instead of 20s on its
+        // first fresh failure. This exercises the surviving retirement arm
+        // (`NoTiles`).
+        let covering_index = make_scenery_index(50, 9, 16);
         let region = DsfRegion::new(50, 9);
         assert!(
-            !index.tiles_in_region(region).is_empty(),
-            "Precondition: region has indexed tiles (land, not ocean) so the \
-             strike path is reachable — ocean regions take tiles.is_empty() \
-             and never touch region_attempts"
+            !covering_index.tiles_in_region(region).is_empty(),
+            "Precondition: the covering index attributes tiles to the region, \
+             so the strike path is reachable"
+        );
+        // An index that knows nothing of this region => RegionDiskState::NoTiles.
+        let empty_index = make_scenery_index(20, 20, 16);
+        assert!(
+            empty_index.tiles_in_region(region).is_empty(),
+            "Precondition: the empty index attributes no tiles to the region"
         );
 
         let geo_index = Arc::new(GeoIndex::new());
@@ -2244,43 +2467,62 @@ mod tests {
             MockDiskChecker::with_tile_coords(std::iter::empty::<TileCoord>());
 
         let mut coord = AdaptivePrefetchCoordinator::with_defaults()
-            .with_scenery_index(Arc::clone(&index))
+            .with_scenery_index(Arc::clone(&covering_index))
             .with_geo_index(Arc::clone(&geo_index))
-            .with_dds_disk_checker(Arc::clone(&empty_checker));
+            .with_dds_disk_checker(Arc::clone(&empty_checker))
+            .with_ortho_union_index(Arc::new(OrthoUnionIndex::new()));
         coord.config.stale_region_timeout = std::time::Duration::ZERO;
 
-        // Retire the region by strikes: MAX_REGION_ATTEMPTS consecutive
-        // stale failures (Incomplete: indexed tiles exist, none on disk).
-        for _ in 0..MAX_REGION_ATTEMPTS {
+        // Accumulate strikes: two stale no-progress evaluations.
+        for _ in 0..2 {
             geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
             coord.evaluate_stale_regions(&geo_index);
         }
+        assert_eq!(
+            coord.region_retry.get(&region).map(|r| r.strikes),
+            Some(2),
+            "Precondition: strikes accumulated while the region was Incomplete"
+        );
+
+        // The region is now observed as having no indexed tiles at all, which
+        // is the only path to NoCoverage.
+        coord.scenery_index = Some(Arc::clone(&empty_index));
+        geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+        coord.evaluate_stale_regions(&geo_index);
         assert!(
             geo_index
                 .get::<PrefetchedRegion>(&region)
                 .is_some_and(|s| s.is_no_coverage()),
-            "Precondition: region retired to NoCoverage by strikes"
+            "Precondition: NoTiles retires the region to NoCoverage"
+        );
+        assert!(
+            !coord.region_retry.contains_key(&region),
+            "retirement must clear the retry bookkeeping of the retired episode"
         );
 
-        // The observer demotes a NoCoverage region it sees contradicted by
-        // an on-demand FUSE generation — it clears the GeoIndex claim only
+        // The observer demotes a NoCoverage region it sees contradicted by an
+        // on-demand FUSE generation — it clears the GeoIndex claim only
         // (`PrefetchStateObserver::observe` -> `geo_index.remove`).
         geo_index.remove::<PrefetchedRegion>(&region);
+        coord.scenery_index = Some(Arc::clone(&covering_index));
 
-        // The region is re-planned and marked InProgress again.
+        // The region is re-planned, marked InProgress, and fails once.
         geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
-
-        // One single fresh stale failure.
         coord.evaluate_stale_regions(&geo_index);
 
+        assert_eq!(
+            coord.region_retry.get(&region).map(|r| r.strikes),
+            Some(1),
+            "a demoted region must start the deferral ladder from the bottom, \
+             not resume the retired episode's strike count"
+        );
         assert!(
             geo_index
                 .get::<PrefetchedRegion>(&region)
                 .map(|s| !s.is_no_coverage())
                 .unwrap_or(true),
             "one fresh failure after an observer-driven demotion must not \
-             immediately re-retire the region — it should get a fresh set \
-             of MAX_REGION_ATTEMPTS strikes"
+             re-retire the region"
         );
     }
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -38,7 +38,7 @@ fn deferral_for(strikes: u8) -> Duration {
 /// `last_covered` is what makes a strike mean "made no progress" rather than
 /// "took too long" — under a large prefetch backlog the latter says nothing
 /// about whether scenery exists.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 struct RegionRetryState {
     /// Consecutive evaluations that observed no new coverage.
     strikes: u8,
@@ -2657,6 +2657,18 @@ mod tests {
                 last_covered: 5,
             },
         );
+        // Seed retry state for the RETAINED region too, so the second
+        // assertion below actually discriminates "only the evicted region's
+        // state is pruned" from "everything got pruned" — without this the
+        // assertion was trivially true (its right-hand disjunct was already
+        // guaranteed by the assertion above it).
+        coord.region_retry.insert(
+            kept,
+            RegionRetryState {
+                strikes: 1,
+                last_covered: 3,
+            },
+        );
 
         coord.run_region_maintenance();
 
@@ -2664,9 +2676,14 @@ mod tests {
             !coord.region_retry.contains_key(&dropped),
             "retry bookkeeping must not outlive the region's entry in the index"
         );
-        assert!(
-            coord.region_retry.is_empty() || !coord.region_retry.contains_key(&dropped),
-            "only the evicted region's state is pruned"
+        assert_eq!(
+            coord.region_retry.get(&kept),
+            Some(&RegionRetryState {
+                strikes: 1,
+                last_covered: 3,
+            }),
+            "only the evicted region's state is pruned — the retained region's \
+             retry state must survive untouched"
         );
     }
 

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -757,10 +757,10 @@ impl AdaptivePrefetchCoordinator {
     /// the region would go stale, and since #226 an `Incomplete` region is
     /// never retired, it would cycle in `Deferred` forever — striking and
     /// re-deferring on an escalating ladder against tiles that were never
-    /// going to arrive. Patch
-    /// ownership is a whole-region property in the `GeoIndex`, so this
-    /// exclusion is exact rather than a heuristic. Such regions keep being
-    /// re-planned and filtered each cycle, as they were before this change.
+    /// going to arrive. Patch ownership is a whole-region property in the
+    /// `GeoIndex`, so this exclusion is exact rather than a heuristic. Such
+    /// regions keep being re-planned and filtered each cycle, as they were
+    /// before this change.
     ///
     /// Marked regions are dropped from `current_plan_regions` so
     /// [`execute()`] only reasons about regions that had tiles to submit.

--- a/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
+++ b/xearthlayer/src/prefetch/adaptive/coordinator/core.rs
@@ -40,7 +40,12 @@ fn deferral_for(strikes: u8) -> Duration {
 /// about whether scenery exists.
 #[derive(Debug, Clone, Copy, Default)]
 struct RegionRetryState {
+    /// Consecutive evaluations that observed no new coverage.
     strikes: u8,
+    /// Coverage seen at the *previous* evaluation — the latest observation,
+    /// deliberately not a high-water mark. Coverage can regress when the DDS
+    /// disk cache's GC daemon evicts tiles; a peak would blind progress
+    /// detection until coverage climbed past it again.
     last_covered: usize,
 }
 
@@ -1103,27 +1108,38 @@ impl AdaptivePrefetchCoordinator {
         // `prefetched` remains low, the fast-path is stalling and the
         // rescue path is carrying the work — the same anti-pattern that
         // produced the 61:4 rescue ratio in the LOWW flight log.
-        let (in_progress, prefetched, no_coverage) = geo_index
-            .iter::<PrefetchedRegion>()
-            .into_iter()
-            .fold((0usize, 0usize, 0usize), |(ip, p, nc), (_, r)| {
-                if r.is_in_progress() {
-                    (ip + 1, p, nc)
-                } else if r.is_prefetched() {
-                    (ip, p + 1, nc)
-                } else {
-                    (ip, p, nc + 1)
-                }
-            });
+        //
+        // `Deferred` gets its own bucket (#226). It is a NON-terminal state —
+        // the region is expected back once `retry_after` expires — so folding
+        // it into `no_coverage` would report land regions as having no
+        // scenery, which is precisely the false alarm this fix removes. It is
+        // also the acceptance criterion's own instrument: `regions_nocoverage`
+        // must be non-zero only over water.
+        let (in_progress, prefetched, no_coverage, deferred) =
+            geo_index.iter::<PrefetchedRegion>().into_iter().fold(
+                (0usize, 0usize, 0usize, 0usize),
+                |(ip, p, nc, d), (_, r)| {
+                    if r.is_in_progress() {
+                        (ip + 1, p, nc, d)
+                    } else if r.is_prefetched() {
+                        (ip, p + 1, nc, d)
+                    } else if r.is_deferred() {
+                        (ip, p, nc, d + 1)
+                    } else {
+                        (ip, p, nc + 1, d)
+                    }
+                },
+            );
         tracing::debug!(
             regions_in_progress = in_progress,
             regions_prefetched = prefetched,
             regions_nocoverage = no_coverage,
+            regions_deferred_active = deferred,
             "Region maintenance: state distribution"
         );
 
         if let Some(ref metrics) = self.metrics_client {
-            metrics.prefetch_region_state(in_progress, prefetched, no_coverage);
+            metrics.prefetch_region_state(in_progress, prefetched, no_coverage, deferred);
         }
     }
 
@@ -1206,6 +1222,12 @@ impl AdaptivePrefetchCoordinator {
                             "Stale InProgress region advancing — retrying"
                         );
                     } else {
+                        // Track the latest observation, not a high-water mark.
+                        // Coverage can regress (the DDS disk cache has a GC
+                        // daemon); leaving `last_covered` at the peak would
+                        // blind progress detection until coverage exceeded it
+                        // again, striking a region that is genuinely advancing.
+                        entry.last_covered = covered;
                         entry.strikes = entry.strikes.saturating_add(1);
                         let strikes = entry.strikes;
                         let deferral = deferral_for(strikes);
@@ -2341,6 +2363,76 @@ mod tests {
         assert_eq!(coord.region_retry.get(&region).unwrap().last_covered, 1);
     }
 
+    /// `last_covered` is the *previous observation*, not a high-water mark.
+    ///
+    /// Coverage can regress: the DDS disk cache has a GC daemon that evicts
+    /// tiles. If the stuck branch left `last_covered` at the best value ever
+    /// seen, progress detection would be blinded until coverage exceeded that
+    /// old peak, and a genuinely advancing region would accrue strikes.
+    #[tokio::test]
+    async fn test_last_covered_tracks_latest_observation_not_high_water_mark() {
+        let index = make_scenery_index(50, 9, 16);
+        let region = DsfRegion::new(50, 9);
+        let tiles = index.tiles_in_region(region);
+        assert!(
+            tiles.len() >= 3,
+            "Precondition: need at least three tiles to model a regression \
+             that still leaves the region Incomplete"
+        );
+
+        let geo_index = Arc::new(GeoIndex::new());
+        let empty_checker: Arc<dyn DdsDiskCacheChecker> =
+            MockDiskChecker::with_tile_coords(std::iter::empty::<TileCoord>());
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_scenery_index(Arc::clone(&index))
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_dds_disk_checker(empty_checker);
+        coord.config.stale_region_timeout = std::time::Duration::ZERO;
+
+        // Helper: re-arm the region and evaluate against a given tile set.
+        let evaluate_with = |coord: &mut AdaptivePrefetchCoordinator, present: &[TileCoord]| {
+            coord.dds_disk_checker =
+                Some(MockDiskChecker::with_tile_coords(present.iter().copied()));
+            geo_index.insert::<PrefetchedRegion>(region, PrefetchedRegion::in_progress());
+            coord.evaluate_stale_regions(&geo_index);
+        };
+
+        // 0 covered -> strike 1.
+        evaluate_with(&mut coord, &[]);
+        assert_eq!(coord.region_retry.get(&region).map(|r| r.strikes), Some(1));
+
+        // Coverage advances to 2 -> progress, strikes cleared.
+        evaluate_with(&mut coord, &[tiles[0], tiles[1]]);
+        assert_eq!(
+            coord.region_retry.get(&region).map(|r| r.last_covered),
+            Some(2),
+            "Precondition: peak coverage of 2 recorded"
+        );
+
+        // GC evicts one tile: coverage regresses to 1. No progress -> strike.
+        evaluate_with(&mut coord, &[tiles[0]]);
+        assert_eq!(
+            coord.region_retry.get(&region).map(|r| r.strikes),
+            Some(1),
+            "a regression is not progress, so it takes a strike"
+        );
+        assert_eq!(
+            coord.region_retry.get(&region).map(|r| r.last_covered),
+            Some(1),
+            "last_covered must follow the latest observation down, not stay at the peak"
+        );
+
+        // The tile comes back: 2 > 1, so this IS progress. Under high-water
+        // semantics the comparison would be 2 > 2 and the region would be
+        // wrongly struck again.
+        evaluate_with(&mut coord, &[tiles[0], tiles[1]]);
+        assert_eq!(
+            coord.region_retry.get(&region).map(|r| r.strikes),
+            Some(0),
+            "recovering to a previously-seen level is still progress"
+        );
+    }
+
     /// The ladder, including that it stops growing at the fourth rung.
     #[test]
     fn test_deferral_ladder() {
@@ -2469,8 +2561,7 @@ mod tests {
         let mut coord = AdaptivePrefetchCoordinator::with_defaults()
             .with_scenery_index(Arc::clone(&covering_index))
             .with_geo_index(Arc::clone(&geo_index))
-            .with_dds_disk_checker(Arc::clone(&empty_checker))
-            .with_ortho_union_index(Arc::new(OrthoUnionIndex::new()));
+            .with_dds_disk_checker(Arc::clone(&empty_checker));
         coord.config.stale_region_timeout = std::time::Duration::ZERO;
 
         // Accumulate strikes: two stale no-progress evaluations.
@@ -2665,10 +2756,83 @@ mod tests {
                     in_progress: 1,
                     prefetched: 2,
                     no_coverage: 3,
+                    deferred: 0,
                 }
             ),
-            "expected PrefetchRegionState {{ in_progress: 1, prefetched: 2, no_coverage: 3 }}, got {:?}",
+            "expected PrefetchRegionState {{ in_progress: 1, prefetched: 2, no_coverage: 3, deferred: 0 }}, got {:?}",
             region_state_events[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deferred_regions_are_not_reported_as_no_coverage() {
+        use crate::metrics::MetricEvent;
+
+        // #226: `regions_nocoverage` non-zero only over water is an acceptance
+        // criterion for this fix. Folding `Deferred` into the NoCoverage
+        // bucket would make the fix falsify its own instrument — a deferred
+        // land region would be reported as having no coverage, which is
+        // exactly the false alarm the fix exists to remove.
+        let geo_index = Arc::new(GeoIndex::new());
+
+        // Distinct counts so an argument swap at the call site, or a swap of
+        // the fold arms, cannot go undetected.
+        geo_index
+            .insert::<PrefetchedRegion>(DsfRegion::new(10, 10), PrefetchedRegion::in_progress());
+        geo_index
+            .insert::<PrefetchedRegion>(DsfRegion::new(20, 20), PrefetchedRegion::prefetched());
+        geo_index
+            .insert::<PrefetchedRegion>(DsfRegion::new(21, 20), PrefetchedRegion::prefetched());
+        for lat in 30..33 {
+            geo_index.insert::<PrefetchedRegion>(
+                DsfRegion::new(lat, 30),
+                PrefetchedRegion::deferred(Instant::now() + Duration::from_secs(20)),
+            );
+        }
+        // Deliberately NO NoCoverage regions: the bucket must stay empty.
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let metrics = MetricsClient::new(tx);
+
+        let mut coord = AdaptivePrefetchCoordinator::with_defaults()
+            .with_geo_index(Arc::clone(&geo_index))
+            .with_metrics_client(metrics);
+
+        // No scenery_index/dds_disk_checker, so `region_disk_state` is
+        // Unknown and maintenance leaves the seeded distribution untouched.
+        coord.run_region_maintenance();
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let region_state_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, MetricEvent::PrefetchRegionState { .. }))
+            .collect();
+        assert_eq!(
+            region_state_events.len(),
+            1,
+            "expected exactly one PrefetchRegionState event, got {:?}",
+            region_state_events
+        );
+
+        let MetricEvent::PrefetchRegionState {
+            in_progress,
+            prefetched,
+            no_coverage,
+            deferred,
+        } = region_state_events[0]
+        else {
+            unreachable!("filtered above")
+        };
+        assert_eq!(*in_progress, 1, "in_progress bucket");
+        assert_eq!(*prefetched, 2, "prefetched bucket");
+        assert_eq!(
+            *no_coverage, 0,
+            "a Deferred region is not a NoCoverage region — folding it into \
+             this bucket falsifies the acceptance instrument for #226"
+        );
+        assert_eq!(
+            *deferred, 3,
+            "deferred regions must be visible as their own gauge, not silently uncounted"
         );
     }
 

--- a/xearthlayer/src/prefetch/state_observer.rs
+++ b/xearthlayer/src/prefetch/state_observer.rs
@@ -83,6 +83,14 @@ impl PrefetchStateObserver {
         // reason enough to stop skipping it. Note this does not license a
         // longer ladder: by the time FUSE asks, the miss already happened.
         // This is a repair, not a prefetch.
+        //
+        // This clears only the region's GeoIndex entry — it deliberately does
+        // NOT reset the coordinator's `region_retry` strike count, which this
+        // observer cannot even reach (it holds only an `Arc<GeoIndex>`). That
+        // is intentional, not an oversight: a region cleared here by demand is
+        // the same ongoing episode as before, not a fresh one, so the
+        // 20/30/40/60s deferral ladder must keep escalating across repeated
+        // demand-driven clears rather than flattening back to 20s each time.
         if state.is_deferred() {
             self.geo_index.remove::<PrefetchedRegion>(&region);
             tracing::debug!(

--- a/xearthlayer/src/prefetch/state_observer.rs
+++ b/xearthlayer/src/prefetch/state_observer.rs
@@ -77,6 +77,22 @@ impl PrefetchStateObserver {
         let Some(state) = self.geo_index.get::<PrefetchedRegion>(&region) else {
             return;
         };
+
+        // Demand beats backoff. A deferred region was never claimed ready, so
+        // this is not a divergence — but the sim asking for tiles here now is
+        // reason enough to stop skipping it. Note this does not license a
+        // longer ladder: by the time FUSE asks, the miss already happened.
+        // This is a repair, not a prefetch.
+        if state.is_deferred() {
+            self.geo_index.remove::<PrefetchedRegion>(&region);
+            tracing::debug!(
+                lat = region.lat,
+                lon = region.lon,
+                "Deferral cleared by on-demand generation"
+            );
+            return;
+        }
+
         // InProgress regions are expected to miss — prefetch has not finished.
         if !(state.is_prefetched() || state.is_no_coverage()) {
             return;
@@ -313,6 +329,33 @@ mod tests {
         assert_eq!(
             demoted_count, 2,
             "a zero window permits every demotion to emit PrefetchRegionDemoted"
+        );
+    }
+
+    #[test]
+    fn test_fuse_miss_clears_deferral_without_counting_divergence() {
+        let geo_index = Arc::new(GeoIndex::new());
+        let tile = tile_in_33_119();
+        let region = region_of(tile);
+        geo_index.insert::<PrefetchedRegion>(
+            region,
+            PrefetchedRegion::deferred(Instant::now() + Duration::from_secs(60)),
+        );
+
+        let (metrics, mut rx) = test_metrics_client();
+        let observer =
+            PrefetchStateObserver::new(Arc::clone(&geo_index)).with_metrics_client(metrics);
+
+        observer.observe(tile, false);
+
+        assert!(
+            geo_index.get::<PrefetchedRegion>(&region).is_none(),
+            "X-Plane demanding tiles here is the strongest evidence the region matters now"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "a deferred region was never claimed ready, so this is not a divergence \
+             and must emit no metric event"
         );
     }
 }

--- a/xearthlayer/src/prefetch/state_observer.rs
+++ b/xearthlayer/src/prefetch/state_observer.rs
@@ -93,6 +93,9 @@ impl PrefetchStateObserver {
         // demand-driven clears rather than flattening back to 20s each time.
         if state.is_deferred() {
             self.geo_index.remove::<PrefetchedRegion>(&region);
+            if let Some(ref metrics) = self.metrics_client {
+                metrics.prefetch_deferral_cleared();
+            }
             tracing::debug!(
                 lat = region.lat,
                 lon = region.lon,
@@ -361,9 +364,47 @@ mod tests {
             "X-Plane demanding tiles here is the strongest evidence the region matters now"
         );
         assert!(
+            matches!(rx.try_recv(), Ok(MetricEvent::PrefetchDeferralCleared)),
+            "a deferred region was never claimed ready, so this is not a divergence — \
+             it must emit PrefetchDeferralCleared instead, not the divergence events"
+        );
+        assert!(
             rx.try_recv().is_err(),
-            "a deferred region was never claimed ready, so this is not a divergence \
-             and must emit no metric event"
+            "exactly one event for a cleared deferral"
+        );
+    }
+
+    #[test]
+    fn test_deferral_cleared_emits_no_divergence_events() {
+        // Companion to the test above, read from the other direction: a
+        // cleared deferral must never ALSO look like a divergence. If the
+        // is_deferred() branch's early `return` were ever removed, this
+        // would start seeing PrefetchStateDiverged / PrefetchRegionDemoted
+        // fall through from the code below it.
+        let geo_index = Arc::new(GeoIndex::new());
+        let tile = tile_in_33_119();
+        let region = region_of(tile);
+        geo_index.insert::<PrefetchedRegion>(
+            region,
+            PrefetchedRegion::deferred(Instant::now() + Duration::from_secs(60)),
+        );
+
+        let (metrics, mut rx) = test_metrics_client();
+        let observer =
+            PrefetchStateObserver::new(Arc::clone(&geo_index)).with_metrics_client(metrics);
+
+        observer.observe(tile, false);
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert_eq!(
+            events.len(),
+            1,
+            "clearing a deferral must emit exactly one event, \
+             never also the divergence/demotion events"
+        );
+        assert!(
+            matches!(events[0], MetricEvent::PrefetchDeferralCleared),
+            "the one event emitted must be PrefetchDeferralCleared"
         );
     }
 }


### PR DESCRIPTION
## Summary

A region that was merely **slow** was indistinguishable from a region with **no scenery
coverage**, so under a large prefetch backlog land regions were permanently retired as ocean and
excluded from prefetch for the rest of the session.

`AdaptivePrefetchCoordinator::evaluate_stale_regions` merged two `RegionDiskState` variants that
mean opposite things:

```rust
RegionDiskState::Incomplete | RegionDiskState::NoTiles => { /* strike -> NoCoverage */ }
```

- `NoTiles` — the scenery index attributes **zero** tiles. `NoCoverage` is correct.
- `Incomplete` — the index attributes N tiles, ≥1 not yet on disk. That is *positive evidence
  coverage exists*; `NoCoverage` is provably wrong.

The comment justifying the arm reads *"No tiles indexed: the region can never be confirmed"* —
true of `NoTiles` and only `NoTiles`. Written for one state, applied to an arm holding two.

Field evidence from @mmaechtel on v0.4.7-alpha.1 (LOWS→EDDF, cold cache): 47°N/8°E and 48°N/8°E —
Baden-Württemberg, not water — retired after 3 × 120s strikes at 10:18:31, then disproved by
on-demand generation at 10:21:14. **2m43s.** Inside those two regions: 27 × `TIMEOUT: DDS
generation exceeded 30s`, each returning a magenta placeholder.

Retirement was self-reinforcing: `NoCoverage` drops a region from planning, so prefetch stops
covering ground the aircraft is entering, FUSE picks the work up on demand against an already
saturated executor, and the added load produces more retirements.

## Changes

**The fix**

- `NoCoverage` is now reachable **only** from `NoTiles`, and immediately rather than after three
  strikes — the scenery index is fully built before the coordinator receives it, so a second
  opinion would be identical. `Incomplete` reaches `NoCoverage` by no path.
- **Strikes are progress-based.** A strike is recorded only when the region's covered-tile count
  did not increase since the previous evaluation. Slow no longer looks like absent, which is the
  reporter's own diagnosis made mechanical.
- `RegionDiskState::Incomplete` carries `{ covered, total }`. The old code reduced "387 of 400
  tiles present" to one bit, then to a strike, then to a permanent verdict.
- New **non-terminal** `RegionState::Deferred { retry_after }` with a 20s/30s/40s/60s ladder,
  60s repeating thereafter. The cap is set by the field evidence above, not by taste: the sim
  demanded that region 2m43s after prefetch gave up, so the window in which a region is skipped
  with nothing in flight has to stay well inside that.
- `should_prefetch` matches on state instead of being a bare `!contains(...)`, under which
  `InProgress`, `Prefetched` and `NoCoverage` were indistinguishable to the planner.
- **Demand beats backoff:** an on-demand FUSE generation inside a `Deferred` region clears the
  deferral immediately and does not count as a divergence. The strike count deliberately survives
  this, so the ladder keeps escalating across repeated demand-clears.
- Retry bookkeeping is pruned when a region is evicted from the retained set.

**Why `Incomplete` is never terminal**

We intend to explore falling back between imagery providers when tiles cannot be completed. That
constrains this fix: whatever state a never-completing region lands in must leave its tiles
retryable. This eliminated two otherwise-reasonable designs rather than merely ranking below them
— treating permanently-404 tiles as "covered" (region reaches `Prefetched`, which nothing
revisits) and a permanent `Partial` state both foreclose retry. `Deferred` is the state a
provider-fallback feature will attach to.

**Performance**

- `Cache::contains_sync` added; `tile_exists_blocking` no longer pays `block_in_place` +
  `block_on` + a `Box::pin` per tile. Resolves the `TODO(#175)` in `dds_disk_bridge.rs`.
- `CoverageDetail::{FirstMissOnly, ExactCounts}` keeps the every-2-second promotion path
  short-circuiting while only the rescue path counts exactly. Without it the whole-branch review
  measured ~44 filesystem `stat()` calls per absent tile landing on a hot path — the cost analysis
  in the design costed only one of the two sources `tile_is_covered` consults.

**Observability** — this is what the acceptance flight is judged on

- `Region making no progress — deferred` WARN carrying `covered`/`total`. `covered=387 total=400`
  reads as "13 tiles are 404ing"; `covered=0 total=400` reads as "nothing is arriving at all".
  Two very different faults, previously indistinguishable.
- `regions_deferred` (counter), `regions_deferred_active` (gauge) and `deferrals_cleared`
  (counter) in the periodic `Prefetch sample` line.
- `mark_no_coverage` raised to `info!` — it is now the only path that marks `NoCoverage` in
  practice, and was invisible at default log level.
- `regions_nocoverage` becomes trustworthy: it counts only regions the index says are genuinely
  empty.

## Related Issues

Fixes #226 (the keyword is also in commit `e4ace5d`, since this PR targets `develop/0.4.7`
rather than the default branch and a PR-body keyword is inert here).

Found during this work, filed separately, **not fixed here**:

- #228 — a pre-existing second path marks `NoCoverage` when there is no scenery index at all,
  bypassing the predicate entirely. Same "cannot tell ≠ absent" family as this issue. Confirmed
  reachable; can corrupt criterion F3 for a tester with no ortho packages installed.
- #229 — `AggregatedState::reset()` has no production caller, so every counter is cumulative
  since start rather than per-interval.
- #230 — the rescue path's exact-count scan can burst ~500k `stat()` calls synchronously on
  cold-cache terrain entry. Analysis and watch signature recorded; **watch for this during the
  flight** rather than treating it as backpressure.

Context: #223 introduced `RegionDiskState` specifically to stop "cannot determine" collapsing
into "confirmed absent" — its doc comment says *"Deliberately not a `bool`"*. This consumer had
merged two of the four variants back together.

## Test Plan

- [x] `make pre-commit` passes (fmt + clippy + tests) — 2499 lib tests, 63 doctests, 0 failed
- [x] `cargo test -p xearthlayer --features debug-map` — 16/16 (that feature's tests had **never
      compiled**; `RegionState` did not derive `Debug`, fixed here)
- [x] Four regression tests were verified to **fail against the pre-fix code**, two on assertions
      rather than compile errors. The load-bearing one reproduces the defect at evaluation 3 —
      the documented strike count.
- [x] Mutation-verified: removing the short-circuit, deleting either end of the metric chains, or
      reverting the `FirstMissOnly` call site each fails a specific test.

**Acceptance is a flight, not CI.** Green tests do not close #226. The corrected criteria are in
https://github.com/samsoir/xearthlayer/issues/226#issuecomment-5310644169 — note the criteria in
the issue description were **unmeasurable**, greping for a log line this PR deletes. In short,
on a cold-cache flight over terrain with packages installed:

| | Check |
|---|---|
| **F1** (decisive) | `grep -c 'was_no_coverage=true'` → **0** |
| **F2** | `Region making no progress — deferred` should **appear**; read `covered`/`total` |
| **F3** | `regions_nocoverage` flat over covered terrain |
| **F4** | `regions_deferred` is cumulative — **difference successive samples**; `regions_deferred_active` should fall back toward 0 in cruise |
| **F5** | `promotions_normal` dominates `promotions_rescue`; `state_diverged` ≈ 0 |

Copy `~/.xearthlayer/xearthlayer.log` before relaunching — it is overwritten every start.

## Checklist

- [x] Code follows the project's SOLID principles and patterns
- [x] Tests added or updated for new/changed behavior
- [x] Documentation updated if applicable (CLAUDE.md, docs/dev/adaptive-prefetch-design.md,
      docs/dev/geo-index-design.md)
- [x] No new warnings from `cargo clippy`

## Known minors, accepted

- Retry entries can leak via two paths eviction cannot see (the advancing arm and the observer's
  demand-clear). ~50 bytes each, low thousands worst case; self-correcting after one strike now
  that `last_covered` tracks the latest observation rather than a high-water mark.
- `regions_deferred_active` also counts regions whose deferral has expired but which have not yet
  been re-marked `InProgress`, so under sustained backpressure it reads slightly high.

No `[Unreleased]` CHANGELOG entry — by convention here the changelog is compiled at release-cut
time, so an empty section is correct in a feature PR.
