### PR TITLE
fix(cache): discard corrupt caches instead of aborting; standardize on one integrity model (#253)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
    - `migrate_cache()` for migrating flat-layout caches to region layout
    - Bridge adapters for executor integration (MemoryCacheBridge, DdsDiskCacheBridge, DiskCacheBridge)
    - Per-provider cache directories
+   - `cache/integrity`: canonical corruption-handling model shared by every on-disk cache (index cache, scenery index cache, DDS/chunk disk tiers) — bounded reads (`length_ceiling`), atomic durable writes (`write_atomic`), discard-on-reject (`CacheLoad::or_discard`); see `docs/dev/cache-integrity-design.md`
    - `XEarthLayerService::start()` creates `CacheLayer` with proper metrics ordering
 
 6. **Configuration** (`xearthlayer/src/config/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
    - `migrate_cache()` for migrating flat-layout caches to region layout
    - Bridge adapters for executor integration (MemoryCacheBridge, DdsDiskCacheBridge, DiskCacheBridge)
    - Per-provider cache directories
-   - `cache/integrity`: canonical corruption-handling model shared by every on-disk cache (index cache, scenery index cache, DDS/chunk disk tiers) — bounded reads (`length_ceiling`), atomic durable writes (`write_atomic`), discard-on-reject (`CacheLoad::or_discard`); see `docs/dev/cache-integrity-design.md`
+   - `cache/integrity`: canonical corruption-handling model shared by every on-disk cache (index cache, scenery index cache, DDS/chunk disk tiers) — bounded reads (`length_ceiling`), atomic durable writes (`write_atomic`, which also creates the parent directory), and invariant-3 satisfied per cache: explicit `discard()` on the disk tiers, unconditional overwrite-on-rebuild for the index caches; see `docs/dev/cache-integrity-design.md`
    - `XEarthLayerService::start()` creates `CacheLayer` with proper metrics ordering
 
 6. **Configuration** (`xearthlayer/src/config/`)
@@ -391,6 +391,7 @@ xearthlayer publish gaps --region <code> [--tile <lat,lon>] [--format <fmt>] [-o
 | `xearthlayer/src/service/cache_layer.rs` | CacheLayer - three-tier cache lifecycle (memory + DDS disk + chunk disk) |
 | `xearthlayer/src/cache/providers/disk.rs` | DiskCacheProvider with internal GC daemon |
 | `xearthlayer/src/cache/adapters/` | Bridge adapters for backward compatibility |
+| `xearthlayer/src/cache/integrity/` | Canonical cache integrity model (`length_ceiling`, `write_atomic`, `discard`, `CacheEntryValidator`) |
 
 ## Configuration
 
@@ -488,5 +489,6 @@ CI will fail if pre-commit checks were not run.
 - **Consolidated FUSE mounting**: `docs/dev/consolidated-mounting-design.md` (single ortho mount, patches + packages)
 - **GeoIndex design**: `docs/dev/geo-index-design.md` (geospatial reference database, patch region ownership)
 - **Memory telemetry**: `docs/dev/memory-telemetry.md` (periodic memory sampling, trace interpretation, confounders)
+- **Cache integrity model**: `docs/dev/cache-integrity-design.md` (bounded reads, atomic durable writes, discard-on-reject, shared by every on-disk cache)
 - memorize review allow(dead_code) macros at major checkpoints. Refactor aggresively to remove them when appropriate.
 - memorize ensure to update the projects documentation to reflect the current state of the project before committing changes

--- a/docs/dev/cache-integrity-design.md
+++ b/docs/dev/cache-integrity-design.md
@@ -35,10 +35,7 @@ corruption must never cost more than a slower rebuild from the real sources
 
 1. **A read has two outcomes: a trusted value, or a miss.** Malformed input
    is a miss — never an error, never an abort, never degraded output served
-   in place of regenerating. There is deliberately no error variant in
-   [`CacheLoad<T>`](#cacheloadt-and-cacheentryvalidator): anything a caller
-   would once have handled as an `Err` is now a `Rejected` that resolves to a
-   miss once the bad entry is discarded.
+   in place of regenerating.
 2. **Every length taken from file content is bounded by evidence from that
    file.** A file's own size is the natural ceiling: nothing legitimate can
    require reading, or allocating for, more bytes than the file holds. See
@@ -50,11 +47,15 @@ corruption must never cost more than a slower rebuild from the real sources
    → rename, with the temp file removed on any failure path. See
    [`write_atomic`](#io-length_ceiling-write_atomic-discard).
 
-These are stated as absolutes because the module enforces them structurally,
-not by convention: invariant 1 is why `CacheLoad` has no `Err(_)` arm at all,
-and invariant 3 is why `or_discard` — the *only* sanctioned way to turn a
-`CacheLoad` into an `Option` — deletes the file itself before it hands back
-`None`.
+Each cache satisfies invariant 3 its own way — there is no single shared type
+that forces it. The disk tiers (`cache/providers/disk.rs`) call
+[`discard`](#io-length_ceiling-write_atomic-discard) explicitly the moment
+[`CacheEntryValidator::validate`](#cacheentryvalidator) rejects an entry. The
+index caches (`ortho_union/cache.rs`, `prefetch/scenery_cache.rs`) have no
+separate validation step to reject from — a bad file there is retired by
+being unconditionally overwritten via `write_atomic` the next time the
+in-memory index rebuilds and saves. Both routes delete-or-overwrite the bad
+file; neither leaves it in place to be rejected again on the next read.
 
 ## Module API
 
@@ -62,7 +63,7 @@ and invariant 3 is why `or_discard` — the *only* sanctioned way to turn a
 
 ```
 cache/integrity/
-├── mod.rs        # IntegrityError, CacheLoad<T>, CacheEntryValidator trait
+├── mod.rs        # IntegrityError, CacheEntryValidator trait
 ├── io.rs         # length_ceiling, write_atomic, discard
 └── validators.rs # MagicAndSize, dds_tile_validator, raw_chunk_validator
 ```
@@ -78,35 +79,26 @@ pub enum IntegrityError {
     BadMagic { expected: &'static [u8] },
     WrongSize { actual: usize, expected: usize },
     ImplausibleLength { claimed: u64, ceiling: u64 },
-    Malformed(String),
 }
 ```
 
 Carried for logs; callers branch on the variant, never on the rendered text.
+`ImplausibleLength` is constructed at both `Vec::with_capacity` bound sites in
+`prefetch/scenery_cache.rs` (`total_tiles` and `package_count`) — the two
+places a garbage count from file content would otherwise reach an allocator.
 
-### `CacheLoad<T>` and `CacheEntryValidator`
+### `CacheEntryValidator`
 
 ```rust
-pub enum CacheLoad<T> {
-    Hit(T),
-    Miss,
-    Rejected(IntegrityError),
-}
-
-impl<T> CacheLoad<T> {
-    pub fn or_discard(self, path: &Path) -> Option<T> { ... }
-}
-
 pub trait CacheEntryValidator: Send + Sync {
     fn name(&self) -> &'static str;
     fn validate(&self, bytes: &[u8]) -> Result<(), IntegrityError>;
 }
 ```
 
-`or_discard` is the collapse point: `Hit` becomes `Some`, `Miss` becomes
-`None`, and `Rejected` calls `discard()` (deleting the file and logging why)
-before also becoming `None`. A caller cannot forget invariant 3 because there
-is no other way to get the `Option` out.
+`name()` identifies which validator rejected an entry; `disk.rs::get()` passes
+it through to `discard()` so the resulting `warn` log line says which check
+failed, not just what the failure was.
 
 ### Validators (`validators.rs`)
 
@@ -135,20 +127,28 @@ bytes for a 4096×4096 BC1 tile with a full 13-level chain.
 pub fn length_ceiling(file: &File) -> io::Result<u64>
 pub fn write_atomic<F>(path: &Path, write: F) -> io::Result<()>
     where F: FnOnce(&mut BufWriter<File>) -> io::Result<()>
-pub fn discard(path: &Path, reason: &IntegrityError)
+pub fn discard(path: &Path, reason: &IntegrityError, validator: &str)
 ```
 
 - `length_ceiling` is invariant 2 in one call: the file's own size, nothing
   more.
-- `write_atomic` writes to a sibling `.tmp` path, flushes, calls
-  `sync_all()`, then renames over the live path; the temp file is removed on
-  any failure in that sequence. It does **not** create parent directories —
-  callers that need that guarantee keep their own `create_dir_all` before
-  calling it.
-- `discard` logs a `warn` with the path and `IntegrityError`, then removes
-  the file; a failure to delete (other than `NotFound`) is itself logged, not
-  propagated — deletion is a best-effort cleanup on a path that has already
-  decided to treat the entry as gone.
+- `write_atomic` creates the destination's parent directory (`create_dir_all`)
+  if it doesn't already exist, then writes to a sibling `.tmp` path, flushes,
+  calls `sync_all()`, and renames over the live path; the temp file is
+  removed on any failure in that sequence. Owning the directory creation here
+  is load-bearing, not a convenience: the only thing that reliably creates
+  `~/.xearthlayer` is `logging.rs`, keyed off the user-settable `logging.file`
+  config value, so a caller that assumed the directory already existed could
+  fail `ENOENT` on a fresh install with a non-default log path. It does
+  **not** `fsync` the parent directory after the rename — that's defensible
+  because the worst crash outcome without it is that the rename itself is
+  lost and the old file survives untouched at the live path, which is
+  invariant 4's "it never happened" branch, not a torn write.
+- `discard` logs a `warn` with the path, `IntegrityError`, and the name of
+  the validator that rejected the entry, then removes the file; a failure to
+  delete (other than `NotFound`) is itself logged, not propagated —
+  deletion is a best-effort cleanup on a path that has already decided to
+  treat the entry as gone.
 
 ## How Each Cache Adopts the Model
 
@@ -185,50 +185,59 @@ from sources on a cache miss and then unconditionally calls
 bad file is retired by being overwritten on the very next successful build,
 not by an explicit delete.
 
-This cache does not use `CacheEntryValidator` / `CacheLoad<T>` — the payload
-is a single bincode-typed struct, and bincode's own deserialization failure
-already distinguishes malformed from well-formed. There is no separate
-"plausible bytes but wrong shape" case for a validator to add value against.
+This cache does not use `CacheEntryValidator` — the payload is a single
+bincode-typed struct, and bincode's own deserialization failure already
+distinguishes malformed from well-formed. There is no separate "plausible
+bytes but wrong shape" case for a validator to add value against.
 
 ### `prefetch/scenery_cache.rs` (`load_cache` / `save_cache`)
 
-The line-based text cache reads a `total_tiles` count from its header before
-allocating `Vec::with_capacity(total_tiles)` for the tile list. That count is
-now bounded by `length_ceiling`:
+The line-based text cache reads a `total_tiles` count and a `package_count`
+from its header before allocating `Vec::with_capacity` for each. Both are
+now bounded, each turned into an `IntegrityError::ImplausibleLength` and an
+`Invalid`/`Err` verdict when they exceed the ceiling:
 
 ```rust
-if total_tiles as u64 > ceiling {
-    return CacheLoadResult::Invalid { error: ... };
+let max_tiles = ceiling / MIN_TILE_LINE_BYTES;
+if total_tiles as u64 > max_tiles {
+    let reason = IntegrityError::ImplausibleLength { claimed: total_tiles as u64, ceiling: max_tiles };
+    return CacheLoadResult::Invalid { error: format!("...{:?}", reason) };
 }
 ```
 
-— a cache cannot hold more tiles than it has bytes, since every tile occupies
-at least one line, so this rejects an implausible count with no risk to a
-genuinely large valid cache.
+— `total_tiles` is divided by `MIN_TILE_LINE_BYTES` (not compared to the raw
+byte ceiling directly) because it sizes a `Vec<SceneryTile>`, not a byte
+buffer: an element-for-element `SceneryTile` costs far more than one file
+byte, so a raw-byte ceiling still let a corrupt count over-reserve by roughly
+`size_of::<SceneryTile>()` per byte of file. `package_count` guards the same
+allocation in `cache_status()` — a second, independent read path added after
+the original tile-count fix, since a CLI status query never goes through
+`load_cache`'s package-count-vs-current-packages cross-check.
 
 `load_cache` is now a thin wrapper over `load_cache_from(path, packages)`,
-split out so tests can point at a temporary file instead of the live
+and `cache_status` over `cache_status_from(path)`, both split out so tests
+can point at a temporary file instead of the live
 `~/.xearthlayer/scenery_index.cache` (potentially ~180 MB) without ever
-reading or mutating it. `save_cache` keeps its own `create_dir_all` (since
-`write_atomic` doesn't create parent directories) and then delegates the
-actual write to `write_atomic`.
+reading or mutating it. `save_cache` delegates its write entirely to
+`write_atomic`, which creates the parent directory itself.
 
-This cache predates the `CacheLoad<T>` type and keeps its own four-variant
-`CacheLoadResult` (`Loaded` / `Stale` / `NotFound` / `Invalid`) rather than
-being rewritten onto it — see [non-decisions](#deliberate-non-decisions)
-below for why `Stale` and `Invalid` are kept distinct. As with the ortho
-union index, the caller (`service/orchestrator/core.rs`) rebuilds from
-sources on `Stale`, `NotFound`, *or* `Invalid` and then unconditionally calls
-`save_cache`, so an invalid file on disk is retired by overwrite on the next
-successful build rather than by explicit deletion.
+This cache keeps its own four-variant `CacheLoadResult` (`Loaded` / `Stale` /
+`NotFound` / `Invalid`) rather than adopting `CacheEntryValidator` — see
+[non-decisions](#deliberate-non-decisions) below for why `Stale` and
+`Invalid` are kept distinct. As with the ortho union index, the caller
+(`service/orchestrator/core.rs`) rebuilds from sources on `Stale`,
+`NotFound`, *or* `Invalid` and then calls `save_cache` **only when
+`total_tiles > 0`** — so an invalid cache whose rebuild happens to find zero
+tiles is never overwritten (or deleted), unlike the ortho union index, which
+saves unconditionally. See [Known Limitations](#known-limitations).
 
 ### `cache/providers/disk.rs` (`DiskCacheProvider`)
 
-This is the one caller that uses the full `CacheEntryValidator` /
-`CacheLoad`-style rejection path (though `get()` inlines the collapse rather
-than constructing a `CacheLoad` value, since it also needs to touch the LRU
-index on the way through). `validator_for_tier` is the single point mapping
-a `DiskTier` to a validator:
+This is the one caller that uses `CacheEntryValidator` for the reject path.
+`get()` calls `validate()` directly and inlines the collapse to `None` itself
+— there is no separate wrapper type — since it also needs to touch the LRU
+index and the size metric on the way through. `validator_for_tier` is the
+single point mapping a `DiskTier` to a validator:
 
 ```rust
 fn validator_for_tier(tier: DiskTier) -> Arc<dyn CacheEntryValidator> {
@@ -245,15 +254,22 @@ DDS tile tier and the raw chunk tier. In `get()`:
 
 ```rust
 if let Err(reason) = self.validator.validate(&data) {
-    crate::cache::integrity::discard(&path, &reason);
+    discard(&path, &reason, self.validator.name());
     self.lru_index.remove(&key_owned);
+    self.report_size_to_metrics();
     return Ok(None);
 }
 ```
 
 a rejected entry is deleted from disk *and* removed from the in-memory LRU
 index in the same branch — the index would otherwise keep pointing at a file
-that no longer exists. A non-`NotFound` I/O error on the read (e.g. a
+that no longer exists. It also reports the (now smaller) cache size to
+metrics immediately, the same as the `set()` and `delete()` paths do; without
+that call the size gauge only self-corrects on the *next* `set()` for that
+key, which never arrives for a tile that regenerates incomplete (#180), so it
+could otherwise hold stale-high indefinitely. `discard()` is passed
+`self.validator.name()` so its `warn` log records which validator rejected
+the entry, not just why. A non-`NotFound` I/O error on the read (e.g. a
 transient disk error) now also degrades to a logged miss rather than
 propagating as `Err` to the caller: the tile regenerates from the next tier
 up instead of failing the request outright.
@@ -307,9 +323,16 @@ identical forever, and so logs say which one actually happened.
   that's checked, a BC3 deployment could see every DDS disk entry rejected
   by `WrongSize`, degrading (safely, but silently) to full re-encoding on
   every read.
-- **`write_atomic` does not create parent directories.** Callers that need
-  the directory to exist keep their own `create_dir_all` before calling it
-  (`prefetch/scenery_cache.rs::save_cache` is the current example).
+- **A scenery cache rebuild that finds zero tiles is neither overwritten nor
+  deleted.** `service/orchestrator/core.rs` only calls `save_cache` when
+  `total_tiles > 0`, so a corrupt-on-disk scenery cache whose rebuild
+  legitimately yields zero tiles (e.g. no packages currently indexed) is left
+  exactly as it was — invariant 3 is not met on this one path. The failed
+  load re-warns on every subsequent startup until either a rebuild finds at
+  least one tile or the file is removed by hand. This is a pre-existing gap,
+  not something this change introduced; fixing it is out of scope here (it
+  would change `service/orchestrator/core.rs` behaviour, which this pass
+  deliberately does not touch).
 - **fsync ordering is not unit-testable** without a fault-injecting
   filesystem — there's no way to assert from a test that the `fsync` happens
   before the `rename` short of intercepting syscalls. It is addressed by
@@ -325,7 +348,7 @@ identical forever, and so logs say which one actually happened.
 
 | File | Purpose |
 |------|---------|
-| `xearthlayer/src/cache/integrity/mod.rs` | `IntegrityError`, `CacheLoad<T>`, `CacheEntryValidator` |
+| `xearthlayer/src/cache/integrity/mod.rs` | `IntegrityError`, `CacheEntryValidator` |
 | `xearthlayer/src/cache/integrity/io.rs` | `length_ceiling`, `write_atomic`, `discard` |
 | `xearthlayer/src/cache/integrity/validators.rs` | `MagicAndSize`, `dds_tile_validator`, `raw_chunk_validator`, `EXPECTED_DDS_SIZE` |
 | `xearthlayer/src/ortho_union/cache.rs` | `IndexCache` — bounded bincode load, `write_atomic` save |

--- a/docs/dev/cache-integrity-design.md
+++ b/docs/dev/cache-integrity-design.md
@@ -1,0 +1,334 @@
+# Cache Integrity Design
+
+**Status**: Implemented
+**Created**: 2026-08-26
+**Issue**: #253
+
+## Overview
+
+XEarthLayer has several caches backed by files on disk: the ortho union index
+cache, the scenery index cache, and the DDS-tile / raw-chunk disk cache tiers.
+Every one of them can be corrupted by something outside the program's
+control — a killed process mid-write, a full disk, a bad sector, manual
+tampering. Before this module existed, each cache handled that possibility
+differently, and none of them handled it safely:
+
+- An oversized or misaligned length prefix in a bincode-encoded cache passed
+  a garbage value to `Vec::with_capacity`, which **aborts the process**
+  (`SIGABRT`) rather than returning an `Err` — no caller could recover from
+  this, however carefully it matched on `Result`.
+- A corrupt DDS tile on disk was read, failed to decode, and was re-served or
+  left in place, so the same file was rejected — or worse, shown to X-Plane
+  as a permanently magenta tile — on every subsequent request.
+- Writes had no consistent durability guarantee: some went through a
+  temp-file-plus-rename, some did not fsync before renaming, so a crash could
+  leave a torn write promoted to the live path.
+
+`cache/integrity` gives every one of these caches one shared model instead of
+each reinventing (or omitting) its own. The starting premise: **a cache is
+never a source of truth**. It exists purely to avoid recomputation; every
+value it returns must be either trustworthy or absent, and losing an entry to
+corruption must never cost more than a slower rebuild from the real sources
+(HTTP downloads, `.ter` file scans, directory walks).
+
+## The Four Invariants
+
+1. **A read has two outcomes: a trusted value, or a miss.** Malformed input
+   is a miss — never an error, never an abort, never degraded output served
+   in place of regenerating. There is deliberately no error variant in
+   [`CacheLoad<T>`](#cacheloadt-and-cacheentryvalidator): anything a caller
+   would once have handled as an `Err` is now a `Rejected` that resolves to a
+   miss once the bad entry is discarded.
+2. **Every length taken from file content is bounded by evidence from that
+   file.** A file's own size is the natural ceiling: nothing legitimate can
+   require reading, or allocating for, more bytes than the file holds. See
+   [`length_ceiling`](#io-length_ceiling-write_atomic-discard).
+3. **A rejected entry is deleted, not left in place.** Otherwise the next
+   read rejects it again, forever — the corruption becomes permanent instead
+   of self-healing.
+4. **A write is durable or it never happened.** Temp file → flush → `fsync`
+   → rename, with the temp file removed on any failure path. See
+   [`write_atomic`](#io-length_ceiling-write_atomic-discard).
+
+These are stated as absolutes because the module enforces them structurally,
+not by convention: invariant 1 is why `CacheLoad` has no `Err(_)` arm at all,
+and invariant 3 is why `or_discard` — the *only* sanctioned way to turn a
+`CacheLoad` into an `Option` — deletes the file itself before it hands back
+`None`.
+
+## Module API
+
+`xearthlayer/src/cache/integrity/` has three files:
+
+```
+cache/integrity/
+├── mod.rs        # IntegrityError, CacheLoad<T>, CacheEntryValidator trait
+├── io.rs         # length_ceiling, write_atomic, discard
+└── validators.rs # MagicAndSize, dds_tile_validator, raw_chunk_validator
+```
+
+It imports nothing from `fuse`, `metrics`, or `service` — it is a leaf module
+that every cache depends on, not one that depends back on any of them.
+
+### `IntegrityError`
+
+```rust
+pub enum IntegrityError {
+    Empty,
+    BadMagic { expected: &'static [u8] },
+    WrongSize { actual: usize, expected: usize },
+    ImplausibleLength { claimed: u64, ceiling: u64 },
+    Malformed(String),
+}
+```
+
+Carried for logs; callers branch on the variant, never on the rendered text.
+
+### `CacheLoad<T>` and `CacheEntryValidator`
+
+```rust
+pub enum CacheLoad<T> {
+    Hit(T),
+    Miss,
+    Rejected(IntegrityError),
+}
+
+impl<T> CacheLoad<T> {
+    pub fn or_discard(self, path: &Path) -> Option<T> { ... }
+}
+
+pub trait CacheEntryValidator: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn validate(&self, bytes: &[u8]) -> Result<(), IntegrityError>;
+}
+```
+
+`or_discard` is the collapse point: `Hit` becomes `Some`, `Miss` becomes
+`None`, and `Rejected` calls `discard()` (deleting the file and logging why)
+before also becoming `None`. A caller cannot forget invariant 3 because there
+is no other way to get the `Option` out.
+
+### Validators (`validators.rs`)
+
+`MagicAndSize` is a `CacheEntryValidator` expressed as magic bytes plus an
+optional exact length, checked in this order: empty first (always reported
+as `Empty`, never `BadMagic`), then magic, then length.
+
+```rust
+pub fn dds_tile_validator() -> MagicAndSize   // b"DDS ", exact EXPECTED_DDS_SIZE
+pub fn raw_chunk_validator() -> MagicAndSize  // empty magic slice, no length check
+```
+
+An empty `magic` slice makes `BadMagic` unreachable — every byte slice
+trivially starts with an empty prefix — which is how `raw_chunk_validator`
+asserts non-emptiness only, without claiming a magic sequence that hasn't
+been verified (see [non-decisions](#deliberate-non-decisions) below).
+
+`EXPECTED_DDS_SIZE` is computed at compile time by walking the same mipmap
+chain the encoder does (halving dimensions, sizing each level as
+`div_ceil(4) * div_ceil(4) * 8` bytes, plus a 128-byte header) — 11,184,952
+bytes for a 4096×4096 BC1 tile with a full 13-level chain.
+
+### `io`: `length_ceiling`, `write_atomic`, `discard`
+
+```rust
+pub fn length_ceiling(file: &File) -> io::Result<u64>
+pub fn write_atomic<F>(path: &Path, write: F) -> io::Result<()>
+    where F: FnOnce(&mut BufWriter<File>) -> io::Result<()>
+pub fn discard(path: &Path, reason: &IntegrityError)
+```
+
+- `length_ceiling` is invariant 2 in one call: the file's own size, nothing
+  more.
+- `write_atomic` writes to a sibling `.tmp` path, flushes, calls
+  `sync_all()`, then renames over the live path; the temp file is removed on
+  any failure in that sequence. It does **not** create parent directories —
+  callers that need that guarantee keep their own `create_dir_all` before
+  calling it.
+- `discard` logs a `warn` with the path and `IntegrityError`, then removes
+  the file; a failure to delete (other than `NotFound`) is itself logged, not
+  propagated — deletion is a best-effort cleanup on a path that has already
+  decided to treat the entry as gone.
+
+## How Each Cache Adopts the Model
+
+The four caches don't all adopt the same amount of the model — the amount
+adopted matches what each one actually needed.
+
+### `ortho_union/cache.rs` (`IndexCache`)
+
+`IndexCache::load` bounds the bincode reader with `length_ceiling` before
+deserializing:
+
+```rust
+let limit = crate::cache::integrity::length_ceiling(&file)?;
+bincode::DefaultOptions::new()
+    .with_fixint_encoding()
+    .allow_trailing_bytes()
+    .with_limit(limit)
+    .deserialize_from(reader)
+```
+
+The three `DefaultOptions` calls reproduce the legacy `bincode::deserialize_from`
+exactly — `bincode::options()` alone defaults to varint encoding and would
+fail to read every cache written before this change. The limit is what turns
+an oversized or misaligned length prefix into an `Err` instead of a
+`SIGABRT`.
+
+`IndexCache::save` delegates entirely to `write_atomic`. `try_load_cached_index`
+logs a `warn` on any load failure ("Discarding unreadable index cache;
+rebuilding from sources") and returns `None` — it does not call `discard()`
+to delete the bad file directly. This still satisfies invariant 3 in
+practice: the caller (`ortho_union/builder.rs`) always rebuilds the index
+from sources on a cache miss and then unconditionally calls
+`save_index_cache`, which overwrites the same path via `write_atomic`. The
+bad file is retired by being overwritten on the very next successful build,
+not by an explicit delete.
+
+This cache does not use `CacheEntryValidator` / `CacheLoad<T>` — the payload
+is a single bincode-typed struct, and bincode's own deserialization failure
+already distinguishes malformed from well-formed. There is no separate
+"plausible bytes but wrong shape" case for a validator to add value against.
+
+### `prefetch/scenery_cache.rs` (`load_cache` / `save_cache`)
+
+The line-based text cache reads a `total_tiles` count from its header before
+allocating `Vec::with_capacity(total_tiles)` for the tile list. That count is
+now bounded by `length_ceiling`:
+
+```rust
+if total_tiles as u64 > ceiling {
+    return CacheLoadResult::Invalid { error: ... };
+}
+```
+
+— a cache cannot hold more tiles than it has bytes, since every tile occupies
+at least one line, so this rejects an implausible count with no risk to a
+genuinely large valid cache.
+
+`load_cache` is now a thin wrapper over `load_cache_from(path, packages)`,
+split out so tests can point at a temporary file instead of the live
+`~/.xearthlayer/scenery_index.cache` (potentially ~180 MB) without ever
+reading or mutating it. `save_cache` keeps its own `create_dir_all` (since
+`write_atomic` doesn't create parent directories) and then delegates the
+actual write to `write_atomic`.
+
+This cache predates the `CacheLoad<T>` type and keeps its own four-variant
+`CacheLoadResult` (`Loaded` / `Stale` / `NotFound` / `Invalid`) rather than
+being rewritten onto it — see [non-decisions](#deliberate-non-decisions)
+below for why `Stale` and `Invalid` are kept distinct. As with the ortho
+union index, the caller (`service/orchestrator/core.rs`) rebuilds from
+sources on `Stale`, `NotFound`, *or* `Invalid` and then unconditionally calls
+`save_cache`, so an invalid file on disk is retired by overwrite on the next
+successful build rather than by explicit deletion.
+
+### `cache/providers/disk.rs` (`DiskCacheProvider`)
+
+This is the one caller that uses the full `CacheEntryValidator` /
+`CacheLoad`-style rejection path (though `get()` inlines the collapse rather
+than constructing a `CacheLoad` value, since it also needs to touch the LRU
+index on the way through). `validator_for_tier` is the single point mapping
+a `DiskTier` to a validator:
+
+```rust
+fn validator_for_tier(tier: DiskTier) -> Arc<dyn CacheEntryValidator> {
+    match tier {
+        DiskTier::Dds => Arc::new(dds_tile_validator()),
+        DiskTier::Chunk => Arc::new(raw_chunk_validator()),
+    }
+}
+```
+
+`DiskCacheProvider` stores the chosen validator at construction, so the
+struct itself stays ignorant of what it holds — the same type backs both the
+DDS tile tier and the raw chunk tier. In `get()`:
+
+```rust
+if let Err(reason) = self.validator.validate(&data) {
+    crate::cache::integrity::discard(&path, &reason);
+    self.lru_index.remove(&key_owned);
+    return Ok(None);
+}
+```
+
+a rejected entry is deleted from disk *and* removed from the in-memory LRU
+index in the same branch — the index would otherwise keep pointing at a file
+that no longer exists. A non-`NotFound` I/O error on the read (e.g. a
+transient disk error) now also degrades to a logged miss rather than
+propagating as `Err` to the caller: the tile regenerates from the next tier
+up instead of failing the request outright.
+
+`set()` on this provider performs its own async atomic write — a
+`tokio::fs::write` to a sibling `.tmp` path followed by `tokio::fs::rename`
+— rather than calling `io::write_atomic`, which takes a synchronous
+`std::fs::File` and would block the async runtime if called directly. This
+write is atomic (a reader never observes a torn file at the live path) but
+does **not** call `sync_all()` before the rename, so invariant 4's
+durability half is not currently enforced for this tier. This is a
+pre-existing asymmetry with the other three caches, not something this
+change introduced or closed; it is recorded here rather than glossed over.
+
+## Deliberate Non-Decisions
+
+Two choices in this model were made on purpose and are recorded here so they
+aren't mistaken for oversights in a later pass.
+
+### Chunk validation is non-empty-only
+
+`raw_chunk_validator()` checks only that a chunk has bytes at all. Asserting
+a JPEG magic (`0xFF 0xD8`) would require proving that all seven current
+imagery providers — Bing, Go2, Google, Apple, ArcGIS, Mapbox, USGS — return
+JPEG for every tile they serve. That has not been audited. Claiming an
+unverified magic and rejecting on mismatch would turn a correctness fix into
+an outage: any provider returning a different (but valid) format would have
+every one of its chunks discarded and regenerated in a loop. Tighten this
+validator only after a provider audit confirms the actual format contract.
+
+### `CacheLoadResult::Stale` stays distinct from `Invalid`
+
+In the scenery index cache, a `Stale` result (packages changed, version
+mismatch) is **correct data that no longer matches its current sources** —
+not corruption. `Invalid` is reserved for data that fails to parse or fails a
+plausibility check (like the `total_tiles` ceiling above). Collapsing both
+into one "discard and rebuild" outcome would lose a useful operational
+diagnostic: `Stale` tells an operator the cache did its job and simply aged
+out; `Invalid` tells them something wrote a broken file. Both currently
+result in the same rebuild-and-overwrite behaviour at the call site, but the
+distinction is kept in the type so that behaviour isn't forced to stay
+identical forever, and so logs say which one actually happened.
+
+## Known Limitations
+
+- **`EXPECTED_DDS_SIZE` is BC1-only.** It's computed from
+  `full_chain_bc1_dds_size(4096, 4096)`, but `texture.format` also accepts
+  `bc3`, which has a different (larger) per-block size. Whether a BC3-sized
+  tile can currently reach the DDS disk cache tier in practice has **not**
+  been verified — see the `TODO(#253)` at the constant's definition. Until
+  that's checked, a BC3 deployment could see every DDS disk entry rejected
+  by `WrongSize`, degrading (safely, but silently) to full re-encoding on
+  every read.
+- **`write_atomic` does not create parent directories.** Callers that need
+  the directory to exist keep their own `create_dir_all` before calling it
+  (`prefetch/scenery_cache.rs::save_cache` is the current example).
+- **fsync ordering is not unit-testable** without a fault-injecting
+  filesystem — there's no way to assert from a test that the `fsync` happens
+  before the `rename` short of intercepting syscalls. It is addressed by
+  construction (the code only has one order it can execute in) and verified
+  by inspection, not by a regression test. Removing the `sync_all()` call
+  entirely still leaves the existing test suite green, which is the honest
+  bound on what that suite proves.
+- **`cache/providers/disk.rs::set()` doesn't fsync before rename** (see
+  above) — atomic, but not durable in the crash sense that `write_atomic`
+  provides for the other three caches.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `xearthlayer/src/cache/integrity/mod.rs` | `IntegrityError`, `CacheLoad<T>`, `CacheEntryValidator` |
+| `xearthlayer/src/cache/integrity/io.rs` | `length_ceiling`, `write_atomic`, `discard` |
+| `xearthlayer/src/cache/integrity/validators.rs` | `MagicAndSize`, `dds_tile_validator`, `raw_chunk_validator`, `EXPECTED_DDS_SIZE` |
+| `xearthlayer/src/ortho_union/cache.rs` | `IndexCache` — bounded bincode load, `write_atomic` save |
+| `xearthlayer/src/prefetch/scenery_cache.rs` | `load_cache` / `save_cache` — bounded `total_tiles`, `write_atomic` save |
+| `xearthlayer/src/cache/providers/disk.rs` | `DiskCacheProvider` — `validator_for_tier`, discard-on-reject `get()` |
+| `docs/dev/index-building-optimization.md` | Ortho union index cache design (corruption handling section links back here) |

--- a/docs/dev/index-building-optimization.md
+++ b/docs/dev/index-building-optimization.md
@@ -65,6 +65,14 @@ pub struct IndexCache {
 }
 ```
 
+##### Corruption handling
+
+The cache is a performance optimization, never a source of truth: any file we
+cannot read is discarded and the index is rebuilt from sources. Reads are
+bounded by the file's own length and writes go through `write_atomic`, both
+from the shared model in `cache/integrity`. See
+[Cache Integrity Design](cache-integrity-design.md).
+
 #### Cache Flow
 
 ```

--- a/xearthlayer/src/cache/integrity/io.rs
+++ b/xearthlayer/src/cache/integrity/io.rs
@@ -1,0 +1,114 @@
+//! Shared mechanics for reading and writing cache entries safely.
+
+use super::IntegrityError;
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+
+/// The ceiling for any length a cache file claims: the file's own size.
+///
+/// Invariant 2 in one call. Nothing legitimate can require reading more bytes
+/// than the file holds, so this rejects a corrupt length with no risk to a
+/// valid entry, however large.
+pub fn length_ceiling(file: &File) -> io::Result<u64> {
+    Ok(file.metadata()?.len())
+}
+
+/// Durably replace a cache file.
+///
+/// Writes to a sibling temp file, flushes, fsyncs, then renames — and removes
+/// the temp file on any failure. Without the fsync, a crash can persist the
+/// rename while the data blocks are still in flight, promoting a half-written
+/// file to the live path.
+pub fn write_atomic<F>(path: &Path, write: F) -> io::Result<()>
+where
+    F: FnOnce(&mut BufWriter<File>) -> io::Result<()>,
+{
+    let tmp_path = path.with_extension("tmp");
+
+    let outcome = (|| {
+        let file = File::create(&tmp_path)?;
+        let mut writer = BufWriter::new(file);
+        write(&mut writer)?;
+        writer.flush()?;
+        writer.get_ref().sync_all()?;
+        Ok(())
+    })();
+
+    match outcome {
+        Ok(()) => {
+            std::fs::rename(&tmp_path, path)?;
+            Ok(())
+        }
+        Err(err) => {
+            let _ = std::fs::remove_file(&tmp_path);
+            Err(err)
+        }
+    }
+}
+
+/// Remove a rejected cache entry, logging why.
+///
+/// Failure to delete is logged and swallowed: we are already on the
+/// regeneration path, and a stray file on disk is not worth aborting for.
+pub fn discard(path: &Path, reason: &IntegrityError) {
+    tracing::warn!(
+        path = %path.display(),
+        reason = ?reason,
+        "discarding corrupt cache entry"
+    );
+
+    if let Err(err) = std::fs::remove_file(path) {
+        if err.kind() != io::ErrorKind::NotFound {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "failed to delete rejected cache entry"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn length_ceiling_is_the_file_size() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("entry");
+        std::fs::write(&path, vec![0u8; 1234]).unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        assert_eq!(length_ceiling(&file).unwrap(), 1234);
+    }
+
+    #[test]
+    fn write_atomic_leaves_no_temp_file_on_success() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("entry.cache");
+
+        write_atomic(&path, |w| w.write_all(b"payload")).unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"payload");
+        assert!(!path.with_extension("tmp").exists());
+    }
+
+    #[test]
+    fn write_atomic_removes_the_temp_file_when_the_write_fails() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("entry.cache");
+
+        let result = write_atomic(&path, |_| {
+            Err(std::io::Error::other("simulated write failure"))
+        });
+
+        assert!(result.is_err());
+        assert!(
+            !path.with_extension("tmp").exists(),
+            "temp file must not survive"
+        );
+        assert!(!path.exists(), "a failed write must not promote anything");
+    }
+}

--- a/xearthlayer/src/cache/integrity/io.rs
+++ b/xearthlayer/src/cache/integrity/io.rs
@@ -16,10 +16,18 @@ pub fn length_ceiling(file: &File) -> io::Result<u64> {
 
 /// Durably replace a cache file.
 ///
-/// Writes to a sibling temp file, flushes, fsyncs, then renames — and removes
-/// the temp file on any failure. Without the fsync, a crash can persist the
-/// rename while the data blocks are still in flight, promoting a half-written
-/// file to the live path.
+/// Creates the parent directory if it does not already exist, then writes to
+/// a sibling temp file, flushes, fsyncs, then renames — and removes the temp
+/// file on any failure. Without the fsync, a crash can persist the rename
+/// while the data blocks are still in flight, promoting a half-written file
+/// to the live path.
+///
+/// Owning `create_dir_all` here (rather than leaving it to callers) is load-
+/// bearing, not a convenience: the one thing that reliably creates
+/// `~/.xearthlayer` is `logging.rs`, keyed off the user-settable
+/// `logging.file` config value. A caller that assumed some other code path
+/// had already created the directory would fail `ENOENT` on a fresh install
+/// with a non-default log path.
 pub fn write_atomic<F>(path: &Path, write: F) -> io::Result<()>
 where
     F: FnOnce(&mut BufWriter<File>) -> io::Result<()>,
@@ -27,6 +35,9 @@ where
     let tmp_path = path.with_extension("tmp");
 
     let outcome = (|| {
+        if let Some(parent) = tmp_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
         let file = File::create(&tmp_path)?;
         let mut writer = BufWriter::new(file);
         write(&mut writer)?;
@@ -49,12 +60,19 @@ where
 
 /// Remove a rejected cache entry, logging why.
 ///
+/// `validator` is the [`CacheEntryValidator::name`](super::CacheEntryValidator::name)
+/// of whichever validator rejected the entry, carried purely for the log
+/// line — callers with no validator in the loop (the index caches, which
+/// reject on a bincode/plausibility check instead) can pass any stable
+/// label for the check that failed.
+///
 /// Failure to delete is logged and swallowed: we are already on the
 /// regeneration path, and a stray file on disk is not worth aborting for.
-pub fn discard(path: &Path, reason: &IntegrityError) {
+pub fn discard(path: &Path, reason: &IntegrityError, validator: &str) {
     tracing::warn!(
         path = %path.display(),
         reason = ?reason,
+        validator,
         "discarding corrupt cache entry"
     );
 
@@ -93,6 +111,22 @@ mod tests {
 
         assert_eq!(std::fs::read(&path).unwrap(), b"payload");
         assert!(!path.with_extension("tmp").exists());
+    }
+
+    #[test]
+    fn write_atomic_creates_a_missing_parent_directory() {
+        let temp = TempDir::new().unwrap();
+        // Neither `nested` nor `deeper` exists yet — write_atomic must
+        // create the whole path, not just assume it's there. This is what
+        // makes `IndexCache::save` safe on a fresh install whose
+        // `logging.file` points somewhere other than `~/.xearthlayer`
+        // (I2/#253): nothing else on that path guarantees the directory
+        // exists.
+        let path = temp.path().join("nested/deeper/entry.cache");
+
+        write_atomic(&path, |w| w.write_all(b"payload")).unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"payload");
     }
 
     #[test]

--- a/xearthlayer/src/cache/integrity/mod.rs
+++ b/xearthlayer/src/cache/integrity/mod.rs
@@ -9,7 +9,12 @@
 //! 1. A read has two outcomes: a trusted value, or a miss.
 //! 2. Every length taken from file content is bounded by evidence from that
 //!    file ([`io::length_ceiling`]).
-//! 3. A rejected entry is deleted, not left in place ([`CacheLoad::or_discard`]).
+//! 3. A rejected entry is deleted, not left in place. Each cache satisfies
+//!    this its own way: the disk tiers call [`io::discard`] explicitly on a
+//!    validator rejection; the index caches (which have no separate
+//!    validation step to reject from) satisfy it by unconditionally
+//!    overwriting the same path via [`io::write_atomic`] the next time they
+//!    rebuild.
 //! 4. A write is durable or it never happened ([`io::write_atomic`]).
 
 mod io;
@@ -17,8 +22,6 @@ mod validators;
 
 pub use io::{discard, length_ceiling, write_atomic};
 pub use validators::{dds_tile_validator, raw_chunk_validator, MagicAndSize, EXPECTED_DDS_SIZE};
-
-use std::path::Path;
 
 /// Why a cache entry was rejected. Carried for logs; callers branch on the
 /// variant, never on the text.
@@ -32,37 +35,6 @@ pub enum IntegrityError {
     WrongSize { actual: usize, expected: usize },
     /// The entry claimed more bytes than the file could possibly hold.
     ImplausibleLength { claimed: u64, ceiling: u64 },
-    /// The entry could not be parsed.
-    Malformed(String),
-}
-
-/// The outcome of loading a cache entry.
-///
-/// There is deliberately no error variant. A cache read cannot fail; it can
-/// only miss. Anything a caller would have handled as an error is a `Rejected`
-/// that resolves to a miss once the bad entry is discarded.
-#[derive(Debug)]
-pub enum CacheLoad<T> {
-    Hit(T),
-    Miss,
-    Rejected(IntegrityError),
-}
-
-impl<T> CacheLoad<T> {
-    /// Collapse to an `Option`, deleting a rejected entry from disk first.
-    ///
-    /// This is the only sanctioned way to turn a `CacheLoad` into a value:
-    /// it guarantees invariant 3 cannot be forgotten at a call site.
-    pub fn or_discard(self, path: &Path) -> Option<T> {
-        match self {
-            CacheLoad::Hit(value) => Some(value),
-            CacheLoad::Miss => None,
-            CacheLoad::Rejected(reason) => {
-                discard(path, &reason);
-                None
-            }
-        }
-    }
 }
 
 /// Validates the raw bytes of one cache entry before they are trusted.
@@ -70,41 +42,4 @@ pub trait CacheEntryValidator: Send + Sync {
     /// Stable name for log fields.
     fn name(&self) -> &'static str;
     fn validate(&self, bytes: &[u8]) -> Result<(), IntegrityError>;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    #[test]
-    fn or_discard_deletes_a_rejected_entry() {
-        let temp = TempDir::new().unwrap();
-        let path = temp.path().join("entry.cache");
-        std::fs::write(&path, b"garbage").unwrap();
-
-        let load: CacheLoad<()> = CacheLoad::Rejected(IntegrityError::Empty);
-        assert!(load.or_discard(&path).is_none());
-        assert!(!path.exists(), "a rejected entry must be removed from disk");
-    }
-
-    #[test]
-    fn or_discard_leaves_a_hit_in_place() {
-        let temp = TempDir::new().unwrap();
-        let path = temp.path().join("entry.cache");
-        std::fs::write(&path, b"good").unwrap();
-
-        assert_eq!(CacheLoad::Hit(7).or_discard(&path), Some(7));
-        assert!(path.exists());
-    }
-
-    #[test]
-    fn or_discard_on_a_miss_touches_nothing() {
-        let temp = TempDir::new().unwrap();
-        let path = temp.path().join("absent.cache");
-
-        let load: CacheLoad<()> = CacheLoad::Miss;
-        assert!(load.or_discard(&path).is_none());
-        assert!(!path.exists());
-    }
 }

--- a/xearthlayer/src/cache/integrity/mod.rs
+++ b/xearthlayer/src/cache/integrity/mod.rs
@@ -1,0 +1,110 @@
+//! Canonical cache integrity model.
+//!
+//! A cache is never a source of truth. Every read has two outcomes: a value we
+//! trust, or a miss. Malformed input is a miss — never an error, never an
+//! abort, never degraded output served in place of regeneration.
+//!
+//! This module gives every cache in the tree one shared model:
+//!
+//! 1. A read has two outcomes: a trusted value, or a miss.
+//! 2. Every length taken from file content is bounded by evidence from that
+//!    file ([`io::length_ceiling`]).
+//! 3. A rejected entry is deleted, not left in place ([`CacheLoad::or_discard`]).
+//! 4. A write is durable or it never happened ([`io::write_atomic`]).
+
+mod io;
+mod validators;
+
+pub use io::{discard, length_ceiling, write_atomic};
+pub use validators::{dds_tile_validator, raw_chunk_validator, MagicAndSize, EXPECTED_DDS_SIZE};
+
+use std::path::Path;
+
+/// Why a cache entry was rejected. Carried for logs; callers branch on the
+/// variant, never on the text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntegrityError {
+    /// The entry held no bytes.
+    Empty,
+    /// The entry did not begin with the format's magic bytes.
+    BadMagic { expected: &'static [u8] },
+    /// The entry's length disagrees with what the format requires.
+    WrongSize { actual: usize, expected: usize },
+    /// The entry claimed more bytes than the file could possibly hold.
+    ImplausibleLength { claimed: u64, ceiling: u64 },
+    /// The entry could not be parsed.
+    Malformed(String),
+}
+
+/// The outcome of loading a cache entry.
+///
+/// There is deliberately no error variant. A cache read cannot fail; it can
+/// only miss. Anything a caller would have handled as an error is a `Rejected`
+/// that resolves to a miss once the bad entry is discarded.
+#[derive(Debug)]
+pub enum CacheLoad<T> {
+    Hit(T),
+    Miss,
+    Rejected(IntegrityError),
+}
+
+impl<T> CacheLoad<T> {
+    /// Collapse to an `Option`, deleting a rejected entry from disk first.
+    ///
+    /// This is the only sanctioned way to turn a `CacheLoad` into a value:
+    /// it guarantees invariant 3 cannot be forgotten at a call site.
+    pub fn or_discard(self, path: &Path) -> Option<T> {
+        match self {
+            CacheLoad::Hit(value) => Some(value),
+            CacheLoad::Miss => None,
+            CacheLoad::Rejected(reason) => {
+                discard(path, &reason);
+                None
+            }
+        }
+    }
+}
+
+/// Validates the raw bytes of one cache entry before they are trusted.
+pub trait CacheEntryValidator: Send + Sync {
+    /// Stable name for log fields.
+    fn name(&self) -> &'static str;
+    fn validate(&self, bytes: &[u8]) -> Result<(), IntegrityError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn or_discard_deletes_a_rejected_entry() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("entry.cache");
+        std::fs::write(&path, b"garbage").unwrap();
+
+        let load: CacheLoad<()> = CacheLoad::Rejected(IntegrityError::Empty);
+        assert!(load.or_discard(&path).is_none());
+        assert!(!path.exists(), "a rejected entry must be removed from disk");
+    }
+
+    #[test]
+    fn or_discard_leaves_a_hit_in_place() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("entry.cache");
+        std::fs::write(&path, b"good").unwrap();
+
+        assert_eq!(CacheLoad::Hit(7).or_discard(&path), Some(7));
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn or_discard_on_a_miss_touches_nothing() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("absent.cache");
+
+        let load: CacheLoad<()> = CacheLoad::Miss;
+        assert!(load.or_discard(&path).is_none());
+        assert!(!path.exists());
+    }
+}

--- a/xearthlayer/src/cache/integrity/validators.rs
+++ b/xearthlayer/src/cache/integrity/validators.rs
@@ -1,0 +1,163 @@
+//! Validators for the opaque blob cache tiers (DDS tiles, raw chunks).
+
+use super::{CacheEntryValidator, IntegrityError};
+
+/// A validator expressed as magic bytes plus an optional exact length.
+///
+/// An empty `magic` slice makes [`IntegrityError::BadMagic`] unreachable —
+/// every byte slice trivially starts with an empty prefix. This is how
+/// [`raw_chunk_validator`] asserts non-emptiness only, without claiming a
+/// magic sequence we have not verified.
+pub struct MagicAndSize {
+    name: &'static str,
+    magic: &'static [u8],
+    expected_len: Option<usize>,
+}
+
+impl CacheEntryValidator for MagicAndSize {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn validate(&self, bytes: &[u8]) -> Result<(), IntegrityError> {
+        // Empty is checked first: an empty entry must report `Empty`, not
+        // `BadMagic` or `WrongSize`, regardless of what magic/length this
+        // validator otherwise requires.
+        if bytes.is_empty() {
+            return Err(IntegrityError::Empty);
+        }
+
+        if !bytes.starts_with(self.magic) {
+            return Err(IntegrityError::BadMagic {
+                expected: self.magic,
+            });
+        }
+
+        if let Some(expected) = self.expected_len {
+            if bytes.len() != expected {
+                return Err(IntegrityError::WrongSize {
+                    actual: bytes.len(),
+                    expected,
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// DDS tiles: `b"DDS "` magic and the exact full-mipmap-chain length.
+pub fn dds_tile_validator() -> MagicAndSize {
+    MagicAndSize {
+        name: "dds_tile",
+        magic: b"DDS ",
+        expected_len: Some(EXPECTED_DDS_SIZE),
+    }
+}
+
+/// Raw chunks: non-empty only.
+///
+/// Asserting a JPEG magic would require proving every provider (Bing, Go2,
+/// Google, and any future addition) returns JPEG for every tile, which has
+/// not been audited. Claiming an unverified magic would turn a correctness
+/// fix into an outage by rejecting valid chunks, so this checks only that the
+/// entry holds bytes at all.
+pub fn raw_chunk_validator() -> MagicAndSize {
+    MagicAndSize {
+        name: "raw_chunk",
+        magic: &[],
+        expected_len: None,
+    }
+}
+
+/// Total byte size of a BC1 DDS with a full mipmap chain, header included.
+///
+/// Walks the chain the same way the encoder does — halving until a dimension
+/// reaches 1, and sizing every level as `blocks_wide * blocks_high * 8`. The
+/// `div_ceil` matters for the tail: 4×4, 2×2 and 1×1 each still occupy one
+/// whole 8-byte block, which the naive `w * h / 2` under-counts.
+const fn full_chain_bc1_dds_size(width: u32, height: u32) -> usize {
+    const HEADER_BYTES: usize = 128;
+    const BLOCK_BYTES: usize = 8;
+
+    let mut total = HEADER_BYTES;
+    let mut w = width;
+    let mut h = height;
+
+    loop {
+        let blocks_wide = w.div_ceil(4) as usize;
+        let blocks_high = h.div_ceil(4) as usize;
+        total += blocks_wide * blocks_high * BLOCK_BYTES;
+
+        if w <= 1 || h <= 1 {
+            return total;
+        }
+
+        w /= 2;
+        h /= 2;
+    }
+}
+
+/// Expected DDS size for a 4096×4096 BC1 tile with a full mipmap chain.
+///
+/// This is the standard size for X-Plane ortho tiles: 13 levels, 11,184,952
+/// bytes. `validate_dds_or_placeholder` gates every FUSE read against it, so
+/// it must track what the encoder actually emits — a regression test asserts
+/// both agree.
+///
+// TODO(#253): BC1-only; texture.format also accepts bc3
+pub const EXPECTED_DDS_SIZE: usize = full_chain_bc1_dds_size(4096, 4096);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dds_validator_accepts_a_well_formed_tile() {
+        let mut bytes = vec![0u8; EXPECTED_DDS_SIZE];
+        bytes[0..4].copy_from_slice(b"DDS ");
+
+        assert_eq!(dds_tile_validator().validate(&bytes), Ok(()));
+    }
+
+    #[test]
+    fn dds_validator_rejects_wrong_magic() {
+        let mut bytes = vec![0u8; EXPECTED_DDS_SIZE];
+        bytes[0..4].copy_from_slice(b"JPEG");
+
+        assert!(matches!(
+            dds_tile_validator().validate(&bytes),
+            Err(IntegrityError::BadMagic { .. })
+        ));
+    }
+
+    #[test]
+    fn dds_validator_rejects_a_truncated_tile() {
+        let mut bytes = vec![0u8; EXPECTED_DDS_SIZE / 2];
+        bytes[0..4].copy_from_slice(b"DDS ");
+
+        assert!(matches!(
+            dds_tile_validator().validate(&bytes),
+            Err(IntegrityError::WrongSize { .. })
+        ));
+    }
+
+    #[test]
+    fn validators_reject_empty_entries() {
+        assert_eq!(
+            dds_tile_validator().validate(&[]),
+            Err(IntegrityError::Empty)
+        );
+        assert_eq!(
+            raw_chunk_validator().validate(&[]),
+            Err(IntegrityError::Empty)
+        );
+    }
+
+    #[test]
+    fn chunk_validator_accepts_any_non_empty_bytes() {
+        // Deliberately not a JPEG: we have not audited every provider's
+        // response format, so chunk validation asserts only non-emptiness.
+        assert_eq!(raw_chunk_validator().validate(&[0x00, 0x01]), Ok(()));
+    }
+}

--- a/xearthlayer/src/cache/integrity/validators.rs
+++ b/xearthlayer/src/cache/integrity/validators.rs
@@ -102,8 +102,9 @@ const fn full_chain_bc1_dds_size(width: u32, height: u32) -> usize {
 ///
 /// This is the standard size for X-Plane ortho tiles: 13 levels, 11,184,952
 /// bytes. `validate_dds_or_placeholder` gates every FUSE read against it, so
-/// it must track what the encoder actually emits — a regression test asserts
-/// both agree.
+/// it must track what the encoder actually emits —
+/// `fuse::placeholder::tests::test_generate_default_placeholder` asserts both
+/// agree, through the real `DdsEncoder`.
 ///
 // TODO(#253): BC1-only; texture.format also accepts bc3
 pub const EXPECTED_DDS_SIZE: usize = full_chain_bc1_dds_size(4096, 4096);

--- a/xearthlayer/src/cache/mod.rs
+++ b/xearthlayer/src/cache/mod.rs
@@ -42,6 +42,7 @@
 // New cache service architecture (Phase 1)
 mod config;
 pub mod gc_scheduler;
+pub mod integrity;
 pub mod lru_index;
 pub mod migrate;
 pub mod providers;

--- a/xearthlayer/src/cache/providers/disk.rs
+++ b/xearthlayer/src/cache/providers/disk.rs
@@ -36,10 +36,23 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::cache::config::DiskProviderConfig;
+use crate::cache::integrity::{dds_tile_validator, raw_chunk_validator, CacheEntryValidator};
 use crate::cache::lru_index::LruIndex;
 use crate::cache::traits::{BoxFuture, Cache, GcResult, ServiceCacheError};
 use crate::cache::DiskTier;
 use crate::metrics::MetricsClient;
+
+/// Choose the tier-appropriate validator.
+///
+/// This is the one place tier maps to a validator, keeping
+/// `DiskCacheProvider` itself ignorant of what it stores — the same struct
+/// backs both the DDS tile tier and the raw chunk tier (#253).
+fn validator_for_tier(tier: DiskTier) -> Arc<dyn CacheEntryValidator> {
+    match tier {
+        DiskTier::Dds => Arc::new(dds_tile_validator()),
+        DiskTier::Chunk => Arc::new(raw_chunk_validator()),
+    }
+}
 
 /// On-disk cache provider with LRU index tracking.
 ///
@@ -72,6 +85,13 @@ pub struct DiskCacheProvider {
     /// Which disk cache tier this provider serves.
     /// Controls which metric event is emitted for size updates.
     tier: DiskTier,
+
+    /// Validates entries read from disk before they are trusted.
+    ///
+    /// Chosen by `tier` at construction (see `validator_for_tier`). A cache
+    /// is never a source of truth: `get()` treats a validator rejection the
+    /// same as a missing file — discard the entry, report a miss (#253).
+    validator: Arc<dyn CacheEntryValidator>,
 }
 
 impl DiskCacheProvider {
@@ -109,6 +129,7 @@ impl DiskCacheProvider {
             shutdown,
             metrics_client: config.metrics_client,
             tier: config.tier,
+            validator: validator_for_tier(config.tier),
         });
 
         // Populate LRU index from disk
@@ -163,6 +184,7 @@ impl DiskCacheProvider {
             shutdown,
             metrics_client: config.metrics_client,
             tier: config.tier,
+            validator: validator_for_tier(config.tier),
         });
 
         info!(
@@ -322,6 +344,17 @@ impl Cache for DiskCacheProvider {
         Box::pin(async move {
             match tokio::fs::read(&path).await {
                 Ok(data) => {
+                    if let Err(reason) = self.validator.validate(&data) {
+                        // A cache is never a source of truth. Delete the bad
+                        // entry so the next request regenerates it — leaving
+                        // it in place would reject it again on every read,
+                        // which is how one corrupt tile became permanently
+                        // magenta (#253).
+                        crate::cache::integrity::discard(&path, &reason);
+                        self.lru_index.remove(&key_owned);
+                        return Ok(None);
+                    }
+
                     // Update LRU index access time
                     self.lru_index.touch(&key_owned);
                     debug!(
@@ -349,14 +382,17 @@ impl Cache for DiskCacheProvider {
                     Ok(None)
                 }
                 Err(e) => {
+                    // A failing disk degrades to a miss rather than an error
+                    // propagated to the caller — the tile regenerates from
+                    // the next tier up instead of failing the request (#253).
                     warn!(
                         key = %key_owned,
                         path = %path.display(),
                         tier = %tier,
                         error = %e,
-                        "Disk cache read error"
+                        "Disk cache read error; treating as a miss"
                     );
-                    Err(ServiceCacheError::Io(e))
+                    Ok(None)
                 }
             }
         })
@@ -457,8 +493,82 @@ impl Drop for DiskCacheProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache::integrity::EXPECTED_DDS_SIZE;
     use std::time::Duration;
     use tempfile::TempDir;
+
+    /// A DDS-tier provider built synchronously (no fs scan, no shared
+    /// runtime dependency) so corruption tests can construct it inline.
+    fn dds_provider(temp: &TempDir) -> Arc<DiskCacheProvider> {
+        Arc::new(DiskCacheProvider {
+            directory: temp.path().to_path_buf(),
+            max_size_bytes: AtomicU64::new(1_000_000_000),
+            lru_index: Arc::new(LruIndex::new(temp.path().to_path_buf())),
+            shutdown: CancellationToken::new(),
+            metrics_client: None,
+            tier: DiskTier::Dds,
+            validator: Arc::new(dds_tile_validator()),
+        })
+    }
+
+    /// A chunk-tier provider, built the same way as `dds_provider` above.
+    fn chunk_provider(temp: &TempDir) -> Arc<DiskCacheProvider> {
+        Arc::new(DiskCacheProvider {
+            directory: temp.path().to_path_buf(),
+            max_size_bytes: AtomicU64::new(1_000_000_000),
+            lru_index: Arc::new(LruIndex::new(temp.path().to_path_buf())),
+            shutdown: CancellationToken::new(),
+            metrics_client: None,
+            tier: DiskTier::Chunk,
+            validator: Arc::new(raw_chunk_validator()),
+        })
+    }
+
+    #[tokio::test]
+    async fn corrupt_dds_entry_is_discarded_and_reported_as_a_miss() {
+        let temp = TempDir::new().unwrap();
+        let provider = dds_provider(&temp);
+        let key = "tile:15:12754:5279";
+
+        // Put a file with the right name but wrong content on disk.
+        let path = provider.key_path(key);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"not a dds tile").unwrap();
+
+        assert!(provider.get(key).await.unwrap().is_none(), "must be a miss");
+        assert!(
+            !path.exists(),
+            "a rejected entry must be deleted so it regenerates"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_chunk_entry_is_discarded_and_reported_as_a_miss() {
+        let temp = TempDir::new().unwrap();
+        let provider = chunk_provider(&temp);
+        let key = "chunk:19:204064:84464";
+
+        let path = provider.key_path(key);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"").unwrap();
+
+        assert!(provider.get(key).await.unwrap().is_none());
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn a_valid_entry_survives_validation() {
+        let temp = TempDir::new().unwrap();
+        let provider = dds_provider(&temp);
+        let key = "tile:15:12754:5279";
+
+        let mut tile = vec![0u8; EXPECTED_DDS_SIZE];
+        tile[0..4].copy_from_slice(b"DDS ");
+        provider.set(key, Bytes::from(tile.clone())).await.unwrap();
+
+        assert_eq!(provider.get(key).await.unwrap(), Some(Bytes::from(tile)));
+        assert!(provider.key_path(key).exists());
+    }
 
     async fn create_test_provider(max_size: u64) -> (TempDir, Arc<DiskCacheProvider>) {
         let temp_dir = TempDir::new().unwrap();

--- a/xearthlayer/src/cache/providers/disk.rs
+++ b/xearthlayer/src/cache/providers/disk.rs
@@ -36,7 +36,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::cache::config::DiskProviderConfig;
-use crate::cache::integrity::{dds_tile_validator, raw_chunk_validator, CacheEntryValidator};
+use crate::cache::integrity::{
+    dds_tile_validator, discard, raw_chunk_validator, CacheEntryValidator,
+};
 use crate::cache::lru_index::LruIndex;
 use crate::cache::traits::{BoxFuture, Cache, GcResult, ServiceCacheError};
 use crate::cache::DiskTier;
@@ -350,8 +352,14 @@ impl Cache for DiskCacheProvider {
                         // it in place would reject it again on every read,
                         // which is how one corrupt tile became permanently
                         // magenta (#253).
-                        crate::cache::integrity::discard(&path, &reason);
+                        discard(&path, &reason, self.validator.name());
                         self.lru_index.remove(&key_owned);
+                        // The gauge otherwise self-corrects only on the next
+                        // `set()` for this key, which never arrives for a
+                        // tile that regenerates incomplete (#180) — leaving
+                        // it stale-high until an unrelated write happens to
+                        // touch it.
+                        self.report_size_to_metrics();
                         return Ok(None);
                     }
 

--- a/xearthlayer/src/fuse/placeholder.rs
+++ b/xearthlayer/src/fuse/placeholder.rs
@@ -153,41 +153,20 @@ pub fn init_placeholder_cache() -> Result<(), DdsError> {
     Ok(())
 }
 
-/// Total byte size of a BC1 DDS with a full mipmap chain, header included.
-///
-/// Walks the chain the same way the encoder does — halving until a dimension
-/// reaches 1, and sizing every level as `blocks_wide * blocks_high * 8`. The
-/// `div_ceil` matters for the tail: 4×4, 2×2 and 1×1 each still occupy one
-/// whole 8-byte block, which the naive `w * h / 2` under-counts.
-const fn full_chain_bc1_dds_size(width: u32, height: u32) -> usize {
-    const HEADER_BYTES: usize = 128;
-    const BLOCK_BYTES: usize = 8;
-
-    let mut total = HEADER_BYTES;
-    let mut w = width;
-    let mut h = height;
-
-    loop {
-        let blocks_wide = w.div_ceil(4) as usize;
-        let blocks_high = h.div_ceil(4) as usize;
-        total += blocks_wide * blocks_high * BLOCK_BYTES;
-
-        if w <= 1 || h <= 1 {
-            return total;
-        }
-
-        w /= 2;
-        h /= 2;
-    }
-}
-
 /// Expected DDS size for a 4096×4096 BC1 tile with a full mipmap chain.
 ///
 /// This is the standard size for X-Plane ortho tiles: 13 levels, 11,184,952
 /// bytes. `validate_dds_or_placeholder` gates every FUSE read against it, so
 /// it must track what the encoder actually emits — a regression test asserts
 /// both agree.
-pub const EXPECTED_DDS_SIZE: usize = full_chain_bc1_dds_size(4096, 4096);
+///
+/// The computation lives in `cache::integrity` (the canonical cache
+/// integrity model shared by all cache tiers) so that DDS disk cache
+/// validation and this FUSE-boundary check can never drift apart. This
+/// re-export exists so existing callers of `fuse::EXPECTED_DDS_SIZE` keep
+/// working. The dependency direction is `fuse -> cache::integrity`, never
+/// the reverse: `cache::integrity` must not import anything from `fuse`.
+pub use crate::cache::integrity::EXPECTED_DDS_SIZE;
 
 /// Validates that DDS data is well-formed and returns it, or substitutes
 /// the default placeholder if validation fails.

--- a/xearthlayer/src/ortho_union/cache.rs
+++ b/xearthlayer/src/ortho_union/cache.rs
@@ -6,10 +6,11 @@
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::io::{self, BufReader, BufWriter};
+use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+use bincode::Options;
 use serde::{Deserialize, Serialize};
 
 use super::index::OrthoUnionIndex;
@@ -114,37 +115,45 @@ impl IndexCache {
     }
 
     /// Load cache from file.
+    ///
+    /// The deserializer is bounded by the file's own length. Nothing
+    /// legitimate can require reading more bytes than the file holds, so this
+    /// rejects a corrupt length prefix with no risk of rejecting a valid
+    /// cache. The bound is not optional: an unbounded reader passes a garbage
+    /// length to `Vec::with_capacity`, which aborts the process — a failure no
+    /// caller can recover from, however carefully it handles `Err`.
     pub fn load(path: &Path) -> io::Result<Self> {
         let file = std::fs::File::open(path)?;
+        let limit = crate::cache::integrity::length_ceiling(&file)?;
         let reader = BufReader::new(file);
 
-        bincode::deserialize_from(reader).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Failed to deserialize index cache: {}", e),
-            )
-        })
+        // These three options reproduce legacy `bincode::deserialize_from`
+        // exactly. They are load-bearing: `bincode::options()` alone defaults
+        // to varint encoding and would fail to read every existing cache.
+        bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(limit)
+            .deserialize_from(reader)
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Failed to deserialize index cache: {}", e),
+                )
+            })
     }
 
     /// Save cache to file.
+    ///
+    /// Durability is delegated to `write_atomic`: temp file, flush, fsync,
+    /// rename, and cleanup on failure. Passing the writer by `&mut` is what
+    /// makes the explicit flush possible — `serialize_into` taking it by value
+    /// is how the drop-flush error came to be discarded.
     pub fn save(&self, path: &Path) -> io::Result<()> {
-        // Ensure parent directory exists
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        // Write to temp file first, then rename for atomicity
-        let temp_path = path.with_extension("tmp");
-        let file = std::fs::File::create(&temp_path)?;
-        let writer = BufWriter::new(file);
-
-        bincode::serialize_into(writer, self)
-            .map_err(|e| io::Error::other(format!("Failed to serialize index cache: {}", e)))?;
-
-        // Atomic rename
-        std::fs::rename(&temp_path, path)?;
-
-        Ok(())
+        crate::cache::integrity::write_atomic(path, |writer| {
+            bincode::serialize_into(writer, self)
+                .map_err(|e| io::Error::other(format!("Failed to serialize index cache: {}", e)))
+        })
     }
 
     /// Check if this cache is valid for the given key.
@@ -193,7 +202,17 @@ pub fn try_load_cached_index(
     cache_path: &Path,
     current_key: &IndexCacheKey,
 ) -> Option<OrthoUnionIndex> {
-    let cache = IndexCache::load(cache_path).ok()?;
+    let cache = match IndexCache::load(cache_path) {
+        Ok(cache) => cache,
+        Err(e) => {
+            tracing::warn!(
+                path = %cache_path.display(),
+                error = %e,
+                "Discarding unreadable index cache; rebuilding from sources"
+            );
+            return None;
+        }
+    };
 
     if cache.is_valid(current_key) {
         tracing::info!(
@@ -302,6 +321,79 @@ mod tests {
 
         let loaded = IndexCache::load(&cache_path).unwrap();
         assert!(loaded.is_valid(&key));
+    }
+
+    /// A cache whose serialized form contains realistic path text, so a
+    /// misaligned read lands on a path the way the field crash did.
+    fn realistic_cache() -> IndexCache {
+        let key = IndexCacheKey {
+            version: "0.4.7-beta.1".to_string(),
+            source_paths: vec![
+                PathBuf::from("/home/user/.xearthlayer/packages/xel-region-eu"),
+                PathBuf::from("/home/user/.xearthlayer/packages/xel-region-na"),
+            ],
+            source_mtimes_secs: vec![1_756_000_000, 1_756_000_001],
+            config_hash: 42,
+        };
+        IndexCache::new(key, OrthoUnionIndex::default())
+    }
+
+    #[test]
+    fn test_load_rejects_oversized_length_prefix() {
+        let temp = TempDir::new().unwrap();
+        let cache_path = temp.path().join("test.cache");
+        realistic_cache().save(&cache_path).unwrap();
+
+        // Overwrite the leading version-length prefix with an absurd length.
+        let mut bytes = std::fs::read(&cache_path).unwrap();
+        bytes[0..8].copy_from_slice(&(u64::MAX / 2).to_le_bytes());
+        std::fs::write(&cache_path, &bytes).unwrap();
+
+        assert!(
+            IndexCache::load(&cache_path).is_err(),
+            "an oversized length prefix must be an error, not a process abort"
+        );
+    }
+
+    #[test]
+    fn test_load_rejects_misaligned_cache() {
+        let temp = TempDir::new().unwrap();
+        let cache_path = temp.path().join("test.cache");
+        realistic_cache().save(&cache_path).unwrap();
+
+        // Drop one byte from the source-path count, shifting every later read
+        // so a length field lands on path text. This is the field failure.
+        let mut bytes = std::fs::read(&cache_path).unwrap();
+        bytes.remove(20);
+        std::fs::write(&cache_path, &bytes).unwrap();
+
+        assert!(
+            IndexCache::load(&cache_path).is_err(),
+            "a misaligned cache must be an error, not a process abort"
+        );
+    }
+
+    #[test]
+    fn test_load_rejects_truncated_cache() {
+        let temp = TempDir::new().unwrap();
+        let cache_path = temp.path().join("test.cache");
+        realistic_cache().save(&cache_path).unwrap();
+
+        let bytes = std::fs::read(&cache_path).unwrap();
+        std::fs::write(&cache_path, &bytes[..bytes.len() / 2]).unwrap();
+
+        assert!(IndexCache::load(&cache_path).is_err());
+    }
+
+    #[test]
+    fn test_save_leaves_no_temp_file_behind() {
+        let temp = TempDir::new().unwrap();
+        let cache_path = temp.path().join("test.cache");
+
+        realistic_cache().save(&cache_path).unwrap();
+
+        assert!(cache_path.exists());
+        assert!(!cache_path.with_extension("tmp").exists());
     }
 
     #[test]

--- a/xearthlayer/src/prefetch/scenery_cache.rs
+++ b/xearthlayer/src/prefetch/scenery_cache.rs
@@ -52,6 +52,14 @@ const FIELD_SEPARATOR: &str = "  ";
 /// Cache filename.
 const CACHE_FILENAME: &str = "scenery_index.cache";
 
+/// Minimum bytes a tile data line can occupy: `row  col  chunk_zoom  lat  lon
+/// is_sea\n` with every field at its shortest (single-digit values, no
+/// fractional part). Used to turn a raw byte ceiling into an element-count
+/// ceiling — `total_tiles` sizes a `Vec<SceneryTile>`, not a byte buffer, so
+/// bounding it by file bytes alone still lets a corrupt count over-reserve by
+/// `size_of::<SceneryTile>()` per byte of file.
+const MIN_TILE_LINE_BYTES: u64 = 11;
+
 /// Metadata about a cached package (for invalidation).
 #[derive(Debug, Clone, PartialEq)]
 pub struct CachedPackageInfo {
@@ -116,8 +124,19 @@ pub fn cache_path() -> PathBuf {
 /// This is useful for CLI commands that need to display cache statistics
 /// without the overhead of loading the full tile data.
 pub fn cache_status() -> io::Result<CacheStatus> {
-    let path = cache_path();
-    let file = File::open(&path)?;
+    cache_status_from(&cache_path())
+}
+
+/// Implementation behind [`cache_status`], parameterized by path for testing.
+fn cache_status_from(path: &std::path::Path) -> io::Result<CacheStatus> {
+    let file = File::open(path)?;
+
+    // A cache cannot hold more packages than it has bytes: every package
+    // occupies at least one line. Captured from the open handle before the
+    // BufReader takes it, mirroring `load_cache_from`'s tile-count bound —
+    // this is the same unbounded-allocation defect (#253) at a second site.
+    let ceiling = crate::cache::integrity::length_ceiling(&file)?;
+
     let reader = BufReader::new(file);
     let mut lines = reader.lines();
 
@@ -146,6 +165,17 @@ pub fn cache_status() -> io::Result<CacheStatus> {
     let package_count: usize = next_line()?
         .parse()
         .map_err(|_| io::Error::other("Failed to parse package count"))?;
+
+    if package_count as u64 > ceiling {
+        let reason = crate::cache::integrity::IntegrityError::ImplausibleLength {
+            claimed: package_count as u64,
+            ceiling,
+        };
+        return Err(io::Error::other(format!(
+            "Implausible package count: {:?}",
+            reason
+        )));
+    }
 
     // Parse tile counts
     let total_tiles: usize = next_line()?
@@ -244,12 +274,7 @@ pub fn save_cache(index: &SceneryIndex, packages: &[(String, PathBuf)]) -> io::R
     let path = cache_path();
     let package_infos = gather_package_info(packages)?;
 
-    // Ensure parent directory exists. `write_atomic` writes a sibling temp
-    // file and does not create directories itself.
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
+    // `write_atomic` creates the parent directory itself.
     crate::cache::integrity::write_atomic(&path, |writer| {
         // Header section
         writeln!(writer, "{}", CACHE_HEADER)?;
@@ -437,11 +462,16 @@ fn load_cache_from(path: &std::path::Path, packages: &[(String, PathBuf)]) -> Ca
         }
     };
 
-    if total_tiles as u64 > ceiling {
+    let max_tiles = ceiling / MIN_TILE_LINE_BYTES;
+    if total_tiles as u64 > max_tiles {
+        let reason = crate::cache::integrity::IntegrityError::ImplausibleLength {
+            claimed: total_tiles as u64,
+            ceiling: max_tiles,
+        };
         return CacheLoadResult::Invalid {
             error: format!(
-                "Implausible tile count {} for a {}-byte cache",
-                total_tiles, ceiling
+                "Implausible tile count for a {}-byte cache: {:?}",
+                ceiling, reason
             ),
         };
     }
@@ -786,6 +816,26 @@ mod tests {
             load_cache_from(&cache_file, &[]),
             CacheLoadResult::Invalid { .. }
         ));
+    }
+
+    #[test]
+    fn test_cache_status_implausible_package_count_is_error_not_fatal() {
+        let temp = TempDir::new().unwrap();
+        let cache_file = temp.path().join("scenery_index.cache");
+
+        // A structurally valid header whose package count cannot fit in the
+        // file — the same defect #253 fixed for `load_cache_from`'s tile
+        // count, reachable here via `xearthlayer scenery-index status`.
+        let mut file = std::fs::File::create(&cache_file).unwrap();
+        writeln!(file, "{}", CACHE_HEADER).unwrap();
+        writeln!(file, "{}", CACHE_VERSION).unwrap();
+        writeln!(file, "999999999999999999").unwrap(); // package count
+        writeln!(file, "0").unwrap(); // total_tiles
+        writeln!(file, "0").unwrap(); // sea_tiles
+        drop(file);
+
+        // Must be an `Err`, not a process abort from `Vec::with_capacity`.
+        assert!(cache_status_from(&cache_file).is_err());
     }
 
     #[test]

--- a/xearthlayer/src/prefetch/scenery_cache.rs
+++ b/xearthlayer/src/prefetch/scenery_cache.rs
@@ -31,7 +31,7 @@
 //! - Any terrain directory's file count changes
 
 use std::fs::{self, File};
-use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -244,59 +244,59 @@ pub fn save_cache(index: &SceneryIndex, packages: &[(String, PathBuf)]) -> io::R
     let path = cache_path();
     let package_infos = gather_package_info(packages)?;
 
-    // Ensure parent directory exists
+    // Ensure parent directory exists. `write_atomic` writes a sibling temp
+    // file and does not create directories itself.
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    let file = File::create(&path)?;
-    let mut writer = BufWriter::new(file);
+    crate::cache::integrity::write_atomic(&path, |writer| {
+        // Header section
+        writeln!(writer, "{}", CACHE_HEADER)?;
+        writeln!(writer, "{}", CACHE_VERSION)?;
+        writeln!(writer, "{}", packages.len())?;
+        writeln!(writer, "{}", index.tile_count())?;
+        writeln!(writer, "{}", index.sea_tile_count())?;
 
-    // Header section
-    writeln!(writer, "{}", CACHE_HEADER)?;
-    writeln!(writer, "{}", CACHE_VERSION)?;
-    writeln!(writer, "{}", packages.len())?;
-    writeln!(writer, "{}", index.tile_count())?;
-    writeln!(writer, "{}", index.sea_tile_count())?;
+        // Package metadata
+        for info in &package_infos {
+            writeln!(
+                writer,
+                "{}{}{}{}{}{}{}",
+                info.name,
+                FIELD_SEPARATOR,
+                info.path.display(),
+                FIELD_SEPARATOR,
+                info.terrain_mtime_secs,
+                FIELD_SEPARATOR,
+                info.terrain_file_count
+            )?;
+        }
 
-    // Package metadata
-    for info in &package_infos {
-        writeln!(
-            writer,
-            "{}{}{}{}{}{}{}",
-            info.name,
-            FIELD_SEPARATOR,
-            info.path.display(),
-            FIELD_SEPARATOR,
-            info.terrain_mtime_secs,
-            FIELD_SEPARATOR,
-            info.terrain_file_count
-        )?;
-    }
+        // Blank line separator
+        writeln!(writer)?;
 
-    // Blank line separator
-    writeln!(writer)?;
+        // Tile data
+        for tile in index.all_tiles() {
+            writeln!(
+                writer,
+                "{}{}{}{}{}{}{}{}{}{}{}",
+                tile.row,
+                FIELD_SEPARATOR,
+                tile.col,
+                FIELD_SEPARATOR,
+                tile.chunk_zoom,
+                FIELD_SEPARATOR,
+                tile.lat,
+                FIELD_SEPARATOR,
+                tile.lon,
+                FIELD_SEPARATOR,
+                if tile.is_sea { 1 } else { 0 }
+            )?;
+        }
 
-    // Tile data
-    for tile in index.all_tiles() {
-        writeln!(
-            writer,
-            "{}{}{}{}{}{}{}{}{}{}{}",
-            tile.row,
-            FIELD_SEPARATOR,
-            tile.col,
-            FIELD_SEPARATOR,
-            tile.chunk_zoom,
-            FIELD_SEPARATOR,
-            tile.lat,
-            FIELD_SEPARATOR,
-            tile.lon,
-            FIELD_SEPARATOR,
-            if tile.is_sea { 1 } else { 0 }
-        )?;
-    }
-
-    writer.flush()?;
+        Ok(())
+    })?;
 
     info!(
         path = %path.display(),
@@ -314,8 +314,15 @@ pub fn save_cache(index: &SceneryIndex, packages: &[(String, PathBuf)]) -> io::R
 /// Returns `Stale` if packages have changed, `NotFound` if cache doesn't exist,
 /// or `Invalid` if the cache is corrupted.
 pub fn load_cache(packages: &[(String, PathBuf)]) -> CacheLoadResult {
-    let path = cache_path();
+    load_cache_from(&cache_path(), packages)
+}
 
+/// Load the scenery index from a specific cache file path.
+///
+/// Split out from [`load_cache`] so tests can point at a temporary file
+/// instead of the live `~/.xearthlayer/scenery_index.cache` — a real,
+/// potentially 180 MB file that must never be read or mutated by a test.
+fn load_cache_from(path: &std::path::Path, packages: &[(String, PathBuf)]) -> CacheLoadResult {
     // Check cache exists
     if !path.exists() {
         debug!(path = %path.display(), "Cache file not found");
@@ -333,11 +340,24 @@ pub fn load_cache(packages: &[(String, PathBuf)]) -> CacheLoadResult {
     };
 
     // Open and parse cache file
-    let file = match File::open(&path) {
+    let file = match File::open(path) {
         Ok(f) => f,
         Err(e) => {
             return CacheLoadResult::Invalid {
                 error: format!("Failed to open cache file: {}", e),
+            }
+        }
+    };
+
+    // A cache cannot hold more tiles than it has bytes: every tile occupies
+    // at least one line. Bounding here is what makes the `Invalid` verdict
+    // below reachable — `Vec::with_capacity` on an implausible count aborts
+    // the process, and no caller can recover from that.
+    let ceiling = match crate::cache::integrity::length_ceiling(&file) {
+        Ok(len) => len,
+        Err(e) => {
+            return CacheLoadResult::Invalid {
+                error: format!("Failed to stat cache file: {}", e),
             }
         }
     };
@@ -416,6 +436,15 @@ pub fn load_cache(packages: &[(String, PathBuf)]) -> CacheLoadResult {
             }
         }
     };
+
+    if total_tiles as u64 > ceiling {
+        return CacheLoadResult::Invalid {
+            error: format!(
+                "Implausible tile count {} for a {}-byte cache",
+                total_tiles, ceiling
+            ),
+        };
+    }
 
     let sea_tiles: usize = match next_line().and_then(|s| s.parse().ok()) {
         Some(c) => c,
@@ -735,6 +764,28 @@ mod tests {
         let result = validate_packages(&[cached], &[current]);
         assert!(result.is_some());
         assert!(result.unwrap().contains("file count"));
+    }
+
+    #[test]
+    fn test_implausible_tile_count_is_invalid_not_fatal() {
+        let temp = TempDir::new().unwrap();
+        let cache_file = temp.path().join("scenery_index.cache");
+
+        // A structurally valid cache whose tile count cannot fit in the file.
+        let mut file = std::fs::File::create(&cache_file).unwrap();
+        writeln!(file, "{}", CACHE_HEADER).unwrap();
+        writeln!(file, "{}", CACHE_VERSION).unwrap();
+        writeln!(file, "0").unwrap(); // package count
+        writeln!(file, "999999999999999999").unwrap(); // total_tiles
+        writeln!(file, "0").unwrap(); // sea_tiles
+        writeln!(file).unwrap();
+        drop(file);
+
+        // Must be a verdict, not a process abort.
+        assert!(matches!(
+            load_cache_from(&cache_file, &[]),
+            CacheLoadResult::Invalid { .. }
+        ));
     }
 
     #[test]

--- a/xearthlayer/src/service/cache_layer.rs
+++ b/xearthlayer/src/service/cache_layer.rs
@@ -332,6 +332,7 @@ impl CacheLayer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache::integrity::EXPECTED_DDS_SIZE;
     use crate::executor::{DdsDiskCache, DiskCache, MemoryCache};
     use bytes::Bytes;
     use tempfile::tempdir;
@@ -432,9 +433,14 @@ mod tests {
         let cache_layer = CacheLayer::new(&config, "test", metrics).await.unwrap();
         let bridge = cache_layer.dds_disk_bridge();
 
-        bridge.put(100, 200, 15, vec![1, 2, 3].into()).await;
+        // This bridge is backed by the real DDS tier (`.as_dds_tier()`), so
+        // a round trip must satisfy the DDS validator (#253) — arbitrary
+        // bytes would now be discarded as corrupt and reported as a miss.
+        let mut tile = vec![0u8; EXPECTED_DDS_SIZE];
+        tile[0..4].copy_from_slice(b"DDS ");
+        bridge.put(100, 200, 15, Bytes::from(tile.clone())).await;
         let result = bridge.get(100, 200, 15).await;
-        assert_eq!(result, Some(Bytes::from(vec![1, 2, 3])));
+        assert_eq!(result, Some(Bytes::from(tile)));
 
         assert!(bridge.contains(100, 200, 15).await);
         assert!(!bridge.contains(999, 999, 15).await);


### PR DESCRIPTION
Closes #253 — RC1 blocker.

## The fix

A user reported `memory allocation of 3418906639127570548 bytes failed` at startup on 0.4.7-beta.1. That number is `0x2f726579616c6874` — the ASCII bytes **`thlayer/`**, a fragment of `~/.xearthlayer/`. It is not an allocation size; it is eight bytes of a path string read as a `u64` length prefix from a corrupt `ortho_union_index.cache`.

`bincode::deserialize_from` ran unbounded, so a garbage length reached `Vec::with_capacity` → `handle_alloc_error` → abort. `try_load_cached_index` already intended "corrupt cache → discard and rebuild" via `.ok()?`, but that intent was unreachable: `.ok()?` catches `Err`, never `SIGABRT`. Reproduced by deleting **one byte** from a real cache file.

An audit found the same defect class in the scenery index cache (unbounded `total_tiles`, and again in `cache_status()`), plus two disk-tier gaps. Rather than patch four sites, this standardizes every cache on one model in `cache/integrity/` with four invariants:

1. A read has two outcomes — a trusted value or a miss. Malformed is a miss.
2. Every length taken from file content is bounded by evidence from that file.
3. A rejected entry is deleted, not left to be rejected again forever.
4. A write is durable or it never happened: temp → flush → fsync → rename.

## Verification

- `make pre-commit` clean: 2514 lib tests + 60 doctests, 0 failed.
- **Mutation-checked**: reverting `.with_limit()` returns the corruption tests to `SIGABRT`; removing the `total_tiles` bound returns that test to `capacity overflow`.
- **Format guards**: `test_cache_save_and_load` and `test_cache_round_trip` are present, unmodified, and passing — the on-disk formats are byte-identical. The `with_fixint_encoding()` / `allow_trailing_bytes()` options are load-bearing; a plain `bincode::options()` would default to varint and break every existing cache.
- Reviewed per-task, then whole-branch on a stronger model; 3 Important + 6 Minor findings all fixed and re-reviewed.

**Honest limit:** removing `sync_all()` leaves the suite green. fsync ordering is not unit-testable without a fault-injecting filesystem — it is addressed by construction and verified by inspection only. Stated in the design doc rather than implied by a test.

## Upgrade-path fix worth calling out for release notes

`3f297b1` ("emit complete mipmap chains") landed in v0.4.7-alpha.1, so **every 0.4.6 user's DDS disk cache holds 5-level tiles of the wrong byte size**. On 0.4.7 today those are read, rejected at the FUSE boundary, served as magenta, and *left on disk forever*. This branch makes them self-heal. Expect a one-time cache-miss storm on the first 0.4.6→0.4.7 flight.

## Deliberate non-decisions

- **Chunk validation is non-empty-only.** Asserting a JPEG magic would need all seven providers audited for response format; an unverified magic would reject valid chunks.
- **`CacheLoadResult::Stale` stays distinct from `Invalid`** — stale is correct-but-outdated data, not corruption.
- **No fsync added to `DiskCacheProvider::set()`.** It is already atomic, so no reader sees a torn file; an fsync per chunk write is a synchronous barrier 256× per tile against a hazard whose entire consequence is a cache miss. Recorded under Known Limitations.

## Notes for reviewers

- The empty `[Unreleased]` CHANGELOG section is intentional — the CHANGELOG is compiled at release-cut time.
- Workaround for users on the current beta: `rm ~/.xearthlayer/ortho_union_index.cache`.
- `EXPECTED_DDS_SIZE` remains BC1-only while `texture.format` accepts `bc3`; reachability unverified, carries a `TODO(#253)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)