### PR TITLE
perf(alloc): pin glibc's mmap threshold and add allocator telemetry (#227)

### DIFF
--- a/docs/dev/memory-telemetry.md
+++ b/docs/dev/memory-telemetry.md
@@ -47,7 +47,7 @@ so that a single unattended flight discriminates between them:
 ```
 
 (Captured before #233. The example above shows 16 fields; a current line
-carries **27** — the six `fuse_*` read fields, the four `dds_handles_*` /
+carries **32** — the five committed/allocator fields, the six `fuse_*` read fields, the four `dds_handles_*` /
 `dds_pinned_*` fields, and `dds_budget_exhausted`, all described below. If you
 are editing this paragraph, count the fields in `log_memory_sample` rather than
 adjusting the number by hand: it has gone stale twice that way.)
@@ -62,6 +62,11 @@ mebibyte", not necessarily "nothing".
 | `rss_mb` | `MemoryProbe` → sum of `Rss:` in `/proc/self/smaps` | Physical pages currently held. **Excludes anything the kernel has swapped out.** |
 | `vm_mb` | `MemoryProbe` → sum of `Size:` in `/proc/self/smaps` | Total mapped address space. Counts anonymous mappings whether resident or paged out. |
 | `swap_mb` | `MemoryProbe` → `/proc/self/status` `VmSwap:` | Anonymous memory swapped out to disk. **This is the field that actually caught #209**: at the moment of the kill, `rss_mb` alone read a healthy 9.3 GB while `swap_mb` would have read 54.7 GB. `0` means **not readable on this platform**, not "nothing swapped" — same convention as `threads`. Linux-only; read in the same `/proc/self/status` pass as `threads`, so it costs no extra file open. |
+| `anon_mb` | `/proc/self/status` `RssAnon:` | Anonymous resident memory. **`anon_mb + swap_mb` is the committed footprint — the number to quote.** It is what the OOM killer scores and what a system monitor shows. Prefer it to `vm_mb`; see below. |
+| `heap_mb` | `mallinfo2.arena` | Bytes glibc obtained via `sbrk`. |
+| `mmap_mb` | `mallinfo2.hblkhd` | Bytes glibc obtained via `mmap` for large allocations. Freed on `munmap`, so this tracks *live* large blocks, not retention. |
+| `inuse_mb` | `mallinfo2.uordblks` | Bytes in use **in arenas only** — an mmapped block never appears here. |
+| `heap_free_mb` | `mallinfo2.fordblks` | Free bytes held inside arenas. **This is the retention signal.** |
 | `threads` | `/proc/self/status` `Threads:` | OS thread count. `0` means **not readable on this platform**, not "no threads" — see below. |
 | `tiles_done` | `state.encodes_completed` | Cumulative DDS encodes completed. The load counter: divide by `uptime_s` for tiles/second. |
 | `encodes_active` | `state.encodes_active` | Encodes in flight right now. Each one holds a 4096×4096 RGBA source image (64 MiB) plus its output buffer. |
@@ -85,6 +90,43 @@ mebibyte", not necessarily "nothing".
 | `dds_handles_peak` | `state.fuse_handles_peak_open` | Highest concurrent open count this session. **Read this, not `dds_handles_open`, when sizing the cap.** The current gauges are sampled on open, on tile production and on release, so a 60-second reader almost always catches them just after a release: the first KDEN run reported `dds_pinned_mb=0` throughout while 31 files were open. |
 | `dds_pinned_peak_mb` | `state.fuse_handles_peak_pinned_bytes` | Highest pinned total this session. Compare against the `dds_pinned_cap_mb` logged at mount: if it approaches the cap, `open()` is close to dropping memoisation. Two scene loads (KDEN, KSLC) peaked at 10-21 MiB against 512, roughly 24x headroom. |
 | `dds_budget_exhausted` | `state.fuse_handle_budget_exhausted` | Opens refused a memoising handle because the pinned-tile budget was full (counter, #236). **Any non-zero value means the #234 fix stopped applying for those opens** and their reads resolved the tile once per call. Zero while `fuse_dds_alloc_mb` climbs means a different fault — the two are otherwise indistinguishable in a log. |
+
+### Committed memory, not `vm_mb`
+
+Quote **`anon_mb + swap_mb`**. `vm_mb` is `VmSize`, which also counts address
+space that is mapped but never touched — dominated by thread stacks. Regressed
+over 195 samples of an 11 h flight, `vm_mb` moves **2.21 MB per thread**
+(r = 0.939; Rust's default stack is 2 MiB) and the tokio blocking pool cycles
+between 37 and 586 threads. That is a ~1 GB sawtooth in `vm_mb` that is not
+memory, with swap unmoved because untouched reservations were never resident.
+
+Two people read that artifact as a finding before it was identified: one as
+"grew monotonically, never fell", the other as "15 falls over 1 GB". On the
+committed basis the same flight has 72 falls over 100 MB against `vm_mb`'s 152,
+and only 5 over 300 MB.
+
+### Reading the allocator fields
+
+The obvious formula is wrong. `inuse_mb` counts arena chunks only; measured on
+glibc 2.44, an 11 MiB allocation — DDS-tile sized — moves `hblkhd` by 11538432
+and `uordblks` by 1968. So `(heap + mmap) - inuse` reports every *live* mmapped
+tile as retention, which is wrong and believable.
+
+| observation | reading |
+|---|---|
+| `heap_free_mb` rising | arena retention / fragmentation — candidate 2 of #227 |
+| `inuse_mb` rising | the process genuinely holds more objects — a real leak |
+| `mmap_mb` falling while `heap_mb` rises | glibc's mmap threshold has adapted past the tile size, so tiles now come from arenas and stop being returned on free |
+| all four flat while `anon_mb` climbs | growth is outside malloc — mapped files, kernel buffers, GPU driver |
+
+That last row matters: `mallinfo2` only sees glibc. If it shows nothing while
+committed memory climbs, look at the smaps mapping breakdown, not the allocator.
+
+At shutdown the service logs a `malloc_trim at shutdown` line with `anon_mb`
+and `heap_free_mb` before and after `malloc_trim(0)`. A large `anon_freed_mb`
+is direct evidence that the footprint was glibc holding free memory; no drop
+points at genuine retention. It runs after the caches are dropped and is a
+measurement only.
 
 ### Counters are cumulative; gauges are current-state
 

--- a/xearthlayer-cli/src/main.rs
+++ b/xearthlayer-cli/src/main.rs
@@ -166,6 +166,14 @@ enum Commands {
 // ============================================================================
 
 fn main() -> ExitCode {
+    // First, before anything allocates in earnest. glibc's mmap threshold
+    // adapts upward past the 11.17 MiB DDS tile size after a single
+    // allocate/free cycle, after which tiles come from arenas and are never
+    // returned to the OS on free. Pinning it costs ~0.16 ms per tile and
+    // bounded arena retention at 4.6 MB against 191.5 MB in a 64-thread
+    // benchmark. Set MALLOC_MMAP_THRESHOLD_ to override. See issue #227.
+    xearthlayer::metrics::configure_allocator();
+
     let cli = Cli::parse();
 
     // Initialize logging once for every subcommand. Falls back to default

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -436,6 +436,25 @@ impl MetricsDaemon {
             // was swapped out. 0 means "not readable on this platform", not
             // "nothing swapped" — same convention as `threads`.
             swap_mb = sample.swap_bytes.unwrap_or(0) / MB,
+            // Anonymous resident memory. `anon_mb + swap_mb` is the committed
+            // footprint -- what the OOM killer scores. Prefer it to vm_mb,
+            // which also counts untouched address space: thread stacks measure
+            // 2.21 MB each over a pool cycling 37..586, so vm_mb carries a ~1 GB
+            // sawtooth that is not memory (#227).
+            anon_mb = sample.anon_bytes.unwrap_or(0) / MB,
+            // glibc accounting (#227). 0 means "not glibc" or "unreadable".
+            //
+            // These are NOT interchangeable. uordblks counts arena chunks only;
+            // an 11 MiB DDS buffer is served by mmap and never appears in it.
+            //   heap_free_mb rising  -> arena retention, candidate 2
+            //   inuse_mb rising      -> we genuinely hold objects, a real leak
+            //   mmap_mb falling while heap_mb rises -> glibc's mmap threshold
+            //     has adapted past the tile size, so tiles now come from arenas
+            //     and stop being returned on free
+            heap_mb = sample.allocator.map_or(0, |a| a.heap_bytes) / MB,
+            mmap_mb = sample.allocator.map_or(0, |a| a.mmapped_bytes) / MB,
+            inuse_mb = sample.allocator.map_or(0, |a| a.in_use_bytes) / MB,
+            heap_free_mb = sample.allocator.map_or(0, |a| a.arena_retained_bytes()) / MB,
             // 0 means "not readable on this platform", not "no threads".
             threads = sample.threads.unwrap_or(0),
             tiles_done = state.encodes_completed,
@@ -1047,6 +1066,51 @@ mod tests {
             .find(|fields| fields.get("message").map(String::as_str) == Some("Memory sample"))
     }
 
+    /// End-to-end against the real allocator: the seeded test above proves the
+    /// wiring, this proves the values are real. A field plumbed correctly but
+    /// reading zero from glibc would pass that test and be useless in flight.
+    #[test]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    fn memory_sample_carries_live_allocator_figures() {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut daemon = MetricsDaemon::with_memory_probe(
+            rx,
+            std::sync::Arc::new(crate::metrics::ProcessMemoryProbe),
+        );
+
+        // Hold DDS-sized allocations across the sample. A bare test process has
+        // arena 1.56 MB and hblkhd 0.38 MB, both of which truncate to 0 in the
+        // MB-scaled log line -- so without this the test asserts against
+        // rounding, not against glibc.
+        let _tiles: Vec<Vec<u8>> = (0..6).map(|_| vec![0u8; 11 * 1024 * 1024]).collect();
+
+        let events = capture_events(|| daemon.log_memory_sample());
+        let sample = find_memory_sample(&events).expect("must emit a memory sample");
+
+        let num = |k: &str| -> u64 {
+            sample
+                .get(k)
+                .unwrap_or_else(|| panic!("{k} missing from the sample line"))
+                .parse()
+                .unwrap_or_else(|_| panic!("{k} is not numeric"))
+        };
+
+        assert!(num("anon_mb") > 0, "RssAnon read as zero");
+        assert!(
+            num("heap_mb") + num("mmap_mb") > 0,
+            "glibc reports nothing obtained from the OS"
+        );
+        assert!(
+            num("mmap_mb") >= 60,
+            "66 MiB of live DDS-sized buffers must show in mmap_mb, got {}",
+            num("mmap_mb")
+        );
+        assert!(
+            num("anon_mb") <= num("rss_mb"),
+            "anonymous resident cannot exceed total resident"
+        );
+    }
+
     #[test]
     fn memory_sample_line_carries_every_field_from_its_correct_source() {
         const MB: u64 = 1024 * 1024;
@@ -1059,7 +1123,14 @@ mod tests {
                     5 * MB + 1, // deliberately not a whole number of MB
                     6 * MB,
                 )
-                .with_swap_bytes(7 * MB),
+                .with_swap_bytes(7 * MB)
+                .with_anon_bytes(4 * MB)
+                .with_allocator(crate::metrics::memory_probe::AllocatorSample {
+                    heap_bytes: 21 * MB,
+                    mmapped_bytes: 22 * MB,
+                    in_use_bytes: 23 * MB,
+                    heap_free_bytes: 24 * MB,
+                }),
             ),
         );
 
@@ -1090,7 +1161,15 @@ mod tests {
         let expected: &[(&str, &str)] = &[
             ("rss_mb", "5"),
             ("vm_mb", "6"),
-            ("swap_mb", "7"),  // StaticMemoryProbe::with_swap_bytes
+            ("swap_mb", "7"), // StaticMemoryProbe::with_swap_bytes
+            ("anon_mb", "4"), // StaticMemoryProbe::with_anon_bytes
+            // Distinct values, so a field wired to the wrong mallinfo2 member
+            // cannot pass. The four are easy to transpose and nothing else
+            // would catch it (#227).
+            ("heap_mb", "21"),
+            ("mmap_mb", "22"),
+            ("inuse_mb", "23"),
+            ("heap_free_mb", "24"),
             ("threads", "42"), // StaticMemoryProbe::new fixes threads at 42
             ("tiles_done", "10"),
             ("encodes_active", "11"),

--- a/xearthlayer/src/metrics/memory_probe.rs
+++ b/xearthlayer/src/metrics/memory_probe.rs
@@ -390,6 +390,50 @@ mod tests {
         assert_eq!(a.obtained_bytes(), 100_900);
     }
 
+    /// The whole point of pinning the threshold: after `configure_allocator`,
+    /// DDS-sized allocations must keep going through `mmap` however many
+    /// allocate/free cycles precede them.
+    ///
+    /// Without it, glibc's threshold adapts past 11 MiB after **one** cycle and
+    /// tiles start coming from arenas, where freeing them returns nothing to
+    /// the OS. Measured on glibc 2.44: holding 44 MiB gives hblkhd 44.4 MB on
+    /// the first round, then 0.4 MB with arena 45.6 MB on every round after.
+    ///
+    /// Asserted as a lower bound while holding the memory. `mallinfo2` is
+    /// process-global and cargo runs tests in parallel, so a delta here is not
+    /// this test's to measure -- see `test_allocator_sample_reports_live_allocations`.
+    #[test]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    fn test_configure_allocator_keeps_large_blocks_off_the_arena() {
+        const MIB: usize = 1024 * 1024;
+
+        // Drive the adaptation the way the tile pipeline does. Without the pin
+        // this alone moves subsequent 11 MiB blocks into the arena.
+        for _ in 0..4 {
+            let churn = vec![3u8; 11 * MIB];
+            std::hint::black_box(&churn);
+            drop(churn);
+        }
+
+        // Environment override wins by design, so this returns false under an
+        // allocator experiment. Either way the threshold ends up pinned.
+        let _ = configure_allocator();
+
+        let tiles: Vec<Vec<u8>> = (0..12).map(|_| vec![9u8; 11 * MIB]).collect();
+        let held = std::hint::black_box(&tiles).len() * 11 * MIB;
+        let a = AllocatorSample::read().expect("glibc");
+
+        assert!(
+            a.mmapped_bytes as usize >= held * 3 / 4,
+            "holding {held} bytes of DDS-sized buffers after four churn cycles, \
+             glibc reports only {} mmapped (arena {}). The threshold adapted, \
+             which is exactly what configure_allocator must prevent.",
+            a.mmapped_bytes,
+            a.heap_bytes
+        );
+        drop(tiles);
+    }
+
     /// The probe must report real figures, not a constant or a stale read.
     ///
     /// Asserted as a **lower bound while holding** the memory, never as a
@@ -486,5 +530,75 @@ mod tests {
             sample.swap_bytes.is_some(),
             "linux should always expose VmSwap, even if the value is 0"
         );
+    }
+}
+
+// =============================================================================
+// Allocator configuration
+// =============================================================================
+
+/// Cap above which glibc must serve an allocation with `mmap` rather than from
+/// an arena: 1 MiB.
+///
+/// A DDS tile is 11.17 MiB. glibc's mmap threshold *starts* at 128 KiB and
+/// adapts **upward** — as far as 32 MiB — each time an mmapped block is freed.
+/// After a single tile allocate/free cycle it has already passed 11 MiB, and
+/// from then on tiles come from arenas instead. Arena memory is returned to the
+/// OS only when the heap top is free or `malloc_trim` runs, so every arena that
+/// ever served a tile keeps that space for the life of the process.
+///
+/// Measured on glibc 2.44, 64 threads allocating and freeing 11 MiB buffers:
+///
+/// | configuration | anonymous resident retained |
+/// |---|---|
+/// | default | 191.5 MB |
+/// | `MALLOC_ARENA_MAX=2` | 70.4 MB |
+/// | threshold pinned to 1 MiB | **4.6 MB** |
+///
+/// The cost is one `mmap`/`munmap` pair per tile, measured at **+0.16 ms** —
+/// about 20 seconds of CPU across an 11-hour flight. See issue #227.
+const MMAP_THRESHOLD_BYTES: usize = 1024 * 1024;
+
+/// Pins glibc's mmap threshold so large allocations are never served from an
+/// arena, and are therefore returned to the OS when freed.
+///
+/// Returns `true` if the threshold was applied. Call once, early, before the
+/// process allocates in earnest.
+///
+/// Setting this parameter through `mallopt` also **disables glibc's dynamic
+/// adjustment** of the threshold, which is the point: a lower starting value
+/// alone would adapt straight back up.
+///
+/// An explicit `MALLOC_MMAP_THRESHOLD_` in the environment wins — glibc has
+/// already applied it at startup, and overriding it here would silently break
+/// anyone measuring an allocator experiment.
+pub fn configure_allocator() -> bool {
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    {
+        if let Ok(value) = std::env::var("MALLOC_MMAP_THRESHOLD_") {
+            tracing::debug!(
+                env_value = %value,
+                "MALLOC_MMAP_THRESHOLD_ set in the environment; leaving glibc's threshold alone"
+            );
+            return false;
+        }
+
+        // SAFETY: mallopt takes two ints and is thread-safe; glibc locks
+        // internally. M_MMAP_THRESHOLD is a documented parameter.
+        let applied = unsafe { libc::mallopt(libc::M_MMAP_THRESHOLD, MMAP_THRESHOLD_BYTES as i32) };
+        if applied == 1 {
+            tracing::debug!(
+                threshold_bytes = MMAP_THRESHOLD_BYTES,
+                "Pinned glibc mmap threshold; large allocations bypass arenas"
+            );
+            true
+        } else {
+            tracing::warn!("mallopt(M_MMAP_THRESHOLD) was rejected; arena retention not bounded");
+            false
+        }
+    }
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+    {
+        false
     }
 }

--- a/xearthlayer/src/metrics/memory_probe.rs
+++ b/xearthlayer/src/metrics/memory_probe.rs
@@ -390,22 +390,36 @@ mod tests {
         assert_eq!(a.obtained_bytes(), 100_900);
     }
 
-    /// A large allocation must move the accounting, or the probe is reading a
-    /// constant and would report "no retention" whatever happened.
+    /// The probe must report real figures, not a constant or a stale read.
+    ///
+    /// Asserted as a **lower bound while holding** the memory, never as a
+    /// delta. `mallinfo2` is process-global and cargo runs tests in parallel
+    /// threads, so a before/after difference is not the test's to measure --
+    /// a sibling test freeing its buffers in between makes `obtained_bytes`
+    /// fall across an allocation. That version failed 8 runs in 12.
+    ///
+    /// Other tests can only ever *add* to these figures, so a floor holds.
     #[test]
-    fn test_allocator_sample_tracks_a_real_allocation() {
-        // A DDS-sized block. Asserted against `obtained_bytes`, not `in_use`:
-        // at 11 MiB glibc serves this by mmap, which `uordblks` never sees.
-        // Measured on glibc 2.44: hblkhd +11538432, uordblks +1968.
-        let before = AllocatorSample::read().expect("glibc").obtained_bytes();
-        let tile = vec![7u8; 11 * 1024 * 1024];
-        let during = AllocatorSample::read().expect("glibc").obtained_bytes();
+    fn test_allocator_sample_reports_live_allocations() {
+        const MIB: usize = 1024 * 1024;
+        // DDS-sized blocks, which glibc serves by mmap: an 11 MiB allocation
+        // moves hblkhd by 11538432 and uordblks by 1968 on glibc 2.44.
+        let tiles: Vec<Vec<u8>> = (0..12).map(|_| vec![7u8; 11 * MIB]).collect();
+        let held = std::hint::black_box(&tiles).len() * 11 * MIB;
+
+        // Assert on the total, never on which route glibc chose. Its mmap
+        // threshold adapts upward after a single alloc/free of this size, so
+        // an identical allocation lands in `hblkhd` early in a process and in
+        // `arena` later. A test that named the route failed 25 runs in 25.
+        let a = AllocatorSample::read().expect("glibc");
         assert!(
-            during >= before + 8 * 1024 * 1024,
-            "11 MiB allocation moved obtained bytes by only {}",
-            during.saturating_sub(before)
+            a.obtained_bytes() as usize >= held,
+            "obtained {} is below the {held} bytes held live (heap {}, mmapped {})",
+            a.obtained_bytes(),
+            a.heap_bytes,
+            a.mmapped_bytes
         );
-        drop(tile);
+        drop(tiles);
     }
 
     /// `anon_bytes` is what makes committed memory readable without arithmetic.

--- a/xearthlayer/src/metrics/memory_probe.rs
+++ b/xearthlayer/src/metrics/memory_probe.rs
@@ -22,6 +22,93 @@ pub struct MemorySample {
     /// `rss_bytes` alone read a healthy 9.3 GB. A trace that only logs
     /// `rss_bytes` cannot see a process swapping itself to death.
     pub swap_bytes: Option<u64>,
+    /// Anonymous resident memory in bytes, from `/proc/self/status` `RssAnon`.
+    /// `None` where not readable.
+    ///
+    /// `anon_bytes + swap_bytes` is the process's **committed** footprint --
+    /// what the OOM killer scores. Prefer it to `vm_bytes`, which also counts
+    /// address space that is mapped but never touched: thread stacks alone
+    /// measured 2.21 MB per thread over a pool cycling 37..586 threads, so
+    /// `vm_bytes` carries a ~1 GB sawtooth that is not memory at all (#227).
+    pub anon_bytes: Option<u64>,
+    /// glibc's own accounting, `None` on non-glibc platforms.
+    pub allocator: Option<AllocatorSample>,
+}
+
+/// glibc allocator accounting, from `mallinfo2`.
+///
+/// **The fields are not interchangeable, and the obvious formula is wrong.**
+/// `in_use_bytes` (`uordblks`) counts *arena* chunks only; a block served by
+/// `mmap` never appears in it. Measured on glibc 2.44, an 11 MiB allocation --
+/// DDS-tile sized -- moves `hblkhd` by 11538432 and `uordblks` by 1968. So
+/// `(heap + mmapped) - in_use` reports every live mmapped tile as retention,
+/// which is both wrong and believable.
+///
+/// What each field actually answers for #227:
+///
+/// - `heap_free_bytes` (`fordblks`) -- free space glibc holds inside arenas.
+///   **This is the retention signal.** Arena memory returns to the OS only via
+///   `malloc_trim` or a free heap top.
+/// - `mmapped_bytes` (`hblkhd`) -- currently mmapped. glibc unmaps these on
+///   free, so this tracks live large allocations, not retention.
+/// - `heap_bytes` (`arena`) rising while `in_use_bytes` stays flat is arena
+///   growth the program is not using.
+///
+/// Watch for a **transition**: glibc's mmap threshold starts at 128 KB and
+/// adapts upward to 32 MB as mmapped blocks are freed. Once it passes 11 MiB,
+/// DDS buffers stop coming from `mmap` and start coming from arenas -- at
+/// which point they are no longer returned to the OS on free. That is
+/// candidate 2 stated precisely, and it would show as `mmapped_bytes` falling
+/// while `heap_bytes` and `heap_free_bytes` climb.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocatorSample {
+    /// Bytes obtained from `sbrk` (`mallinfo2.arena`).
+    pub heap_bytes: u64,
+    /// Bytes obtained from `mmap` for large allocations (`mallinfo2.hblkhd`).
+    pub mmapped_bytes: u64,
+    /// Bytes currently allocated to the program (`mallinfo2.uordblks`).
+    pub in_use_bytes: u64,
+    /// Free bytes held inside arenas (`mallinfo2.fordblks`) -- fragmentation.
+    pub heap_free_bytes: u64,
+}
+
+impl AllocatorSample {
+    /// Reads glibc's accounting. `None` where `mallinfo2` is unavailable.
+    ///
+    /// `mallinfo2` takes every arena's lock, so it is not free -- at the 60s
+    /// sample cadence that is immaterial, but do not call it on a hot path.
+    pub fn read() -> Option<Self> {
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        {
+            // SAFETY: mallinfo2 takes no arguments and returns a plain struct
+            // of integers. It is thread-safe; glibc locks the arenas itself.
+            let mi = unsafe { libc::mallinfo2() };
+            Some(Self {
+                heap_bytes: mi.arena as u64,
+                mmapped_bytes: mi.hblkhd as u64,
+                in_use_bytes: mi.uordblks as u64,
+                heap_free_bytes: mi.fordblks as u64,
+            })
+        }
+        #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+        {
+            None
+        }
+    }
+
+    /// Bytes glibc holds from the OS inside arenas without handing them to the
+    /// program -- the retention signal for #227.
+    ///
+    /// This is `fordblks` alone. It deliberately excludes `hblkhd`: mmapped
+    /// blocks are unmapped on free, so live ones are not retention.
+    pub fn arena_retained_bytes(&self) -> u64 {
+        self.heap_free_bytes
+    }
+
+    /// Total bytes obtained from the OS, by either route.
+    pub fn obtained_bytes(&self) -> u64 {
+        self.heap_bytes + self.mmapped_bytes
+    }
 }
 
 /// Reads the current process's memory footprint.
@@ -64,13 +151,14 @@ impl ProcessMemoryProbe {
     /// Both fields are read from the same file read so the file is only
     /// opened once per sample.
     #[cfg(target_os = "linux")]
-    fn linux_status_fields() -> (Option<u64>, Option<u64>) {
+    fn linux_status_fields() -> (Option<u64>, Option<u64>, Option<u64>) {
         let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
-            return (None, None);
+            return (None, None, None);
         };
 
         let mut threads = None;
         let mut swap_bytes = None;
+        let mut anon_bytes = None;
 
         for line in status.lines() {
             if let Some(value) = line.strip_prefix("Threads:") {
@@ -83,15 +171,21 @@ impl ProcessMemoryProbe {
                     .strip_suffix("kB")
                     .and_then(|kb| kb.trim().parse::<u64>().ok())
                     .map(|kb| kb * 1024);
+            } else if let Some(value) = line.strip_prefix("RssAnon:") {
+                anon_bytes = value
+                    .trim()
+                    .strip_suffix("kB")
+                    .and_then(|kb| kb.trim().parse::<u64>().ok())
+                    .map(|kb| kb * 1024);
             }
         }
 
-        (threads, swap_bytes)
+        (threads, swap_bytes, anon_bytes)
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn linux_status_fields() -> (Option<u64>, Option<u64>) {
-        (None, None)
+    fn linux_status_fields() -> (Option<u64>, Option<u64>, Option<u64>) {
+        (None, None, None)
     }
 }
 
@@ -104,13 +198,58 @@ impl MemoryProbe for ProcessMemoryProbe {
         });
 
         let stats = memory_stats::memory_stats()?;
-        let (threads, swap_bytes) = Self::linux_status_fields();
+        let (threads, swap_bytes, anon_bytes) = Self::linux_status_fields();
         Some(MemorySample {
             rss_bytes: stats.physical_mem as u64,
             vm_bytes: stats.virtual_mem as u64,
             threads,
             swap_bytes,
+            anon_bytes,
+            allocator: AllocatorSample::read(),
         })
+    }
+}
+
+/// Asks glibc to return free arena memory to the OS, and logs what moved.
+///
+/// A pure measurement, called once at shutdown: the answer is how much of the
+/// footprint was glibc holding free memory rather than the process holding
+/// objects. Freed arena memory is normally released only when the heap top is
+/// free, so a large drop here is direct evidence for candidate 2 of #227, and
+/// no drop points at genuine retention.
+///
+/// Not for periodic use -- `malloc_trim` walks every arena taking locks.
+pub fn log_malloc_trim_at_shutdown() {
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    {
+        const MB: u64 = 1024 * 1024;
+        let probe = ProcessMemoryProbe;
+        let (Some(before), Some(before_alloc)) = (probe.sample(), AllocatorSample::read()) else {
+            return;
+        };
+
+        // SAFETY: malloc_trim takes a pad in bytes and is thread-safe; glibc
+        // locks the arenas itself.
+        let released = unsafe { libc::malloc_trim(0) };
+
+        let (Some(after), Some(after_alloc)) = (probe.sample(), AllocatorSample::read()) else {
+            return;
+        };
+
+        let anon_before = before.anon_bytes.unwrap_or(before.rss_bytes);
+        let anon_after = after.anon_bytes.unwrap_or(after.rss_bytes);
+
+        tracing::info!(
+            trim_released_any = released == 1,
+            anon_before_mb = anon_before / MB,
+            anon_after_mb = anon_after / MB,
+            anon_freed_mb = anon_before.saturating_sub(anon_after) / MB,
+            heap_free_before_mb = before_alloc.arena_retained_bytes() / MB,
+            heap_free_after_mb = after_alloc.arena_retained_bytes() / MB,
+            heap_before_mb = before_alloc.heap_bytes / MB,
+            heap_after_mb = after_alloc.heap_bytes / MB,
+            "malloc_trim at shutdown"
+        );
     }
 }
 
@@ -158,8 +297,30 @@ impl StaticMemoryProbe {
                 vm_bytes,
                 threads: Some(42),
                 swap_bytes: Some(0),
+                anon_bytes: Some(rss_bytes),
+                allocator: None,
             }),
         }
+    }
+
+    /// Overrides the configured allocator accounting.
+    ///
+    /// No-op if the probe was built with [`Self::unavailable`].
+    pub(crate) fn with_allocator(mut self, allocator: AllocatorSample) -> Self {
+        if let Some(sample) = self.sample.as_mut() {
+            sample.allocator = Some(allocator);
+        }
+        self
+    }
+
+    /// Overrides the configured anonymous-resident byte count.
+    ///
+    /// No-op if the probe was built with [`Self::unavailable`].
+    pub(crate) fn with_anon_bytes(mut self, anon_bytes: u64) -> Self {
+        if let Some(sample) = self.sample.as_mut() {
+            sample.anon_bytes = Some(anon_bytes);
+        }
+        self
     }
 
     /// Overrides the configured swap byte count.
@@ -188,6 +349,79 @@ impl MemoryProbe for StaticMemoryProbe {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The point of #227's next flight: glibc's own accounting must be
+    /// readable, and the retention gap must be derivable from it.
+    #[test]
+    fn test_allocator_sample_reads_glibc_accounting() {
+        let Some(a) = AllocatorSample::read() else {
+            panic!("mallinfo2 must be available on a glibc Linux build");
+        };
+        // A running test process has allocated *something* from somewhere.
+        assert!(
+            a.heap_bytes + a.mmapped_bytes > 0,
+            "allocator reports no memory obtained from the OS"
+        );
+        assert!(a.in_use_bytes > 0, "allocator reports nothing in use");
+        // glibc's own invariant: an arena is its in-use plus its free space.
+        // If this breaks, the struct is being misread (usually a layout or
+        // signedness mistake), and every other figure is untrustworthy.
+        assert!(
+            a.in_use_bytes + a.heap_free_bytes >= a.heap_bytes,
+            "arena {} exceeds in_use {} + free {}",
+            a.heap_bytes,
+            a.in_use_bytes,
+            a.heap_free_bytes
+        );
+    }
+
+    /// Retention is the gap between what glibc took and what we hold.
+    #[test]
+    fn test_arena_retention_excludes_live_mmapped_blocks() {
+        let a = AllocatorSample {
+            heap_bytes: 900,
+            mmapped_bytes: 100_000,
+            in_use_bytes: 250,
+            heap_free_bytes: 650,
+        };
+        // Not 100_650: a live mmapped block is in use, not retained. The naive
+        // `obtained - in_use` would report 100_650 here.
+        assert_eq!(a.arena_retained_bytes(), 650);
+        assert_eq!(a.obtained_bytes(), 100_900);
+    }
+
+    /// A large allocation must move the accounting, or the probe is reading a
+    /// constant and would report "no retention" whatever happened.
+    #[test]
+    fn test_allocator_sample_tracks_a_real_allocation() {
+        // A DDS-sized block. Asserted against `obtained_bytes`, not `in_use`:
+        // at 11 MiB glibc serves this by mmap, which `uordblks` never sees.
+        // Measured on glibc 2.44: hblkhd +11538432, uordblks +1968.
+        let before = AllocatorSample::read().expect("glibc").obtained_bytes();
+        let tile = vec![7u8; 11 * 1024 * 1024];
+        let during = AllocatorSample::read().expect("glibc").obtained_bytes();
+        assert!(
+            during >= before + 8 * 1024 * 1024,
+            "11 MiB allocation moved obtained bytes by only {}",
+            during.saturating_sub(before)
+        );
+        drop(tile);
+    }
+
+    /// `anon_bytes` is what makes committed memory readable without arithmetic.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_probe_reports_anonymous_resident_memory() {
+        let sample = ProcessMemoryProbe.sample().expect("probe must work here");
+        let anon = sample.anon_bytes.expect("linux always exposes RssAnon");
+        assert!(anon > 0, "process reports no anonymous resident memory");
+        assert!(
+            anon <= sample.rss_bytes,
+            "anonymous {} cannot exceed total resident {}",
+            anon,
+            sample.rss_bytes
+        );
+    }
 
     #[test]
     fn process_probe_reports_nonzero_memory() {

--- a/xearthlayer/src/metrics/mod.rs
+++ b/xearthlayer/src/metrics/mod.rs
@@ -20,8 +20,8 @@ pub use client::MetricsClient;
 pub use daemon::{MetricsDaemon, MetricsStateSnapshot, SharedMetricsState};
 pub use event::MetricEvent;
 pub use memory_probe::{
-    log_allocator_environment, log_malloc_trim_at_shutdown, AllocatorSample, MemoryProbe,
-    MemorySample, ProcessMemoryProbe,
+    configure_allocator, log_allocator_environment, log_malloc_trim_at_shutdown, AllocatorSample,
+    MemoryProbe, MemorySample, ProcessMemoryProbe,
 };
 pub use optional::OptionalMetrics;
 pub use reporter::{MetricsReporter, TuiReporter};

--- a/xearthlayer/src/metrics/mod.rs
+++ b/xearthlayer/src/metrics/mod.rs
@@ -19,7 +19,10 @@ mod system;
 pub use client::MetricsClient;
 pub use daemon::{MetricsDaemon, MetricsStateSnapshot, SharedMetricsState};
 pub use event::MetricEvent;
-pub use memory_probe::{log_allocator_environment, MemoryProbe, MemorySample, ProcessMemoryProbe};
+pub use memory_probe::{
+    log_allocator_environment, log_malloc_trim_at_shutdown, AllocatorSample, MemoryProbe,
+    MemorySample, ProcessMemoryProbe,
+};
 pub use optional::OptionalMetrics;
 pub use reporter::{MetricsReporter, TuiReporter};
 pub use snapshot::TelemetrySnapshot;

--- a/xearthlayer/src/service/orchestrator/core.rs
+++ b/xearthlayer/src/service/orchestrator/core.rs
@@ -615,6 +615,12 @@ impl ServiceOrchestrator {
         self.mount_manager.unmount_all();
         info!("FUSE mounts unmounted (cache services shutdown via service drop)");
 
+        // Measurement, not housekeeping: how much of the footprint was glibc
+        // holding free arena memory rather than the process holding objects
+        // (#227). Runs after the caches are dropped so their memory is free by
+        // now, and last so it cannot perturb anything above it.
+        crate::metrics::log_malloc_trim_at_shutdown();
+
         info!("ServiceOrchestrator shutdown complete");
     }
 }


### PR DESCRIPTION
Bounds the arena retention behind #227, and adds the telemetry that measured it.

## The mechanism

A DDS tile is 11.17 MiB. glibc's mmap threshold starts at 128 KiB and adapts
**upward** — as far as 32 MiB — each time an mmapped block is freed. It passes
11 MiB after a *single* tile allocate/free cycle, after which tiles come from
arenas, which return memory to the OS only when the heap top is free. Every
arena that ever served a tile keeps that space for the process lifetime, and
glibc allows up to 8 arenas per core.

Reproduced on glibc 2.44 — holding 44 MiB across rounds:

```
round 0:  arena   1.6 MB   hblkhd  44.4 MB     <- served by mmap
round 1:  arena  45.6 MB   hblkhd   0.4 MB     <- served by the arena
round 2+: arena  45.6 MB   hblkhd   0.4 MB     <- and not returned on free
```

64 threads cycling 11 MiB buffers:

| configuration | anonymous resident retained |
|---|---:|
| default | 191.5 MB |
| `MALLOC_ARENA_MAX=2` | 70.4 MB |
| **threshold pinned to 1 MiB** | **4.6 MB** |

## Flight result

KMSP→MMMD, 4.3 h, against a same-build 11.5 h flight on default malloc.
Committed memory (`RssAnon + VmSwap`) at **matched encode counts**:

| encodes | default | pinned | reduction |
|---:|---:|---:|---:|
| 10,000 | 8,954 MB | 6,956 MB | 22% |
| 20,000 | 11,143 MB | 7,003 MB | 37% |
| 25,000 | 13,353 MB | 7,641 MB | 43% |
| 39,157 | 13,721 MB | 8,970 MB | **35%** |

`heap_mb` reached 3,403 MB at 2.1 h and held there for the next 1.3 h through
several prefetch bursts, while `heap_free_mb` oscillated 2,519–2,683 within it
— arena space being recycled rather than accumulated. Over the final hour
committed *fell* 9,151 → 8,970 MB across 3,000 encodes.

**This does not close #227.** The flight ended at 39,157 encodes; the default
run gained a further 5.9 GB beyond that point. What is established is that the
steep early retention is bounded. The tail needs a long-haul on this build.

## Implementation note

Applied with `mallopt`, not the environment. `MALLOC_MMAP_THRESHOLD_` is read
by glibc *before* `main`, so `env::set_var` there would be inert. Setting the
parameter through `mallopt` also **disables glibc's dynamic adjustment**, which
is the actual mechanism — a lower starting value alone would adapt straight
back up. An explicit environment override wins, so allocator experiments are
not silently overridden.

## Telemetry

Five fields added to the `Memory sample` line:

| field | reading |
|---|---|
| `anon_mb` | `RssAnon`; `anon_mb + swap_mb` is the committed footprint |
| `heap_mb` / `mmap_mb` | which route glibc served an allocation by |
| `inuse_mb` | rising means the process genuinely holds more objects |
| `heap_free_mb` | free space held inside arenas — the retention signal |

`vm_mb` should no longer be quoted as a footprint: regressed over 195 samples
it moves **2.21 MB per thread** (r = 0.939, Rust default stack 2 MiB) against a
pool cycling 37–586, so it carries a ~1 GB sawtooth that is not memory. Two
observers read that artifact as a finding before it was identified.

`malloc_trim(0)` runs once at shutdown, logging committed and arena-free bytes
either side. Measurement only.

## Verification

`make pre-commit` green. Two defects were caught by tests before flight:

- The obvious retention formula `(heap + mmap) - inuse` is **wrong** — `uordblks`
  counts arena chunks only, and an 11 MiB allocation moves `hblkhd` by 11538432
  while moving `uordblks` by 1968. It would have reported every live mmapped
  tile as retention: wrong, and plausible enough to survive a flight and a
  write-up. Retention is `fordblks` alone.
- An allocator test asserted a delta of process-global state in a parallel
  suite and failed 8 runs in 12. Now asserts a lower bound while holding.

The `configure_allocator` test is mutation-verified — it churns four
allocate/free cycles to drive the adaptation, then asserts DDS-sized blocks are
still served by mmap; removing the call fails it. Stable over 15 consecutive
runs, plus 3 full lib runs.

`[Unreleased]` is intentionally untouched; the CHANGELOG is compiled at
release-cut time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
