### PR TITLE
fix(config): remove the executor pool-sizing keys that never reached the executor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,7 +405,7 @@ Key sections:
 - `[texture]` - DDS format (bc1/bc3), compressor backend (software/ispc/gpu), GPU device selection
 - `[prefetch]` - Boundary-driven prefetch, web_api_port (default 8086), calibration, transition ramp
 - `[prewarm]` - Cold-start cache warming (grid_rows/grid_cols for DSF tile grid around airport)
-- `[executor]` - Resource pool capacities (network, CPU, disk I/O), job limits, retry behavior
+- `[executor]` - Job limits and retry behavior. Resource pool capacities are NOT configurable — they are derived from logical core count by `ResourcePoolConfig::default()` (see #249)
 - `[fuse]` - FUSE kernel limits (max_background, congestion_threshold)
 - `[packages]` - Package manager settings (concurrent_downloads: parallel part downloads 1-10)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,14 +218,13 @@ timeout = 10
 
 ### [executor]
 
-Controls the job executor daemon's resource pools and concurrency limits. The executor is the core tile processing engine that manages parallel downloads, encoding, and caching.
+Controls the job executor daemon's job limits and download behaviour. The executor is the core tile processing engine that manages parallel downloads, encoding, and caching.
+
+**Resource pool capacities are not configurable.** Network, CPU and disk I/O pool sizes are derived from the host's logical core count by `ResourcePoolConfig::default()`, using multipliers tuned by flight testing and load-bearing for the memory behaviour fixed in [#227](https://github.com/samsoir/xearthlayer/issues/227). The `network_concurrent`, `cpu_concurrent` and `disk_io_concurrent` keys were removed in [#249](https://github.com/samsoir/xearthlayer/issues/249): they never reached the executor, so any value on disk described a capacity nothing used. `xearthlayer config upgrade` removes them.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `max_concurrent_jobs` | integer | `ceil(num_cpus × 0.75)` | Maximum concurrent DDS tile jobs (1-256). Previously in `[control_plane]`. |
-| `network_concurrent` | integer | `128` | Concurrent HTTP connections (clamped to 64-256) |
-| `cpu_concurrent` | integer | `num_cpus / 2` | Concurrent CPU-bound operations (assemble + encode) — leaves headroom for X-Plane |
-| `disk_io_concurrent` | integer | `64` | Concurrent disk I/O operations (auto-detected from storage type) |
 | `request_timeout_secs` | integer | `10` | HTTP request timeout per chunk (seconds) |
 | `max_retries` | integer | `3` | Maximum retry attempts per failed chunk |
 | `retry_base_delay_ms` | integer | `100` | Base delay for exponential backoff (ms) |
@@ -235,11 +234,6 @@ Controls the job executor daemon's resource pools and concurrency limits. The ex
 [executor]
 ; Job concurrency (defaults are tuned for most systems)
 ; max_concurrent_jobs = 12       ; Max concurrent tile jobs (ceil(num_cpus * 0.75))
-
-; Resource pool sizing
-network_concurrent = 128         ; HTTP connections (64-256 range)
-cpu_concurrent = 8               ; CPU-bound ops (defaults to num_cpus / 2)
-disk_io_concurrent = 64          ; Disk I/O (auto-detected from storage type)
 
 ; Download behavior
 request_timeout_secs = 10        ; Per-chunk timeout

--- a/xearthlayer-cli/src/commands/run.rs
+++ b/xearthlayer-cli/src/commands/run.rs
@@ -164,10 +164,13 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
     // Check if we'll use TUI (need to know before creating services)
     let use_tui = atty::is(atty::Stream::Stdout);
 
-    // Build pipeline settings from executor config (executor replaced the deprecated pipeline section)
+    // Pool sizing is no longer configurable (#249) — it is derived by
+    // ResourcePoolConfig::default(). These two fields keep their own defaults so
+    // PipelineSettings still constructs; nothing reads them today, since
+    // ServiceConfig::pipeline() has no caller.
     let pipeline_settings = PipelineSettings {
-        max_http_concurrent: config.executor.network_concurrent,
-        max_cpu_concurrent: config.executor.cpu_concurrent,
+        max_http_concurrent: xearthlayer::config::default_http_concurrent(),
+        max_cpu_concurrent: xearthlayer::config::default_cpu_concurrent(),
         max_prefetch_in_flight: config.pipeline.max_prefetch_in_flight,
         request_timeout_secs: config.executor.request_timeout_secs,
         max_retries: config.executor.max_retries,

--- a/xearthlayer/src/config/defaults.rs
+++ b/xearthlayer/src/config/defaults.rs
@@ -59,13 +59,6 @@ pub fn default_max_concurrent_jobs() -> usize {
     (num_cpus() / 2).max(2)
 }
 
-/// Default executor CPU concurrent: num_cpus / 2, minimum 2.
-///
-/// Matches the pipeline CPU concurrent default — leaves headroom for X-Plane.
-pub fn default_executor_cpu_concurrent() -> usize {
-    (num_cpus() / 2).max(2)
-}
-
 /// Clamps HTTP concurrency to valid range and logs a warning if clamped.
 pub(super) fn clamp_http_concurrent(value: usize) -> usize {
     if value < MIN_HTTP_CONCURRENT {
@@ -292,13 +285,6 @@ pub const DEFAULT_GPU_DEVICE: &str = "integrated";
 // Executor defaults
 // =============================================================================
 
-/// Default network resource pool capacity.
-/// Conservative default of 128 prevents provider rate limiting.
-pub const DEFAULT_EXECUTOR_NETWORK_CONCURRENT: usize = 128;
-
-/// Default disk I/O resource pool capacity for SSD storage.
-pub const DEFAULT_EXECUTOR_DISK_IO_CONCURRENT: usize = 64;
-
 /// Default maximum concurrent tasks in the executor.
 pub const DEFAULT_EXECUTOR_MAX_CONCURRENT_TASKS: usize = 128;
 
@@ -416,9 +402,6 @@ impl Default for ConfigFile {
                 directory: Some(config_dir.join("patches")),
             },
             executor: ExecutorSettings {
-                network_concurrent: DEFAULT_EXECUTOR_NETWORK_CONCURRENT,
-                cpu_concurrent: default_executor_cpu_concurrent(),
-                disk_io_concurrent: DEFAULT_EXECUTOR_DISK_IO_CONCURRENT,
                 max_concurrent_tasks: DEFAULT_EXECUTOR_MAX_CONCURRENT_TASKS,
                 job_channel_capacity: DEFAULT_EXECUTOR_JOB_CHANNEL_CAPACITY,
                 request_channel_capacity: DEFAULT_EXECUTOR_REQUEST_CHANNEL_CAPACITY,

--- a/xearthlayer/src/config/keys.rs
+++ b/xearthlayer/src/config/keys.rs
@@ -108,9 +108,6 @@ pub enum ConfigKey {
     PatchesDirectory,
 
     // Executor settings
-    ExecutorNetworkConcurrent,
-    ExecutorCpuConcurrent,
-    ExecutorDiskIoConcurrent,
     ExecutorMaxConcurrentJobs,
     ExecutorRequestTimeoutSecs,
     ExecutorMaxRetries,
@@ -188,9 +185,6 @@ impl FromStr for ConfigKey {
             "patches.directory" => Ok(ConfigKey::PatchesDirectory),
 
             // Executor settings
-            "executor.network_concurrent" => Ok(ConfigKey::ExecutorNetworkConcurrent),
-            "executor.cpu_concurrent" => Ok(ConfigKey::ExecutorCpuConcurrent),
-            "executor.disk_io_concurrent" => Ok(ConfigKey::ExecutorDiskIoConcurrent),
             "executor.max_concurrent_jobs" => Ok(ConfigKey::ExecutorMaxConcurrentJobs),
             "executor.request_timeout_secs" => Ok(ConfigKey::ExecutorRequestTimeoutSecs),
             "executor.max_retries" => Ok(ConfigKey::ExecutorMaxRetries),
@@ -260,9 +254,6 @@ impl ConfigKey {
             ConfigKey::PatchesDirectory => "patches.directory",
 
             // Executor settings
-            ConfigKey::ExecutorNetworkConcurrent => "executor.network_concurrent",
-            ConfigKey::ExecutorCpuConcurrent => "executor.cpu_concurrent",
-            ConfigKey::ExecutorDiskIoConcurrent => "executor.disk_io_concurrent",
             ConfigKey::ExecutorMaxConcurrentJobs => "executor.max_concurrent_jobs",
             ConfigKey::ExecutorRequestTimeoutSecs => "executor.request_timeout_secs",
             ConfigKey::ExecutorMaxRetries => "executor.max_retries",
@@ -400,9 +391,6 @@ impl ConfigKey {
                 .unwrap_or_default(),
 
             // Executor settings
-            ConfigKey::ExecutorNetworkConcurrent => config.executor.network_concurrent.to_string(),
-            ConfigKey::ExecutorCpuConcurrent => config.executor.cpu_concurrent.to_string(),
-            ConfigKey::ExecutorDiskIoConcurrent => config.executor.disk_io_concurrent.to_string(),
             ConfigKey::ExecutorMaxConcurrentJobs => {
                 config.control_plane.max_concurrent_jobs.to_string()
             }
@@ -573,15 +561,6 @@ impl ConfigKey {
             }
 
             // Executor settings
-            ConfigKey::ExecutorNetworkConcurrent => {
-                config.executor.network_concurrent = value.parse().unwrap();
-            }
-            ConfigKey::ExecutorCpuConcurrent => {
-                config.executor.cpu_concurrent = value.parse().unwrap();
-            }
-            ConfigKey::ExecutorDiskIoConcurrent => {
-                config.executor.disk_io_concurrent = value.parse().unwrap();
-            }
             ConfigKey::ExecutorMaxConcurrentJobs => {
                 config.control_plane.max_concurrent_jobs = value.parse().unwrap();
             }
@@ -672,9 +651,6 @@ impl ConfigKey {
             ConfigKey::PatchesDirectory => Box::new(OptionalPathSpec),
 
             // Executor settings
-            ConfigKey::ExecutorNetworkConcurrent => Box::new(PositiveIntegerSpec),
-            ConfigKey::ExecutorCpuConcurrent => Box::new(PositiveIntegerSpec),
-            ConfigKey::ExecutorDiskIoConcurrent => Box::new(PositiveIntegerSpec),
             ConfigKey::ExecutorMaxConcurrentJobs => Box::new(IntegerRangeSpec::new(1, 256)),
             ConfigKey::ExecutorRequestTimeoutSecs => Box::new(PositiveIntegerSpec),
             ConfigKey::ExecutorMaxRetries => Box::new(PositiveIntegerSpec),
@@ -738,9 +714,6 @@ impl ConfigKey {
             ConfigKey::PatchesEnabled,
             ConfigKey::PatchesDirectory,
             // Executor settings
-            ConfigKey::ExecutorNetworkConcurrent,
-            ConfigKey::ExecutorCpuConcurrent,
-            ConfigKey::ExecutorDiskIoConcurrent,
             ConfigKey::ExecutorMaxConcurrentJobs,
             ConfigKey::ExecutorRequestTimeoutSecs,
             ConfigKey::ExecutorMaxRetries,
@@ -1381,5 +1354,22 @@ mod tests {
         assert!(key.validate("RTX 5090").is_ok());
         assert!(key.validate("").is_err());
         assert!(key.validate("   ").is_err());
+    }
+
+    #[test]
+    fn executor_pool_keys_are_no_longer_settable() {
+        // Removed in #249. Pool sizing is derived from the tuned policy in
+        // ResourcePoolConfig::default(); `config set` must not offer a lever
+        // that would silently undo it.
+        for key in [
+            "executor.network_concurrent",
+            "executor.cpu_concurrent",
+            "executor.disk_io_concurrent",
+        ] {
+            assert!(
+                ConfigKey::from_str(key).is_err(),
+                "{key} should no longer resolve to a ConfigKey"
+            );
+        }
     }
 }

--- a/xearthlayer/src/config/mod.rs
+++ b/xearthlayer/src/config/mod.rs
@@ -45,8 +45,6 @@ pub use file::{
     config_directory,
     config_file_path,
     default_cpu_concurrent,
-    // Executor defaults
-    default_executor_cpu_concurrent,
     default_http_concurrent,
     default_max_concurrent_jobs,
     default_prefetch_in_flight,
@@ -78,10 +76,8 @@ pub use file::{
     DEFAULT_DISK_CACHE_SIZE,
     // Download defaults
     DEFAULT_DOWNLOAD_TIMEOUT_SECS,
-    DEFAULT_EXECUTOR_DISK_IO_CONCURRENT,
     DEFAULT_EXECUTOR_JOB_CHANNEL_CAPACITY,
     DEFAULT_EXECUTOR_MAX_CONCURRENT_TASKS,
-    DEFAULT_EXECUTOR_NETWORK_CONCURRENT,
     DEFAULT_EXECUTOR_REQUEST_CHANNEL_CAPACITY,
     // Generation defaults
     DEFAULT_GENERATION_TIMEOUT_SECS,

--- a/xearthlayer/src/config/parser.rs
+++ b/xearthlayer/src/config/parser.rs
@@ -537,16 +537,6 @@ pub(super) fn parse_ini(ini: &Ini) -> Result<ConfigFile, ConfigFileError> {
 
     // [executor] section
     if let Some(section) = ini.section(Some("executor")) {
-        if let Some(v) = section.get("network_concurrent") {
-            let parsed: usize = v.parse().map_err(|_| ConfigFileError::InvalidValue {
-                section: "executor".to_string(),
-                key: "network_concurrent".to_string(),
-                value: v.to_string(),
-                reason: "must be a positive integer".to_string(),
-            })?;
-            // Clamp to valid range (same as HTTP concurrent)
-            config.executor.network_concurrent = clamp_http_concurrent(parsed);
-        }
         // Moved from the deprecated [control_plane] section in #160. Parsed after
         // [control_plane] above, so the [executor] value wins when both are present.
         if let Some(v) = section.get("max_concurrent_jobs") {
@@ -554,24 +544,6 @@ pub(super) fn parse_ini(ini: &Ini) -> Result<ConfigFile, ConfigFileError> {
                 v.parse().map_err(|_| ConfigFileError::InvalidValue {
                     section: "executor".to_string(),
                     key: "max_concurrent_jobs".to_string(),
-                    value: v.to_string(),
-                    reason: "must be a positive integer".to_string(),
-                })?;
-        }
-        if let Some(v) = section.get("cpu_concurrent") {
-            config.executor.cpu_concurrent =
-                v.parse().map_err(|_| ConfigFileError::InvalidValue {
-                    section: "executor".to_string(),
-                    key: "cpu_concurrent".to_string(),
-                    value: v.to_string(),
-                    reason: "must be a positive integer".to_string(),
-                })?;
-        }
-        if let Some(v) = section.get("disk_io_concurrent") {
-            config.executor.disk_io_concurrent =
-                v.parse().map_err(|_| ConfigFileError::InvalidValue {
-                    section: "executor".to_string(),
-                    key: "disk_io_concurrent".to_string(),
                     value: v.to_string(),
                     reason: "must be a positive integer".to_string(),
                 })?;
@@ -747,8 +719,6 @@ max_concurrent_jobs = 12
         let mut config = ConfigFile::default();
         config.cache.dds_disk_ratio = 0.75;
         config.generation.timeout = 42;
-        config.executor.cpu_concurrent = 7;
-        config.executor.disk_io_concurrent = 33;
         config.control_plane.max_concurrent_jobs = 11;
         config.fuse.max_background = 512;
         config.fuse.congestion_threshold = 384;
@@ -759,8 +729,6 @@ max_concurrent_jobs = 12
         let loaded = ConfigFile::load_from(&config_path).unwrap();
         assert_eq!(loaded.cache.dds_disk_ratio, 0.75);
         assert_eq!(loaded.generation.timeout, 42);
-        assert_eq!(loaded.executor.cpu_concurrent, 7);
-        assert_eq!(loaded.executor.disk_io_concurrent, 33);
         assert_eq!(loaded.control_plane.max_concurrent_jobs, 11);
         assert_eq!(loaded.fuse.max_background, 512);
         assert_eq!(loaded.fuse.congestion_threshold, 384);
@@ -1035,6 +1003,34 @@ temp_dir = /tmp/xearthlayer
         assert_eq!(
             config.packages.temp_dir,
             Some(PathBuf::from("/tmp/xearthlayer"))
+        );
+    }
+
+    #[test]
+    fn config_with_removed_executor_pool_keys_still_loads() {
+        // Every user upgrading to this release has these three keys on disk.
+        // They must be ignored, never rejected -- a hard error here would stop
+        // XEarthLayer starting for the entire existing install base.
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.ini");
+
+        std::fs::write(
+            &config_path,
+            r#"
+[executor]
+network_concurrent = 256
+cpu_concurrent = 16
+disk_io_concurrent = 64
+max_retries = 5
+"#,
+        )
+        .unwrap();
+
+        let config = ConfigFile::load_from(&config_path)
+            .expect("a config carrying the removed keys must still load");
+        assert_eq!(
+            config.executor.max_retries, 5,
+            "surrounding keys still parse"
         );
     }
 }

--- a/xearthlayer/src/config/settings.rs
+++ b/xearthlayer/src/config/settings.rs
@@ -292,15 +292,6 @@ pub struct PatchesSettings {
 /// Executor daemon configuration for the job/task framework.
 #[derive(Debug, Clone)]
 pub struct ExecutorSettings {
-    /// Network resource pool capacity (concurrent HTTP connections).
-    /// Default: 128 (clamped to 64-256 range)
-    pub network_concurrent: usize,
-    /// CPU resource pool capacity (concurrent assemble/encode operations).
-    /// Default: num_cpus * 1.25, minimum num_cpus + 2
-    pub cpu_concurrent: usize,
-    /// Disk I/O resource pool capacity (concurrent disk operations).
-    /// Default: 64 for SSD, auto-detected from storage type
-    pub disk_io_concurrent: usize,
     /// Maximum concurrent tasks the executor can run.
     /// Default: 128
     pub max_concurrent_tasks: usize,

--- a/xearthlayer/src/config/upgrade.rs
+++ b/xearthlayer/src/config/upgrade.rs
@@ -140,6 +140,14 @@ pub const DEPRECATED_KEYS: &[&str] = &[
     "control_plane.stall_threshold_secs",
     "control_plane.health_check_interval_secs",
     "control_plane.semaphore_timeout_secs",
+    // Removed in #249 — resource pool sizing is derived from the tuned policy in
+    // ResourcePoolConfig::default() and is not user-overridable. The values these
+    // keys carried never reached the executor, so no value on disk represents a
+    // considered choice; config list even reported a cpu_concurrent computed by a
+    // second, contradictory formula that nothing consumed.
+    "executor.network_concurrent",
+    "executor.cpu_concurrent",
+    "executor.disk_io_concurrent",
     // Removed in #160 — internal executor implementation details not useful as config
     "executor.max_concurrent_tasks",
     "executor.job_channel_capacity",
@@ -614,6 +622,55 @@ type = bing
         let summary = analysis.summary();
         assert!(summary.contains("2 new setting(s)"));
         assert!(summary.contains("1 deprecated setting(s)"));
+    }
+
+    #[test]
+    fn test_deprecated_executor_pool_keys() {
+        // Removed in #249: pool sizing is derived from the tuned policy in
+        // ResourcePoolConfig::default() and is no longer user-overridable.
+        assert!(DEPRECATED_KEYS.contains(&"executor.network_concurrent"));
+        assert!(DEPRECATED_KEYS.contains(&"executor.cpu_concurrent"));
+        assert!(DEPRECATED_KEYS.contains(&"executor.disk_io_concurrent"));
+    }
+
+    #[test]
+    fn test_analyze_flags_executor_pool_keys_as_deprecated() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.ini");
+
+        std::fs::write(
+            &config_path,
+            r#"
+[executor]
+network_concurrent = 256
+cpu_concurrent = 16
+disk_io_concurrent = 64
+"#,
+        )
+        .unwrap();
+
+        let analysis = analyze_config(&config_path).unwrap();
+
+        for key in [
+            "executor.network_concurrent",
+            "executor.cpu_concurrent",
+            "executor.disk_io_concurrent",
+        ] {
+            assert!(
+                analysis.deprecated_keys.contains(&key.to_string()),
+                "{key} should be reported as deprecated, not silently kept"
+            );
+            assert!(
+                !analysis.unknown_keys.contains(&key.to_string()),
+                "{key} is a known removal, not an unrecognised key"
+            );
+            assert!(
+                !analysis.missing_keys.contains(&key.to_string()),
+                "{key} must not also be reported as missing - that is the \
+                 self-contradiction that made needs_upgrade permanently true \
+                 during the disk_io_profile removal"
+            );
+        }
     }
 
     #[test]

--- a/xearthlayer/src/config/writer.rs
+++ b/xearthlayer/src/config/writer.rs
@@ -114,13 +114,6 @@ timeout = {}
 ; Job executor daemon settings for tile generation.
 ; These control resource pools, concurrency, and retry behavior.
 
-; Resource pool capacities (concurrent operations by type)
-; Network: HTTP connections for chunk downloads (default: 128, clamped to 64-256)
-network_concurrent = {}
-; CPU: Assemble + encode operations (default: num_cpus / 2)
-cpu_concurrent = {}
-; Disk I/O: Cache read/write operations (default: 64 for SSD)
-disk_io_concurrent = {}
 ; Maximum concurrent DDS tile jobs (default: num_cpus / 2)
 max_concurrent_jobs = {}
 
@@ -272,9 +265,6 @@ congestion_threshold = {}
         config.generation.threads,
         config.generation.timeout,
         // Executor settings
-        config.executor.network_concurrent,
-        config.executor.cpu_concurrent,
-        config.executor.disk_io_concurrent,
         config.control_plane.max_concurrent_jobs,
         config.executor.request_timeout_secs,
         config.executor.max_retries,

--- a/xearthlayer/src/executor/config.rs
+++ b/xearthlayer/src/executor/config.rs
@@ -54,17 +54,6 @@ impl Default for ExecutorConfig {
     }
 }
 
-impl From<&crate::config::ExecutorSettings> for ExecutorConfig {
-    fn from(settings: &crate::config::ExecutorSettings) -> Self {
-        Self {
-            resource_pools: ResourcePoolConfig::from(settings),
-            job_channel_capacity: settings.job_channel_capacity,
-            max_concurrent_tasks: settings.max_concurrent_tasks,
-            job_concurrency_limits: JobConcurrencyLimits::new(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/xearthlayer/src/executor/daemon.rs
+++ b/xearthlayer/src/executor/daemon.rs
@@ -123,15 +123,6 @@ impl Default for ExecutorDaemonConfig {
     }
 }
 
-impl From<&crate::config::ExecutorSettings> for ExecutorDaemonConfig {
-    fn from(settings: &crate::config::ExecutorSettings) -> Self {
-        Self {
-            executor: ExecutorConfig::from(settings),
-            channel_capacity: settings.request_channel_capacity,
-        }
-    }
-}
-
 // =============================================================================
 // Memory Cache Trait (minimal interface for daemon)
 // =============================================================================

--- a/xearthlayer/src/executor/resource_pool.rs
+++ b/xearthlayer/src/executor/resource_pool.rs
@@ -459,17 +459,6 @@ impl ResourcePoolConfig {
     }
 }
 
-impl From<&crate::config::ExecutorSettings> for ResourcePoolConfig {
-    fn from(settings: &crate::config::ExecutorSettings) -> Self {
-        Self {
-            network: settings.network_concurrent,
-            disk_io: settings.disk_io_concurrent,
-            cpu: settings.cpu_concurrent,
-            max_prefetch_fraction: DEFAULT_MAX_PREFETCH_FRACTION,
-        }
-    }
-}
-
 // =============================================================================
 // Resource Pools Collection
 // =============================================================================

--- a/xearthlayer/src/manager/mounts.rs
+++ b/xearthlayer/src/manager/mounts.rs
@@ -431,10 +431,12 @@ impl MountManager {
         // I/O, and at 512 threads it ratchets glibc's arena high-water mark on
         // every excursion. See runtime::build_service_runtime and issue #227.
         //
-        // `ResourcePoolConfig::default()` is what the executor receives here,
-        // via `RuntimeConfig::default()` in `service::RuntimeBuilder`. If that
-        // path ever takes user `[executor]` settings, this must take the same
-        // config or the cap goes stale.
+        // `ResourcePoolConfig::default()` is the only source of pool sizing,
+        // here and in `RuntimeConfig::default()` for the executor, so the cap
+        // and the pools it bounds cannot diverge. The `[executor]` sizing keys
+        // that could once have forked this were removed in #249 precisely
+        // because they reached neither path — a config carrying them silently
+        // described capacities nothing used.
         let runtime = match crate::runtime::build_service_runtime(
             &crate::executor::ResourcePoolConfig::default(),
         ) {


### PR DESCRIPTION
Addresses the pool-sizing half of #249. **Does not close it** — see Scope below.

## Why removal rather than wiring

`executor.network_concurrent`, `executor.cpu_concurrent` and `executor.disk_io_concurrent` were parsed, validated and reported by `config list`, but no value ever reached a resource pool. The pools have always been sized by `ResourcePoolConfig::default()`.

The keys were worse than inert. `config list` reported values computed by a **second formula that contradicted the live one**:

| | formula | on a 32-thread host |
|---|---|---|
| `config list` printed | `num_cpus / 2` | **16** |
| the executor actually ran | `ceil(cores × 1.25)` | **40** |

16 is plausible enough to read as a physical-core derivation — it isn’t; it’s `32 / 2`, and it only matches physical cores because SMT happens to be exactly 2×.

**Wiring these, as #249 proposes, would have been a regression.** A config written before #57 still carries `network_concurrent = 256` — the exact figure #57 removed to fix priority inversion — and #227 established that glibc’s arena high-water is driven by our own peak concurrency, so a pool size is a memory decision, not only a throughput one. The config defaults also break the pipeline-balance invariant #57 set (`network = cpu × 1.5`): they specify 128 and 16, a ratio of 8×.

So pool sizing is derived, full stop. `ResourcePoolConfig::default()` is **unchanged** — its multipliers are flight-tuned and deliberately untouched.

## What else went

The `From<&ExecutorSettings>` impls for `ResourcePoolConfig`, `ExecutorConfig` and `ExecutorDaemonConfig`. They existed only to carry these values into the executor — the path #249 identifies as never taken — and had no production caller; every construction site already used `::default()`.

## Upgrade safety

A config still containing the three keys **loads normally**; `config upgrade` removes them. There is a regression test for exactly this, because every existing user has these keys on disk and a hard parse error would stop XEarthLayer starting for the entire install base.

The `DEPRECATED_KEYS` addition and the `ConfigKey` removal land in **one commit** deliberately: splitting them is what made `analyze_config` treat a key as both expected and deprecated during the `disk_io_profile` removal, pinning `needs_upgrade` permanently true.

## Verification

- `make pre-commit` clean — 2528 tests (up from 2524), 0 failed.
- **Mutation-checked**: reverting the `DEPRECATED_KEYS` entries makes both deprecation tests fail, so they guard the fix rather than assert it.
- `config_with_removed_executor_pool_keys_still_loads` passes before *and* after by design — it is a compatibility guard, not a reproduction.

## Docs corrected as fallout

- `docs/configuration.md` still described `disk_io_concurrent` as "auto-detected from storage type" — a fossil of the `disk_io_profile` machinery removed in #243.
- The hazard note at `manager/mounts.rs` warned that #227’s blocking-pool cap would go stale "if that path ever takes user `[executor]` settings". That fork no longer exists, so the comment now records why instead of warning about it.

## Scope — #249 stays open

This covers 3 of its 7 keys, the half carrying regression risk. Still to do, as separate low-risk work:

- `request_timeout_secs`, `max_retries`, `retry_base_delay_ms` — inert via the `ServiceConfig::pipeline()` path, which also has no caller. Download *behaviour*, not concurrency tuning.
- `max_concurrent_jobs` — reaches the TUI’s `ControlPlaneWidget` but enforces nothing, so the dashboard renders a ceiling that does not exist. That is a display defect with its own design question, and #250 touched its parser recently.

## Notes for reviewers

The empty `[Unreleased]` CHANGELOG section is intentional — the CHANGELOG is compiled at release-cut time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)