### PR TITLE
fix(runtime): cap glibc arenas at 4, with environment override (#227)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,20 @@ applied in code, not by environment variable, and both have flight evidence:
 - **Blocking pool cap** — tokio's 512 default let the pool reach 581 threads,
   and each excursion ratcheted glibc's arena high-water mark by ~420 MB. The
   arena reached 6,166 MB while holding 572 MB of live data.
+- **`mallopt(M_ARENA_MAX, 4)`** — glibc's default of `8 x ncores` (256 here)
+  lets every burst recruit fresh arenas, each keeping its own high-water mark
+  for the life of the process, so the total is the sum of every peak ever
+  seen and never converges. Capping the count removes the supply: the sum
+  saturates once each arena has seen its worst burst. On the reference leg the
+  arena settled at 3,916 MB within six minutes and held to the byte — peak
+  concurrent demand (3,093 MB) plus ~27% headroom — against 6,091 MB still
+  climbing at hour 10.75 uncapped. Override with `MALLOC_ARENA_MAX`.
+
+Both pins defer to an explicit `MALLOC_*` variable or `GLIBC_TUNABLES` entry:
+`mallopt` silently overrides what glibc read at startup, so without that check
+a user's own setting would vanish with no diagnostic. **Both are `cfg`-gated to
+`linux-gnu`** — macOS uses libmalloc and currently has neither these fixes nor
+the allocator telemetry.
 
 DDS payloads are `bytes::Bytes` end to end (#237): a tile is 10.66 MiB and a
 FUSE read wants ~4% of it, so cloning a payload costs more than delivering it.

--- a/xearthlayer-cli/src/main.rs
+++ b/xearthlayer-cli/src/main.rs
@@ -166,12 +166,24 @@ enum Commands {
 // ============================================================================
 
 fn main() -> ExitCode {
-    // First, before anything allocates in earnest. glibc's mmap threshold
-    // adapts upward past the 11.17 MiB DDS tile size after a single
-    // allocate/free cycle, after which tiles come from arenas and are never
-    // returned to the OS on free. Pinning it costs ~0.16 ms per tile and
-    // bounded arena retention at 4.6 MB against 191.5 MB in a 64-thread
-    // benchmark. Set MALLOC_MMAP_THRESHOLD_ to override. See issue #227.
+    // First, before anything allocates in earnest, and before any thread is
+    // created — the arena ceiling only bounds arenas not yet made.
+    //
+    // Two glibc parameters, both from issue #227:
+    //
+    // - mmap threshold: glibc adapts it upward past the 10.66 MiB DDS tile
+    //   size after a single allocate/free cycle, after which tiles come from
+    //   arenas and are never returned on free. Pinning costs ~0.16 ms per tile
+    //   and bounded arena retention at 4.6 MB against 191.5 MB in a 64-thread
+    //   benchmark.
+    // - arena ceiling: glibc's default of 8 x ncores lets every burst recruit
+    //   fresh arenas, each keeping its own high-water mark forever. An
+    //   11-hour flight reached a 6,091 MB arena holding 1,002 MB of live data,
+    //   still growing at hour 10.75. Capped, the same route settled at
+    //   3,916 MB within six minutes and held to the byte.
+    //
+    // Either can be overridden with MALLOC_MMAP_THRESHOLD_ / MALLOC_ARENA_MAX
+    // or GLIBC_TUNABLES; an explicit user setting always wins.
     xearthlayer::metrics::configure_allocator();
 
     let cli = Cli::parse();

--- a/xearthlayer/src/metrics/memory_probe.rs
+++ b/xearthlayer/src/metrics/memory_probe.rs
@@ -390,6 +390,58 @@ mod tests {
         assert_eq!(a.obtained_bytes(), 100_900);
     }
 
+    /// An explicit user setting must win over our pin, because `mallopt`
+    /// silently overrides what glibc already read from the environment.
+    /// Measured on glibc 2.44 with 64 threads: `MALLOC_ARENA_MAX=64` alone
+    /// gives a 23 MB arena, but `MALLOC_ARENA_MAX=64` plus `mallopt(4)` gives
+    /// 1 MB — the user's setting vanishes with no diagnostic.
+    #[test]
+    fn an_explicit_env_setting_defers_our_pin() {
+        assert!(user_pinned(Some("8"), None, TUNABLE_ARENA_MAX));
+    }
+
+    /// `GLIBC_TUNABLES` is the second way to set the same parameter, and
+    /// `mallopt` overrides it just as silently.
+    #[test]
+    fn a_tunables_setting_defers_our_pin() {
+        assert!(user_pinned(
+            None,
+            Some("glibc.malloc.arena_max=8"),
+            TUNABLE_ARENA_MAX
+        ));
+    }
+
+    /// A tunables string that names some *other* parameter must not stop us
+    /// pinning this one. A naive `is_some()` on the variable would.
+    #[test]
+    fn unrelated_tunables_do_not_defer_our_pin() {
+        assert!(!user_pinned(
+            None,
+            Some("glibc.malloc.tcache_max=64:glibc.malloc.arena_test=2"),
+            TUNABLE_ARENA_MAX
+        ));
+    }
+
+    /// With nothing set, we pin.
+    #[test]
+    fn an_empty_environment_lets_us_pin() {
+        assert!(!user_pinned(None, None, TUNABLE_ARENA_MAX));
+    }
+
+    /// The cap must be well below glibc's default of `8 x ncores`, or pinning
+    /// it achieves nothing. Four is the value flown on 2026-08-25.
+    #[test]
+    fn arena_max_is_meaningfully_below_the_glibc_default() {
+        let glibc_default = 8 * std::thread::available_parallelism().map_or(4, |p| p.get());
+        assert!(ARENA_MAX >= 2, "at least two arenas, or contention bites");
+        assert!(
+            (ARENA_MAX as usize) < glibc_default,
+            "ARENA_MAX {} must be below glibc's default {}",
+            ARENA_MAX,
+            glibc_default
+        );
+    }
+
     /// The whole point of pinning the threshold: after `configure_allocator`,
     /// DDS-sized allocations must keep going through `mmap` however many
     /// allocate/free cycles precede them.
@@ -559,6 +611,64 @@ mod tests {
 /// about 20 seconds of CPU across an 11-hour flight. See issue #227.
 const MMAP_THRESHOLD_BYTES: usize = 1024 * 1024;
 
+/// Maximum number of glibc malloc arenas: 4.
+///
+/// glibc gives each thread an arena to avoid lock contention, defaulting to
+/// `8 x ncores` — 256 on a 32-core host. A thread keeps its arena, each arena
+/// grows to cover the worst burst *it* ever saw, and glibc returns memory only
+/// by trimming the **top** of a heap, so space stranded below a live
+/// allocation stays committed. Total arena is therefore the sum of every
+/// arena's personal high-water mark, and with 256 available a burst can always
+/// recruit fresh ones — which is why it never converges.
+///
+/// Measured over an 11-hour flight on the default ceiling: the arena reached
+/// 6,091 MB while holding 1,002 MB of live data, growing in 18 discrete steps
+/// that were still occurring at hour 10.75. Capping the count removes the
+/// supply: once every arena has seen its worst burst the sum saturates.
+///
+/// On the same route with this cap, the arena reached 3,916 MB within six
+/// minutes and then held to the byte — 151 consecutive samples, 26,360
+/// encodes, zero drift. That figure is peak concurrent demand (3,093 MB
+/// measured) plus about 27% fragmentation headroom: the arena is now sized by
+/// what the workload needs at once rather than by its history.
+///
+/// Four rather than two keeps a contention margin. The largest and most
+/// frequent allocations already bypass arenas entirely via
+/// [`MMAP_THRESHOLD_BYTES`], so what remains is one dominant size class of
+/// ~256 KiB chunk buffers — close to the best case for a low arena count.
+/// See issue #227.
+const ARENA_MAX: i32 = 4;
+
+/// The `GLIBC_TUNABLES` key that sets the arena ceiling.
+const TUNABLE_ARENA_MAX: &str = "glibc.malloc.arena_max";
+
+/// The `GLIBC_TUNABLES` key that sets the mmap threshold.
+const TUNABLE_MMAP_THRESHOLD: &str = "glibc.malloc.mmap_threshold";
+
+/// Whether the user has already pinned this parameter themselves.
+///
+/// glibc reads both `MALLOC_*` variables and `GLIBC_TUNABLES` before `main`,
+/// but a later `mallopt` silently overrides either. Measured on glibc 2.44:
+/// `MALLOC_ARENA_MAX=64` alone yields a 23 MB arena; the same variable with a
+/// subsequent `mallopt(M_ARENA_MAX, 4)` yields 1 MB. Without this check a user
+/// running an allocator experiment would have their setting discarded with no
+/// diagnostic.
+fn user_pinned(env_value: Option<&str>, tunables: Option<&str>, tunable_key: &str) -> bool {
+    env_value.is_some() || tunables.is_some_and(|t| t.contains(tunable_key))
+}
+
+/// Which allocator parameters [`configure_allocator`] pinned.
+///
+/// A parameter is `false` when the user set it themselves, when `mallopt`
+/// rejected it, or when the target is not linux-gnu.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocatorConfig {
+    /// glibc's mmap threshold was pinned to [`MMAP_THRESHOLD_BYTES`].
+    pub mmap_threshold_pinned: bool,
+    /// glibc's arena ceiling was pinned to [`ARENA_MAX`].
+    pub arena_max_pinned: bool,
+}
+
 /// Pins glibc's mmap threshold so large allocations are never served from an
 /// arena, and are therefore returned to the OS when freed.
 ///
@@ -572,33 +682,64 @@ const MMAP_THRESHOLD_BYTES: usize = 1024 * 1024;
 /// An explicit `MALLOC_MMAP_THRESHOLD_` in the environment wins — glibc has
 /// already applied it at startup, and overriding it here would silently break
 /// anyone measuring an allocator experiment.
-pub fn configure_allocator() -> bool {
+pub fn configure_allocator() -> AllocatorConfig {
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     {
-        if let Ok(value) = std::env::var("MALLOC_MMAP_THRESHOLD_") {
-            tracing::debug!(
-                env_value = %value,
-                "MALLOC_MMAP_THRESHOLD_ set in the environment; leaving glibc's threshold alone"
-            );
-            return false;
-        }
+        let tunables = std::env::var("GLIBC_TUNABLES").ok();
+        let mmap_env = std::env::var("MALLOC_MMAP_THRESHOLD_").ok();
+        let arena_env = std::env::var("MALLOC_ARENA_MAX").ok();
 
-        // SAFETY: mallopt takes two ints and is thread-safe; glibc locks
-        // internally. M_MMAP_THRESHOLD is a documented parameter.
-        let applied = unsafe { libc::mallopt(libc::M_MMAP_THRESHOLD, MMAP_THRESHOLD_BYTES as i32) };
-        if applied == 1 {
-            tracing::debug!(
-                threshold_bytes = MMAP_THRESHOLD_BYTES,
-                "Pinned glibc mmap threshold; large allocations bypass arenas"
-            );
-            true
-        } else {
-            tracing::warn!("mallopt(M_MMAP_THRESHOLD) was rejected; arena retention not bounded");
-            false
+        AllocatorConfig {
+            mmap_threshold_pinned: pin(
+                libc::M_MMAP_THRESHOLD,
+                MMAP_THRESHOLD_BYTES as i32,
+                "mmap threshold",
+                user_pinned(
+                    mmap_env.as_deref(),
+                    tunables.as_deref(),
+                    TUNABLE_MMAP_THRESHOLD,
+                ),
+            ),
+            arena_max_pinned: pin(
+                libc::M_ARENA_MAX,
+                ARENA_MAX,
+                "arena ceiling",
+                user_pinned(arena_env.as_deref(), tunables.as_deref(), TUNABLE_ARENA_MAX),
+            ),
         }
     }
     #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
     {
+        AllocatorConfig {
+            mmap_threshold_pinned: false,
+            arena_max_pinned: false,
+        }
+    }
+}
+
+/// Apply one `mallopt` parameter unless the user already set it.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn pin(param: libc::c_int, value: i32, label: &str, deferred: bool) -> bool {
+    if deferred {
+        tracing::info!(
+            parameter = label,
+            "Set in the environment; leaving glibc's value alone"
+        );
+        return false;
+    }
+
+    // SAFETY: mallopt takes two ints and is thread-safe; glibc locks
+    // internally. Both parameters used here are documented.
+    let applied = unsafe { libc::mallopt(param, value) };
+    if applied == 1 {
+        tracing::debug!(parameter = label, value, "Pinned glibc allocator parameter");
+        true
+    } else {
+        tracing::warn!(
+            parameter = label,
+            value,
+            "mallopt was rejected; allocator retention is not bounded"
+        );
         false
     }
 }

--- a/xearthlayer/src/metrics/mod.rs
+++ b/xearthlayer/src/metrics/mod.rs
@@ -20,8 +20,8 @@ pub use client::MetricsClient;
 pub use daemon::{MetricsDaemon, MetricsStateSnapshot, SharedMetricsState};
 pub use event::MetricEvent;
 pub use memory_probe::{
-    configure_allocator, log_allocator_environment, log_malloc_trim_at_shutdown, AllocatorSample,
-    MemoryProbe, MemorySample, ProcessMemoryProbe,
+    configure_allocator, log_allocator_environment, log_malloc_trim_at_shutdown, AllocatorConfig,
+    AllocatorSample, MemoryProbe, MemorySample, ProcessMemoryProbe,
 };
 pub use optional::OptionalMetrics;
 pub use reporter::{MetricsReporter, TuiReporter};


### PR DESCRIPTION
## The fix

glibc's arena ceiling defaults to `8 x ncores` — 256 on a 32-core host. A thread
keeps whichever arena it first got, each arena grows to cover the worst burst
*it* ever saw, and glibc returns memory only by trimming the **top** of a heap,
so space stranded below a live allocation stays committed for the life of the
process.

Total arena is therefore the **sum of every arena's personal high-water mark**.
That is why it never converged: with 256 available, every burst can recruit
*fresh* arenas that have not yet seen one, so there is always a new peak to add.

`mallopt(M_ARENA_MAX, 4)` removes the supply. Once each of four arenas has seen
its worst burst, no fresh ones remain and the sum saturates.

## In flight now — 7 h 40 min, 88,258 encodes

Same route as #243's verification flight (FAOR→EGLL), so the comparison holds
everything but this change constant.

**The arena is bounded.** It reached 3,916 MB in the first six minutes, in six
steps, and has not moved since:

```
heap since last step: min=3915  max=3916  DRIFT=1 MB
                      over 454 samples / 81,121 encodes / 7.6 h
```

It did not merely slow — it went *down* by a megabyte. Uncapped on the same
route: 18 steps spread across 11 hours, still stepping at hour 10.75, ending at
6,091 MB while holding 1,002 MB of live data.

3,916 MB is peak concurrent demand (3,093 MB measured on the baseline flight)
plus about 27% fragmentation headroom. The arena is now sized by what the
workload needs at once rather than by its history — which makes it a number that
can be stated in advance, and therefore something a `MemoryHigh=` could be set
against in v0.5.0.

### Not yet ahead on total memory

| encodes | no cap | ARENA_MAX=4 | gap |
|---:|---:|---:|---:|
| 40,000 | 7,258 | 8,834 | +1,576 |
| 55,000 | 7,209 | 8,835 | +1,626 |
| 70,000 | 9,012 | 9,613 | +601 |
| 85,000 | 9,024 | 9,716 | +692 |

The cap front-loads the whole arena into the first six minutes, so it is behind
early and the gap closes as the uncapped run accumulates. Growth rates have
separated: **19.6 MB per 1,000 encodes capped, against 71 MB per 1,000** over
the uncapped run's own tail. Where the lines cross will be in the final metrics;
it has not happened yet.

Component decomposition at idle shows why the remaining growth is not the arena:

```
enc      committed   arena   memcache   mmap-cache   live
15,957      8,653     3,916     4,085         653     399
45,594      8,835     3,916     4,085         822     617
75,796      9,596     3,915     4,085       1,586     759
```

Arena flat, memory cache at its configured budget, and all movement in `mmap`
outside the cache — which *oscillates* (811 → 1,318 → 811 → 1,272 → 822) rather
than ratcheting. That is in-flight tiles during prefetch bursts, returned each
time, which is the mmap threshold pin working as intended. One baseline shift of
~775 MB around 64,000 encodes is the only durable move, and it is a separate
question from this PR.

## Environment override

`mallopt` silently overrides what glibc read from the environment at startup, so
the override only works if we check for it. Measured on glibc 2.44, 64 threads:

```
env=64, no mallopt              : arena=23 MB
env=64, mallopt(4)  <- conflict : arena= 1 MB
```

Without the check, a user running an allocator experiment would have their
setting discarded with no diagnostic. Both pins now defer to an explicit
`MALLOC_*` variable **or** a `GLIBC_TUNABLES` entry naming the same parameter,
and log at INFO when they do.

This also fixes the pre-existing case for the mmap threshold, which checked only
`MALLOC_MMAP_THRESHOLD_` and would have silently overridden
`GLIBC_TUNABLES=glibc.malloc.mmap_threshold=...`.

## Verification

`make pre-commit` green. Two mutations checked, each caught only by its own test:

| mutation | test |
|---|---|
| drop the environment check | `an_explicit_env_setting_defers_our_pin`, `a_tunables_setting_defers_our_pin` |
| naive `tunables.is_some()` ignoring which key | `unrelated_tunables_do_not_defer_our_pin` |

The environment decision is a pure function, so the tests do not mutate
process-global state.

`configure_allocator()` now returns `AllocatorConfig` rather than `bool` — one
flag per pin, since a single bool cannot say which of two independent settings
applied. Both existing callers ignored the return value.

## Scope note

Both pins are `cfg`-gated to `linux-gnu`, as is all allocator telemetry. macOS
uses libmalloc and has neither. That gap is out of scope here and is the subject
of a separate v0.5.0 allocator evaluation.

## Status

**Flight in progress, ~2.5 h remaining.** This PR will be updated with end-of-
flight metrics — final arena drift, the crossover point, and total committed at
matched work. Not merge-ready until then.
