### PR TITLE
fix(config): wire three settings that never reached the runtime

### DIFF
--- a/xearthlayer-cli/src/commands/run.rs
+++ b/xearthlayer-cli/src/commands/run.rs
@@ -189,6 +189,7 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
         .cache_directory(config.cache.directory.clone())
         .cache_memory_size(config.cache.memory_size)
         .cache_disk_size(config.cache.disk_size)
+        .cache_dds_disk_ratio(config.cache.dds_disk_ratio)
         .generation_threads(config.generation.threads)
         .generation_timeout(config.generation.timeout)
         .pipeline(pipeline_settings)

--- a/xearthlayer/src/config/parser.rs
+++ b/xearthlayer/src/config/parser.rs
@@ -547,6 +547,17 @@ pub(super) fn parse_ini(ini: &Ini) -> Result<ConfigFile, ConfigFileError> {
             // Clamp to valid range (same as HTTP concurrent)
             config.executor.network_concurrent = clamp_http_concurrent(parsed);
         }
+        // Moved from the deprecated [control_plane] section in #160. Parsed after
+        // [control_plane] above, so the [executor] value wins when both are present.
+        if let Some(v) = section.get("max_concurrent_jobs") {
+            config.control_plane.max_concurrent_jobs =
+                v.parse().map_err(|_| ConfigFileError::InvalidValue {
+                    section: "executor".to_string(),
+                    key: "max_concurrent_jobs".to_string(),
+                    value: v.to_string(),
+                    reason: "must be a positive integer".to_string(),
+                })?;
+        }
         if let Some(v) = section.get("cpu_concurrent") {
             config.executor.cpu_concurrent =
                 v.parse().map_err(|_| ConfigFileError::InvalidValue {
@@ -667,6 +678,95 @@ mod tests {
     use crate::config::defaults::*;
     use crate::config::settings::ConfigFile;
     use tempfile::TempDir;
+
+    /// Regression: `max_concurrent_jobs` moved from the deprecated [control_plane]
+    /// section to [executor] in #160, but the parser was not updated — a config
+    /// written by XEarthLayer itself could not be read back.
+    #[test]
+    fn test_max_concurrent_jobs_survives_write_read_round_trip() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.ini");
+
+        let mut config = ConfigFile::default();
+        let non_default = default_max_concurrent_jobs() + 3;
+        config.control_plane.max_concurrent_jobs = non_default;
+        config.save_to(&config_path).unwrap();
+
+        let loaded = ConfigFile::load_from(&config_path).unwrap();
+        assert_eq!(loaded.control_plane.max_concurrent_jobs, non_default);
+    }
+
+    #[test]
+    fn test_max_concurrent_jobs_read_from_executor_section() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.ini");
+
+        std::fs::write(
+            &config_path,
+            r#"
+[executor]
+max_concurrent_jobs = 12
+"#,
+        )
+        .unwrap();
+
+        let config = ConfigFile::load_from(&config_path).unwrap();
+        assert_eq!(config.control_plane.max_concurrent_jobs, 12);
+    }
+
+    /// The [executor] value wins over the deprecated [control_plane] one.
+    #[test]
+    fn test_executor_max_concurrent_jobs_overrides_control_plane() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.ini");
+
+        std::fs::write(
+            &config_path,
+            r#"
+[control_plane]
+max_concurrent_jobs = 4
+
+[executor]
+max_concurrent_jobs = 12
+"#,
+        )
+        .unwrap();
+
+        let config = ConfigFile::load_from(&config_path).unwrap();
+        assert_eq!(config.control_plane.max_concurrent_jobs, 12);
+    }
+
+    /// Guards the whole writer/parser pair: every value below is non-default and
+    /// must survive a save/load cycle. Catches settings the writer emits into a
+    /// section the parser does not read.
+    #[test]
+    fn test_non_default_values_survive_write_read_round_trip() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.ini");
+
+        let mut config = ConfigFile::default();
+        config.cache.dds_disk_ratio = 0.75;
+        config.generation.timeout = 42;
+        config.executor.cpu_concurrent = 7;
+        config.executor.disk_io_concurrent = 33;
+        config.control_plane.max_concurrent_jobs = 11;
+        config.fuse.max_background = 512;
+        config.fuse.congestion_threshold = 384;
+        config.prefetch.cycle_interval_ms = 3000;
+        config.packages.concurrent_downloads = 9;
+        config.save_to(&config_path).unwrap();
+
+        let loaded = ConfigFile::load_from(&config_path).unwrap();
+        assert_eq!(loaded.cache.dds_disk_ratio, 0.75);
+        assert_eq!(loaded.generation.timeout, 42);
+        assert_eq!(loaded.executor.cpu_concurrent, 7);
+        assert_eq!(loaded.executor.disk_io_concurrent, 33);
+        assert_eq!(loaded.control_plane.max_concurrent_jobs, 11);
+        assert_eq!(loaded.fuse.max_background, 512);
+        assert_eq!(loaded.fuse.congestion_threshold, 384);
+        assert_eq!(loaded.prefetch.cycle_interval_ms, 3000);
+        assert_eq!(loaded.packages.concurrent_downloads, 9);
+    }
 
     #[test]
     fn test_invalid_provider_type() {

--- a/xearthlayer/src/manager/mounts.rs
+++ b/xearthlayer/src/manager/mounts.rs
@@ -11,7 +11,9 @@ use std::time::Duration;
 
 use tokio::sync::mpsc;
 
-use crate::config::defaults::{DEFAULT_FUSE_CONGESTION_THRESHOLD, DEFAULT_FUSE_MAX_BACKGROUND};
+use crate::config::defaults::{
+    DEFAULT_FUSE_CONGESTION_THRESHOLD, DEFAULT_FUSE_MAX_BACKGROUND, DEFAULT_GENERATION_TIMEOUT_SECS,
+};
 use crate::fuse::fuse3::Fuse3OrthoUnionFS;
 use crate::fuse::SpawnedMountHandle;
 use crate::geo_index::{DsfRegion, GeoIndex, PatchCoverage};
@@ -160,6 +162,8 @@ pub struct MountManager {
     fuse_max_background: u16,
     /// Congestion threshold for background FUSE requests (kernel limit).
     fuse_congestion_threshold: u16,
+    /// Upper bound in seconds for a single DDS generation behind a FUSE read.
+    generation_timeout_secs: u64,
 }
 
 impl MountManager {
@@ -182,6 +186,7 @@ impl MountManager {
             geo_index: None,
             fuse_max_background: DEFAULT_FUSE_MAX_BACKGROUND,
             fuse_congestion_threshold: DEFAULT_FUSE_CONGESTION_THRESHOLD,
+            generation_timeout_secs: DEFAULT_GENERATION_TIMEOUT_SECS,
         }
     }
 
@@ -203,6 +208,14 @@ impl MountManager {
     pub fn set_fuse_limits(&mut self, max_background: u16, congestion_threshold: u16) {
         self.fuse_max_background = max_background;
         self.fuse_congestion_threshold = congestion_threshold;
+    }
+
+    /// Set the upper bound for a single DDS generation behind a FUSE read.
+    ///
+    /// This is the only limit on how long a FUSE `read()` on a virtual DDS tile
+    /// can block; on expiry a placeholder texture is returned.
+    pub fn set_generation_timeout(&mut self, timeout_secs: u64) {
+        self.generation_timeout_secs = timeout_secs;
     }
 
     /// Get the number of active mounts.
@@ -486,7 +499,8 @@ impl MountManager {
                 .with_geo_index(Arc::clone(&geo_index))
                 .with_state_observer(state_observer)
                 .with_scene_tracker_channel(scene_tracker_tx)
-                .with_fuse_limits(self.fuse_max_background, self.fuse_congestion_threshold);
+                .with_fuse_limits(self.fuse_max_background, self.fuse_congestion_threshold)
+                .with_timeout(Duration::from_secs(self.generation_timeout_secs));
 
         // Wire metrics client for coalesced request tracking
         if let Some(metrics) = metrics_client {

--- a/xearthlayer/src/service/orchestrator/core.rs
+++ b/xearthlayer/src/service/orchestrator/core.rs
@@ -115,6 +115,9 @@ impl ServiceOrchestrator {
         // Create mount manager with Custom Scenery path and FUSE kernel limits
         let mut mount_manager = MountManager::with_scenery_path(&config.custom_scenery_path);
         mount_manager.set_fuse_limits(config.fuse.max_background, config.fuse.congestion_threshold);
+        if let Some(timeout_secs) = config.service.generation_timeout() {
+            mount_manager.set_generation_timeout(timeout_secs);
+        }
 
         // Wire FUSE analyzer callback for position inference
         if let Some(ref analyzer) = fuse_analyzer {


### PR DESCRIPTION
Fixes the three wireable cases from #248.

Three settings were parsed, validated and reported by `config list`, but the
value never arrived where it is used — a hardcoded constant or a default won
silently, without a warning.

- **`generation.timeout`**: `ServiceConfig::generation_timeout()` had no caller.
  `MountManager` now carries the value and passes it to `Fuse3OrthoUnionFS` via
  `.with_timeout()`, next to the existing `.with_fuse_limits()`.

- **`cache.dds_disk_ratio`**: the `ServiceConfig` builder chain in `run.rs` never
  called `.cache_dds_disk_ratio()`, so `CacheLayer` always fell back to 0.6 while
  the TUI computed its DDS budget from the config file — display and cache
  service disagreed.

- **`executor.max_concurrent_jobs`**: #160 moved the key from the deprecated
  `[control_plane]` section to `[executor]` and updated the writer, but not the
  parser, so a config written by XEarthLayer could not be read back. The parser
  now reads it from `[executor]` too, after `[control_plane]`, so the newer
  location wins when both are present.

### Behaviour change

The `generation.timeout` fix lowers the effective bound on a blocking FUSE read
from the hardcoded 30s to the configured default of 10s. Per the discussion in
#248 the 30s looks like a struct default rather than a tuned value, but this is
the one part of this PR that changes runtime behaviour rather than just honouring
a setting — worth a look before merging.

### Tests

Four regression tests in `config/parser.rs`, including a write/read round-trip
over non-default values that guards the writer/parser pair in general. All four
fail without the parser change (verified by removing only the production hunk).

They do **not** cover the other two cases — those round-trip through the config
file fine and break further downstream, so they need a different kind of guard.

### Not included

`generation.threads` and `prefetch.cycle_interval_ms` have the same shape and are
described in #248, but both need a decision (wire or remove) rather than a
mechanical fix, so I left them alone. The wider `[executor]` gap is #249.

`make pre-commit` passes.
