### PR TITLE
feat(fuse): count and announce DDS handle budget exhaustion (#236)

### DIFF
--- a/docs/dev/memory-telemetry.md
+++ b/docs/dev/memory-telemetry.md
@@ -46,10 +46,13 @@ so that a single unattended flight discriminates between them:
 2026-08-06 06:20:33Z  INFO Memory sample uptime_s=60 rss_mb=873 vm_mb=1459 swap_mb=0 threads=71 tiles_done=0 encodes_active=0 chunks_ok=0 chunks_failed=0 mem_cache_mb=0 dds_disk_mb=158268 chunk_disk_mb=55301 gc_evicted_mb=0 chunk_index_entries=3803083 disk_writes_active=0 mem_cache_writes_active=0
 ```
 
-(Captured before #233; a current line also carries the six `fuse_*` read
-fields described below.)
+(Captured before #233. The example above shows 16 fields; a current line
+carries **27** — the six `fuse_*` read fields, the four `dds_handles_*` /
+`dds_pinned_*` fields, and `dds_budget_exhausted`, all described below. If you
+are editing this paragraph, count the fields in `log_memory_sample` rather than
+adjusting the number by hand: it has gone stale twice that way.)
 
-Twenty-two fields, in emission order. Every `_mb` value is truncating integer
+Fields are listed below in emission order. Every `_mb` value is truncating integer
 division by 1 MiB (1 048 576 bytes), so a value of `0` means "under one
 mebibyte", not necessarily "nothing".
 
@@ -80,7 +83,8 @@ mebibyte", not necessarily "nothing".
 | `dds_handles_open` | `state.fuse_handles_open` | Virtual DDS files X-Plane currently has open (gauge). Each one may pin a whole tile so later reads can slice it (#234). Nothing measured this before, so `MAX_PINNED_TILE_BYTES` is currently a guess — this is the number that should replace it. |
 | `dds_pinned_mb` | `state.fuse_handles_pinned_bytes` | Tile bytes pinned by those handles (gauge). Bounded by `MAX_PINNED_TILE_BYTES` (512 MiB); on reaching it, `open()` stops memoising and reads fall back to resolving per call. |
 | `dds_handles_peak` | `state.fuse_handles_peak_open` | Highest concurrent open count this session. **Read this, not `dds_handles_open`, when sizing the cap.** The current gauges are sampled on open, on tile production and on release, so a 60-second reader almost always catches them just after a release: the first KDEN run reported `dds_pinned_mb=0` throughout while 31 files were open. |
-| `dds_pinned_peak_mb` | `state.fuse_handles_peak_pinned_bytes` | Highest pinned total this session. Compare against `MAX_PINNED_TILE_BYTES`: if it approaches 512, `open()` is close to silently dropping memoisation and the cap wants raising. |
+| `dds_pinned_peak_mb` | `state.fuse_handles_peak_pinned_bytes` | Highest pinned total this session. Compare against the `dds_pinned_cap_mb` logged at mount: if it approaches the cap, `open()` is close to dropping memoisation. Two scene loads (KDEN, KSLC) peaked at 10-21 MiB against 512, roughly 24x headroom. |
+| `dds_budget_exhausted` | `state.fuse_handle_budget_exhausted` | Opens refused a memoising handle because the pinned-tile budget was full (counter, #236). **Any non-zero value means the #234 fix stopped applying for those opens** and their reads resolved the tile once per call. Zero while `fuse_dds_alloc_mb` climbs means a different fault — the two are otherwise indistinguishable in a log. |
 
 ### Counters are cumulative; gauges are current-state
 
@@ -102,6 +106,24 @@ This distinction matters when judging an acceptance criterion. "`regions_deferre
 must not climb without bound" is about the *slope* across samples; the raw number
 climbing is not a fault. (`AggregatedState::reset()` used to exist and implied
 otherwise; it had no production caller and was removed in #229.)
+
+### Sizing the DDS handle budget
+
+`dds_handles_open` and `dds_pinned_mb` measure different things and diverge by
+more than an order of magnitude. Handles are counted at `open()`; bytes are
+counted when a tile is **materialised**, which happens on first read. X-Plane
+reads each texture in about two calls and releases promptly, so most open
+handles hold nothing: 31 concurrent opens corresponded to roughly **two**
+resident tiles.
+
+**Size the cap against `dds_pinned_peak_mb`, never against `dds_handles_peak`.**
+Multiplying the open count by the tile size overstates the requirement by
+around 16x — that error is what put the original "1.5x headroom" estimate in
+#236, when the real figure was about 24x.
+
+The cap is soft: admission tests `pinned + expected` without reserving, so
+concurrent opens can pass together and overshoot. With the measured headroom
+this is immaterial; if `dds_budget_exhausted` ever moves, revisit it.
 
 ### Reading the two amplification ratios
 

--- a/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
+++ b/xearthlayer/src/fuse/fuse3/ortho_union_fs.rs
@@ -61,24 +61,41 @@ use std::ffi::{OsStr, OsString};
 use std::io::SeekFrom;
 use std::num::NonZeroU32;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::sync::mpsc;
 use tokio::sync::OnceCell;
-use tracing::{debug, trace, Instrument};
+use tracing::{debug, trace, warn, Instrument};
 
-/// Ceiling on DDS bytes pinned by open file handles.
+/// Ceiling on DDS bytes pinned by open file handles: 512 MiB, or 48 tiles.
 ///
 /// Each memoising handle holds one whole tile for as long as X-Plane keeps the
 /// file open, which is new retention in a codebase with an open unbounded-growth
 /// investigation (#227). Past this point `open()` stops handing out memoising
 /// handles and reads fall back to resolving per call, so the bound costs
-/// throughput rather than correctness. `open_dds_handles()` and
-/// `pinned_tile_bytes()` expose the real figures so this can be tuned from
-/// flight data rather than guessed at twice.
+/// throughput rather than correctness.
+///
+/// **Sized against measurement, not opens** (#236). Two scene loads on one
+/// machine (KDEN warm, KSLC cold, 2026-08-19) peaked at **31 concurrent opens**
+/// but only **10-21 MiB pinned** -- roughly two tiles, about 24x headroom.
+/// The two figures diverge because `pinned_tile_bytes` counts *materialised*
+/// tiles, and a tile is produced on first read, not on `open()`: X-Plane reads
+/// each texture in two calls and releases promptly, so most open handles hold
+/// nothing. Sizing this from the open count instead would overstate the
+/// requirement by more than an order of magnitude.
+///
+/// The bound is **soft**. Admission tests `pinned + expected` but reserves
+/// nothing, so concurrent opens can all pass against one remaining slot and
+/// then materialise together. Reserving on `open()` would be worse: X-Plane
+/// may open a file it never reads, so reservations would be held for tiles
+/// that never exist and the cap would engage falsely.
+///
+/// If `dds_budget_exhausted` on the `Memory sample` line is ever non-zero, a
+/// real scene has exceeded what this was sized against -- raise it against
+/// `dds_pinned_peak_mb` from that flight rather than by guessing again.
 const MAX_PINNED_TILE_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Per-open state for one virtual DDS file.
@@ -165,6 +182,12 @@ pub struct Fuse3OrthoUnionFS {
     peak_handles_open: AtomicU64,
     /// Highest pinned byte total seen.
     peak_pinned_tile_bytes: AtomicU64,
+    /// Whether the budget-exhausted warning has been emitted this session.
+    ///
+    /// Latched, because the cap engages for every open in a burst rather than
+    /// once: an unlatched warn would bury the log it exists to serve. The
+    /// per-occurrence count goes to metrics instead (#236).
+    budget_warning_logged: AtomicBool,
     /// Optional channel for notifying Scene Tracker of DDS accesses.
     ///
     /// When set, the filesystem sends a [`FuseAccessEvent`] for each DDS
@@ -235,6 +258,7 @@ impl Fuse3OrthoUnionFS {
             pinned_tile_bytes: AtomicU64::new(0),
             peak_handles_open: AtomicU64::new(0),
             peak_pinned_tile_bytes: AtomicU64::new(0),
+            budget_warning_logged: AtomicBool::new(false),
             scene_tracker_tx: None,
             metrics_client: None,
             fuse_max_background: None,
@@ -271,6 +295,7 @@ impl Fuse3OrthoUnionFS {
             pinned_tile_bytes: AtomicU64::new(0),
             peak_handles_open: AtomicU64::new(0),
             peak_pinned_tile_bytes: AtomicU64::new(0),
+            budget_warning_logged: AtomicBool::new(false),
             scene_tracker_tx: None,
             metrics_client: None,
             fuse_max_background: None,
@@ -423,6 +448,15 @@ impl Fuse3OrthoUnionFS {
 
     /// Publish the handle gauge. Called on open and release -- two events per
     /// texture, against the 12-23 reads it takes to serve one.
+    /// Claims the one-shot budget warning: true on the first call of the
+    /// session, false ever after.
+    ///
+    /// The cap engages for every open in a burst, not once, so the warning is
+    /// latched and the per-occurrence count goes to metrics instead (#236).
+    fn claim_budget_warning(&self) -> bool {
+        !self.budget_warning_logged.swap(true, Ordering::Relaxed)
+    }
+
     fn report_handle_gauge(&self) {
         let open = self.dds_handles.len() as u64;
         let pinned = self.pinned_tile_bytes.load(Ordering::Relaxed);
@@ -501,6 +535,15 @@ impl Fuse3OrthoUnionFS {
         mount_options.no_open_dir_support(true);
 
         let mount_path = PathBuf::from(mountpoint);
+
+        // State the ceiling once, so a flight log is self-describing: a reader
+        // comparing dds_pinned_peak_mb against it does not have to know the
+        // constant, and does not have to guess which build it came from (#236).
+        tracing::info!(
+            dds_pinned_cap_mb = MAX_PINNED_TILE_BYTES / (1024 * 1024),
+            dds_pinned_cap_tiles = MAX_PINNED_TILE_BYTES / self.virtual_dds_config.size().max(1),
+            "Virtual DDS handle memoisation budget"
+        );
 
         #[cfg(target_os = "linux")]
         let handle = fuse3::raw::Session::new(mount_options)
@@ -1138,13 +1181,26 @@ impl Filesystem for Fuse3OrthoUnionFS {
         // Refuse to memoise past the pinned-bytes ceiling. fh 0 makes read()
         // resolve per call, which is slower but correct.
         let expected = self.virtual_dds_config.size();
-        if self.pinned_tile_bytes.load(Ordering::Relaxed) + expected > MAX_PINNED_TILE_BYTES {
-            debug!(
-                inode = inode,
-                pinned_mb = self.pinned_tile_bytes.load(Ordering::Relaxed) / (1024 * 1024),
-                open_handles = self.dds_handles.len(),
-                "DDS handle budget exhausted - serving this open without memoisation"
-            );
+        let pinned = self.pinned_tile_bytes.load(Ordering::Relaxed);
+        if pinned + expected > MAX_PINNED_TILE_BYTES {
+            // Count every refusal: this is what lets a flight log tell "the
+            // cap engaged" from "the #234 fix stopped working", which look
+            // identical otherwise -- both show fuse_dds_alloc_mb climbing.
+            if let Some(metrics) = &self.metrics_client {
+                metrics.fuse_handle_budget_exhausted();
+            }
+            // Warn once, at default level. Before #236 this was debug-only, so
+            // the degradation was invisible on an ordinary flight.
+            if self.claim_budget_warning() {
+                warn!(
+                    pinned_mb = pinned / (1024 * 1024),
+                    cap_mb = MAX_PINNED_TILE_BYTES / (1024 * 1024),
+                    open_handles = self.dds_handles.len(),
+                    "DDS handle budget exhausted - serving opens without memoisation. \
+                     Reads now resolve their tile once per call. Further occurrences \
+                     are counted in dds_budget_exhausted on the Memory sample line."
+                );
+            }
             return Ok(ReplyOpen {
                 fh: 0,
                 flags: FOPEN_DIRECT_IO,
@@ -1640,6 +1696,121 @@ mod tests {
                 zoom: 16,
                 map_type: "BI".to_string(),
             })
+    }
+
+    /// Fixture wired to an observable metrics channel.
+    fn virtual_dds_fixture_with_metrics() -> (
+        Fuse3OrthoUnionFS,
+        mpsc::UnboundedReceiver<crate::metrics::MetricEvent>,
+        TempDir,
+    ) {
+        let (fs, _requests, temp) = virtual_dds_fixture();
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            fs.with_metrics(crate::metrics::MetricsClient::new(tx)),
+            rx,
+            temp,
+        )
+    }
+
+    fn budget_exhausted_events(
+        rx: &mut mpsc::UnboundedReceiver<crate::metrics::MetricEvent>,
+    ) -> usize {
+        let mut n = 0;
+        while let Ok(event) = rx.try_recv() {
+            if matches!(
+                event,
+                crate::metrics::MetricEvent::FuseHandleBudgetExhausted
+            ) {
+                n += 1;
+            }
+        }
+        n
+    }
+
+    /// Past the ceiling `open()` hands back fh 0, so `read()` resolves per
+    /// call. Slower, but correct -- the bound costs throughput, never data.
+    #[tokio::test]
+    async fn test_open_past_budget_refuses_memoisation() {
+        use fuse3::raw::Filesystem;
+
+        let (fs, _rx, _temp) = virtual_dds_fixture_with_metrics();
+        let ino = virtual_inode(&fs);
+
+        // One tile short of the ceiling: pinned + expected must exceed it.
+        fs.pinned_tile_bytes
+            .store(MAX_PINNED_TILE_BYTES, Ordering::Relaxed);
+
+        let opened = fs.open(test_request(), ino, 0).await.unwrap();
+        assert_eq!(opened.fh, 0, "refused opens get no memoising handle");
+        assert_eq!(
+            opened.flags, FOPEN_DIRECT_IO,
+            "the file must still bypass the page cache"
+        );
+        assert!(
+            fs.dds_handles.is_empty(),
+            "a refused open must not leave a handle behind"
+        );
+    }
+
+    /// #236: the fallback was visible only under `--debug`, so a flight could
+    /// not tell "the cap engaged" from "the #234 fix stopped working".
+    #[tokio::test]
+    async fn test_open_past_budget_counts_every_refusal() {
+        use fuse3::raw::Filesystem;
+
+        let (fs, mut rx, _temp) = virtual_dds_fixture_with_metrics();
+        let ino = virtual_inode(&fs);
+        fs.pinned_tile_bytes
+            .store(MAX_PINNED_TILE_BYTES, Ordering::Relaxed);
+
+        for _ in 0..3 {
+            let opened = fs.open(test_request(), ino, 0).await.unwrap();
+            assert_eq!(opened.fh, 0);
+        }
+
+        // Every refusal counts: the counter measures lost memoisations, and
+        // one event could not be told from an assignment.
+        assert_eq!(budget_exhausted_events(&mut rx), 3);
+    }
+
+    /// The warning latches. Once the cap engages it engages for every open in
+    /// the burst, and a per-open warn would bury the log it is meant to serve.
+    #[tokio::test]
+    async fn test_budget_warning_is_latched() {
+        use fuse3::raw::Filesystem;
+
+        let (fs, _rx, _temp) = virtual_dds_fixture_with_metrics();
+        let ino = virtual_inode(&fs);
+        fs.pinned_tile_bytes
+            .store(MAX_PINNED_TILE_BYTES, Ordering::Relaxed);
+
+        // Assert the claim, not the flag. A flag assertion passes even if the
+        // warn is emitted unconditionally, so long as something sets it.
+        fs.open(test_request(), ino, 0).await.unwrap();
+        assert!(
+            !fs.claim_budget_warning(),
+            "the first refusal must have consumed the one-shot claim"
+        );
+
+        for _ in 0..3 {
+            fs.open(test_request(), ino, 0).await.unwrap();
+            assert!(
+                !fs.claim_budget_warning(),
+                "later refusals must not re-arm the warning"
+            );
+        }
+    }
+
+    /// The latch in isolation: true exactly once, whatever the caller does.
+    #[test]
+    fn test_claim_budget_warning_is_one_shot() {
+        let (fs, _requests, _temp) = virtual_dds_fixture();
+
+        assert!(fs.claim_budget_warning(), "first claim must succeed");
+        for _ in 0..5 {
+            assert!(!fs.claim_budget_warning(), "every later claim must fail");
+        }
     }
 
     /// One open, many reads, one tile request.

--- a/xearthlayer/src/metrics/client.rs
+++ b/xearthlayer/src/metrics/client.rs
@@ -120,6 +120,12 @@ impl MetricsClient {
         });
     }
 
+    /// Records an `open()` refused a memoising handle for want of budget.
+    #[inline]
+    pub fn fuse_handle_budget_exhausted(&self) {
+        self.send(MetricEvent::FuseHandleBudgetExhausted);
+    }
+
     /// Reports the current virtual DDS handle gauge.
     #[inline]
     pub fn fuse_handles(

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -329,6 +329,11 @@ impl MetricsDaemon {
                     self.state.fuse_file_alloc_bytes += materialised;
                 }
             }
+            MetricEvent::FuseHandleBudgetExhausted => {
+                // Counter: accumulate. Each event is one open that lost
+                // memoisation, not a level to be assigned.
+                self.state.fuse_handle_budget_exhausted += 1;
+            }
             MetricEvent::FuseHandlesUpdate {
                 open,
                 pinned_bytes,
@@ -462,6 +467,7 @@ impl MetricsDaemon {
             dds_pinned_mb = state.fuse_handles_pinned_bytes / MB,
             dds_handles_peak = state.fuse_handles_peak_open,
             dds_pinned_peak_mb = state.fuse_handles_peak_pinned_bytes / MB,
+            dds_budget_exhausted = state.fuse_handle_budget_exhausted,
             "Memory sample"
         );
     }
@@ -1480,6 +1486,37 @@ mod tests {
             "must accumulate, not assign"
         );
         assert_eq!(daemon.state.prefetch_promotions_rescue, 1);
+    }
+
+    #[test]
+    fn test_handle_budget_exhausted_accumulates() {
+        // A counter, not a gauge. One event and a zero start are
+        // indistinguishable under `+=` and `=`, so send several.
+        let (mut daemon, _tx) = create_daemon();
+        for _ in 0..3 {
+            daemon.process_event(MetricEvent::FuseHandleBudgetExhausted);
+        }
+        assert_eq!(
+            daemon.state.fuse_handle_budget_exhausted, 3,
+            "must accumulate, not assign"
+        );
+    }
+
+    #[test]
+    fn test_memory_sample_reports_budget_exhausted() {
+        // The whole point of #236: a flight log must be able to tell "the cap
+        // engaged" apart from "the #234 fix stopped working", which otherwise
+        // look identical -- both show fuse_dds_alloc_mb climbing.
+        let (mut daemon, _tx) = create_daemon();
+        daemon.state.fuse_handle_budget_exhausted = 9;
+
+        let events = capture_events(|| daemon.log_memory_sample());
+        let sample = find_memory_sample(&events).expect("must emit a memory sample line");
+
+        assert_eq!(
+            sample.get("dds_budget_exhausted").map(String::as_str),
+            Some("9")
+        );
     }
 
     #[tokio::test]

--- a/xearthlayer/src/metrics/event.rs
+++ b/xearthlayer/src/metrics/event.rs
@@ -254,6 +254,15 @@ pub enum MetricEvent {
         peak_pinned_bytes: u64,
     },
 
+    /// An `open()` was refused a memoising handle because the pinned-tile
+    /// budget was exhausted.
+    ///
+    /// Counter, not a gauge: each occurrence is one open that fell back to
+    /// resolving its tile per read -- the pre-#234 cost. The cap has roughly
+    /// 24x measured headroom, so any non-zero value means a scene reached a
+    /// density nothing has been sized against. See #236.
+    FuseHandleBudgetExhausted,
+
     /// A FUSE request started being handled.
     FuseRequestStarted,
 
@@ -361,6 +370,7 @@ impl MetricEvent {
             Self::FuseTileServed => "fuse_tile_served",
             Self::FuseRead { .. } => "fuse_read",
             Self::FuseHandlesUpdate { .. } => "fuse_handles_update",
+            Self::FuseHandleBudgetExhausted => "fuse_handle_budget_exhausted",
             Self::FuseRequestStarted => "fuse_request_started",
             Self::FuseRequestCompleted => "fuse_request_completed",
             Self::FuseRequestQueued => "fuse_request_queued",

--- a/xearthlayer/src/metrics/state.rs
+++ b/xearthlayer/src/metrics/state.rs
@@ -272,6 +272,14 @@ pub struct AggregatedState {
     pub fuse_handles_peak_open: u64,
     /// Highest pinned byte total seen this session.
     pub fuse_handles_peak_pinned_bytes: u64,
+    /// Opens refused a memoising handle for want of pinned-tile budget
+    /// (counter, cumulative since process start, #236).
+    ///
+    /// Any non-zero value means `MAX_PINNED_TILE_BYTES` engaged and those
+    /// opens fell back to resolving their tile once per read -- the pre-#234
+    /// cost. Read it alongside `dds_pinned_peak_mb`: a climbing
+    /// `fuse_dds_alloc_mb` with this at zero is a different fault entirely.
+    pub fuse_handle_budget_exhausted: u64,
 
     // =========================================================================
     // Peak Tracking
@@ -381,6 +389,7 @@ impl AggregatedState {
             fuse_handles_pinned_bytes: 0,
             fuse_handles_peak_open: 0,
             fuse_handles_peak_pinned_bytes: 0,
+            fuse_handle_budget_exhausted: 0,
             peak_bytes_per_second: 0.0,
             prefetch_regions_in_progress: 0,
             prefetch_regions_prefetched: 0,


### PR DESCRIPTION
Fixes #236

Past `MAX_PINNED_TILE_BYTES`, `open()` stops handing out memoising handles and
reads fall back to resolving the tile once per call — the pre-#234 cost. That
was announced by one `debug!` line, so on an ordinary flight the fix could stop
applying with no visible symptom beyond `fuse_dds_alloc_mb` climbing again,
which reads identically to "#234 never worked".

## Changes

- **`dds_budget_exhausted`** on the `Memory sample` line: cumulative count of
  opens refused a handle. Non-zero means the cap engaged; zero while
  `fuse_dds_alloc_mb` climbs means a different fault.
- **Latched `warn!`** at default level on the first refusal. Latched because the
  cap engages for every open in a burst, and a per-open warn would bury the log
  it exists to serve.
- **Cap logged once at mount** (`dds_pinned_cap_mb`), so a log is
  self-describing and a reader need not know which build produced it.

## The cap stays a constant, and its premise needed correcting

The issue asked whether the ceiling should be derived or configurable. It stays
512 MiB: `fuse.max_background` bounds requests *in flight* while a handle
persists *between* reads, so it does not bound pinned bytes; the memory-cache
budget is an unrelated concern; and a config key is a knob nobody can set for a
value with this much headroom.

**This much headroom is the correction.** The issue reasoned from 31 concurrent
opens to "roughly 330 MiB against 512 — about 1.5× headroom". The peak gauge
added alongside it measured **10–21 MiB**.

Handles are counted at `open()`. Bytes are counted when a tile is
**materialised**, inside `get_or_init` on the first read. X-Plane reads each
texture in about two calls and releases promptly, so 31 open files held roughly
**two** resident tiles. Multiplying the open count by the tile size overstated
the requirement by ~16×; real headroom is about **24×** (the cap holds 48 tiles).

The constant's doc comment and `docs/dev/memory-telemetry.md` now both say:
size against `dds_pinned_peak_mb`, never against `dds_handles_peak`.

## Documented rather than fixed

The cap is **soft** — admission tests `pinned + expected` without reserving, so
concurrent opens can pass together and overshoot. Reserving on `open()` would be
worse: X-Plane may open a file it never reads, so reservations would be held for
tiles that never exist and the cap would engage falsely. Immaterial at the
measured headroom; the new counter is what reports if that changes.

## Verification

`make pre-commit` green — 2,499 tests. Four new tests, all mutation-verified:

| Mutation | Test that fails |
|---|---|
| latch removed (warn every time) | `test_budget_warning_is_latched`, `test_claim_budget_warning_is_one_shot` |
| metrics emit removed | `test_open_past_budget_counts_every_refusal` |
| daemon counter assigns instead of `+=` | `test_handle_budget_exhausted_accumulates` |

The budget refusal path had **no test at all** before this; `test_open_past_budget_refuses_memoisation` now covers it.

The latch test initially asserted the flag rather than the claim and passed
under the first mutation above. `claim_budget_warning()` was extracted so the
one-shot contract is the thing asserted.

## Note on the evidence

The 10–21 MiB figures come from the session record of two scene loads (KDEN
warm, KSLC cold, 2026-08-19), not from a file that still exists —
`~/.xearthlayer/xearthlayer.log` is overwritten each run. They are stated in the
docs as those two loads on one machine, not as a general result. The counter
this PR adds is partly so the next flight leaves durable evidence.

`[Unreleased]` is intentionally untouched; the CHANGELOG is compiled at
release-cut time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
