### PR TITLE
refactor(metrics): delete AggregatedState::reset(), which was never called (#229)

### DIFF
--- a/docs/dev/adaptive-prefetch-design.md
+++ b/docs/dev/adaptive-prefetch-design.md
@@ -444,8 +444,9 @@ surface.
 
 The daemon aggregates these and logs them on the same 60s cadence as the
 memory sample. The counters among them are cumulative totals since process
-start, because `AggregatedState::reset()` — which does zero them — has no
-production caller; wire it up and these become totals since the last reset:
+start; nothing windows them, so difference successive samples to get a rate.
+The `regions_*` state fields are gauges, assigned wholesale from the GeoIndex
+each maintenance cycle rather than accumulated:
 
 ```
 INFO Prefetch sample uptime_s=... regions_in_progress=... regions_prefetched=...

--- a/docs/dev/memory-telemetry.md
+++ b/docs/dev/memory-telemetry.md
@@ -82,6 +82,27 @@ mebibyte", not necessarily "nothing".
 | `dds_handles_peak` | `state.fuse_handles_peak_open` | Highest concurrent open count this session. **Read this, not `dds_handles_open`, when sizing the cap.** The current gauges are sampled on open, on tile production and on release, so a 60-second reader almost always catches them just after a release: the first KDEN run reported `dds_pinned_mb=0` throughout while 31 files were open. |
 | `dds_pinned_peak_mb` | `state.fuse_handles_peak_pinned_bytes` | Highest pinned total this session. Compare against `MAX_PINNED_TILE_BYTES`: if it approaches 512, `open()` is close to silently dropping memoisation and the cap wants raising. |
 
+### Counters are cumulative; gauges are current-state
+
+Every counter on this line — `tiles_done`, `chunks_ok`, `chunks_failed`,
+`gc_evicted_mb`, `fuse_*_reads`, and the `Prefetch sample` counters
+(`regions_deferred`, `deferrals_cleared`, `promotions_*`) — is **cumulative
+since process start**. Nothing windows them: there is no per-interval reset, so
+a raw value always climbs and a single line cannot tell you what happened in the
+last minute. **Difference successive samples to get a rate**, or divide by
+`uptime_s` for a session average.
+
+Gauges — `encodes_active`, `disk_writes_active`, `mem_cache_writes_active`,
+`dds_handles_open`, `dds_pinned_mb`, `chunk_index_entries`, the
+`regions_*` state counts, and everything from `MemoryProbe` — are current-state
+and are read directly. Peak fields (`dds_handles_peak`, `dds_pinned_peak_mb`)
+are high-water marks over the session, not current values.
+
+This distinction matters when judging an acceptance criterion. "`regions_deferred`
+must not climb without bound" is about the *slope* across samples; the raw number
+climbing is not a fault. (`AggregatedState::reset()` used to exist and implied
+otherwise; it had no production caller and was removed in #229.)
+
 ### Reading the two amplification ratios
 
 `*_alloc_mb / *_read_mb` is the read amplification for each path. 1.0 means the

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -490,8 +490,8 @@ impl MetricsDaemon {
             state_diverged = state.prefetch_state_diverged,
             regions_demoted = state.prefetch_regions_demoted,
             // #226: how often a region was skipped for making no progress.
-            // Cumulative since process start — `AggregatedState::reset()` has
-            // no production caller — so it only ever climbs. It does NOT climb
+            // Cumulative since process start — difference successive samples
+            // for a rate — so it only ever climbs. It does NOT climb
             // every maintenance cycle: a stuck region is moved to `Deferred`
             // immediately, and `is_stale()` only re-evaluates `InProgress`
             // regions, so the region sits off-cycle until its deferral expires
@@ -1339,12 +1339,9 @@ mod tests {
     fn test_prefetch_sample_reports_regions_deferred() {
         // regions_deferred is a COUNTER, unlike the region-state gauges
         // above: it accumulates across the daemon's own event stream rather
-        // than being assigned wholesale from GeoIndex each cycle, so it
-        // belongs in `reset()` while the gauges do not.
-        //
-        // `reset()` has no production caller today, so in a running process
-        // the counter is cumulative since start. This asserts the `reset()`
-        // contract for the field, not a per-interval window in the log.
+        // than being assigned wholesale from GeoIndex each cycle. Nothing
+        // windows it, so in a running process it is cumulative since start —
+        // difference successive log samples for a rate.
         let (mut daemon, _tx) = create_daemon();
         daemon.state.prefetch_regions_deferred = 7;
         daemon.state.prefetch_regions_nocoverage = 3;
@@ -1369,25 +1366,6 @@ mod tests {
             sample.get("regions_deferred_active").map(String::as_str),
             Some("4"),
             "the gauge is a separate field from the counter"
-        );
-
-        daemon.state.reset();
-        assert_eq!(
-            daemon.state.prefetch_regions_deferred, 0,
-            "counter must reset"
-        );
-        assert_eq!(
-            daemon.state.prefetch_deferrals_cleared, 0,
-            "counter must reset"
-        );
-        assert_eq!(
-            daemon.state.prefetch_regions_nocoverage, 3,
-            "gauge must NOT reset"
-        );
-        assert_eq!(
-            daemon.state.prefetch_regions_deferred_active, 4,
-            "the deferred gauge is externally derived from GeoIndex, so it \
-             must NOT reset either"
         );
     }
 
@@ -1502,19 +1480,6 @@ mod tests {
             "must accumulate, not assign"
         );
         assert_eq!(daemon.state.prefetch_promotions_rescue, 1);
-    }
-
-    #[test]
-    fn test_promotion_counters_reset() {
-        let (mut daemon, _tx) = create_daemon();
-        daemon.process_event(MetricEvent::PrefetchRegionsPromotedNormal { count: 4 });
-        daemon.process_event(MetricEvent::PrefetchRegionPromotedRescue);
-        daemon.state.reset();
-        assert_eq!(
-            daemon.state.prefetch_promotions_normal, 0,
-            "counters reset, unlike the region gauges"
-        );
-        assert_eq!(daemon.state.prefetch_promotions_rescue, 0);
     }
 
     #[tokio::test]

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -150,7 +150,7 @@ pub struct AggregatedState {
     pub dds_disk_bytes_written: u64,
     /// Total bytes read from chunk disk cache (cache hits).
     pub chunk_disk_bytes_read: u64,
-    /// Initial disk cache size (scanned on startup, not reset).
+    /// Initial disk cache size (scanned on startup).
     pub initial_disk_cache_bytes: u64,
     /// Total bytes evicted from disk cache by the GC daemon.
     pub disk_bytes_evicted: u64,
@@ -284,7 +284,8 @@ pub struct AggregatedState {
     // =========================================================================
     /// Regions with tiles submitted, awaiting confirmation (gauge, from
     /// `PrefetchRegionState`; externally derived from `GeoIndex`, like the
-    /// disk-cache-size gauges above, so it is excluded from `reset()`).
+    /// disk-cache-size gauges above — assigned wholesale each maintenance
+    /// cycle rather than accumulated from this daemon's event stream).
     pub prefetch_regions_in_progress: usize,
     /// Regions confirmed fully cached (gauge).
     pub prefetch_regions_prefetched: usize,
@@ -301,8 +302,8 @@ pub struct AggregatedState {
     /// Total regions demoted in response to divergence (counter).
     pub prefetch_regions_demoted: u64,
     /// Total regions deferred for making no progress, cumulative since
-    /// process start (counter). `reset()` has no production caller, so this
-    /// is never windowed.
+    /// process start (counter). Never windowed — difference successive log
+    /// samples to get a rate.
     pub prefetch_regions_deferred: u64,
     /// Total region deferrals cleared by on-demand FUSE generation, cumulative
     /// since process start (counter, #226). The post-fix analogue of
@@ -397,63 +398,6 @@ impl AggregatedState {
     /// Returns the uptime duration.
     pub fn uptime(&self) -> std::time::Duration {
         self.uptime_start.elapsed()
-    }
-
-    /// Resets all counters to zero.
-    pub fn reset(&mut self) {
-        self.uptime_start = Instant::now();
-        self.downloads_active = 0;
-        self.chunks_downloaded = 0;
-        self.chunks_failed = 0;
-        self.chunks_retried = 0;
-        self.bytes_downloaded = 0;
-        self.download_time_us = 0;
-        self.chunk_disk_cache_hits = 0;
-        self.chunk_disk_cache_misses = 0;
-        self.disk_writes_active = 0;
-        self.chunk_disk_bytes_written = 0;
-        self.dds_disk_bytes_written = 0;
-        self.chunk_disk_bytes_read = 0;
-        self.dds_disk_cache_hits = 0;
-        self.dds_disk_cache_misses = 0;
-        self.fuse_dds_disk_cache_hits = 0;
-        self.fuse_dds_disk_cache_misses = 0;
-        self.dds_disk_bytes_read = 0;
-        self.memory_cache_hits = 0;
-        self.memory_cache_misses = 0;
-        self.fuse_memory_cache_hits = 0;
-        self.fuse_memory_cache_misses = 0;
-        self.memory_cache_size_bytes = 0;
-        self.mem_cache_writes_active = 0;
-        self.jobs_submitted = 0;
-        self.fuse_jobs_submitted = 0;
-        self.jobs_completed = 0;
-        self.jobs_failed = 0;
-        self.jobs_timed_out = 0;
-        self.jobs_active = 0;
-        self.jobs_coalesced = 0;
-        self.encodes_active = 0;
-        self.encodes_completed = 0;
-        self.bytes_encoded = 0;
-        self.encode_time_us = 0;
-        self.assembly_time_us = 0;
-        self.fuse_tiles_served = 0;
-        self.fuse_requests_active = 0;
-        self.fuse_requests_waiting = 0;
-        self.peak_bytes_per_second = 0.0;
-        // prefetch_regions_{in_progress,prefetched,nocoverage,deferred_active}
-        // are NOT reset:
-        // like chunk_disk_cache_size_bytes/dds_disk_cache_size_bytes/
-        // chunk_index_entries above, they are externally-derived gauges
-        // (assigned wholesale from GeoIndex each maintenance cycle), not
-        // counters accumulated from this daemon's own event stream. Zeroing
-        // them here would misreport "no regions" until the next cycle.
-        self.prefetch_state_diverged = 0;
-        self.prefetch_regions_demoted = 0;
-        self.prefetch_regions_deferred = 0;
-        self.prefetch_deferrals_cleared = 0;
-        self.prefetch_promotions_normal = 0;
-        self.prefetch_promotions_rescue = 0;
     }
 }
 
@@ -563,19 +507,6 @@ mod tests {
         assert_eq!(state.chunks_downloaded, 0);
         assert_eq!(state.jobs_submitted, 0);
         assert!(state.uptime().as_secs() < 1);
-    }
-
-    #[test]
-    fn test_aggregated_state_reset() {
-        let mut state = AggregatedState::default();
-        state.chunks_downloaded = 100;
-        state.bytes_downloaded = 1_000_000;
-        state.jobs_completed = 50;
-
-        state.reset();
-        assert_eq!(state.chunks_downloaded, 0);
-        assert_eq!(state.bytes_downloaded, 0);
-        assert_eq!(state.jobs_completed, 0);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #229

`AggregatedState::reset()` had no production caller — all three call sites were
inside `#[cfg(test)]` — so every field it zeroed has always been cumulative
since process start, while the code, its tests and several comments read as
though a per-interval reset ran.

## Why delete rather than wire it up

The issue framed this as a choice. Investigation made it one-sided: **`reset()`
zeroes eight in-flight gauges alongside the counters.**

| Field | Maintained by |
|---|---|
| `downloads_active`, `disk_writes_active`, `mem_cache_writes_active` | `+= 1` / `saturating_sub(1)` |
| `jobs_active`, `encodes_active` | `+= 1` / `saturating_sub(1)` |
| `fuse_requests_active`, `fuse_requests_waiting` | `+= 1` / `saturating_sub(1)` |
| `memory_cache_size_bytes` | assigned wholesale |

Zeroing an increment/decrement gauge mid-flight strands the pending decrements
at the `saturating_sub` floor, so the gauge under-reports by the in-flight depth
— every interval, cumulatively. Calling `reset()` would have taken eight working
gauges and broken them; "wire it up" was really "audit 45 fields and split
gauges from counters first".

Cumulative is also the better contract: a cumulative series can be differenced,
a windowed one cannot be un-differenced, and a dropped sample loses that
interval permanently. Keeping it also means existing flight logs stay comparable
with new ones, which matters while #227 is being diagnosed from four captured
runs.

## Coverage

`test_aggregated_state_reset` seeded only three genuine counters and never
touched a gauge, so it could not have detected the defect above. It and
`test_promotion_counters_reset` are removed as tests of dead code.

The production gauge-vs-counter distinction from #226 keeps full coverage:
counters accumulate (`test_promotion_counters_accumulate`), gauges are assigned
wholesale (the `PrefetchRegionState` replace-not-accumulate test at
`daemon.rs:1458`). Only assertions about the dead function's behaviour were
removed.

## Verification

`make pre-commit` green — 2,494 tests, 93 in `metrics`. −116 / +34 lines.

Acceptance criteria from the issue: `reset()` is out of the tree; no comment
describes a field as per-interval; `docs/dev/memory-telemetry.md` and
`docs/dev/adaptive-prefetch-design.md` now state that counters are cumulative,
gauges are current-state, peaks are high-water marks, and that a rate comes from
differencing successive samples.

## Note for reviewers

No behaviour changes — this function never ran in production. What changes is
the documented contract, which now matches what the counters have always done.

`[Unreleased]` is intentionally untouched; the CHANGELOG is compiled at
release-cut time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
