### PR TITLE
Release v0.4.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,13 +67,30 @@ jobs:
     name: Build Release Binary
     runs-on: ubuntu-latest
     needs: [verify]
+    # Built inside an ubuntu:22.04 container rather than on `ubuntu-latest`.
+    # The runner image is not ours to pin: when GitHub moved `ubuntu-latest`
+    # from 22.04 to 24.04 our glibc floor rose from 2.34 to 2.39 with no
+    # commit, and the .deb and tarball stopped installing on Debian 12 and
+    # Ubuntu 22.04 LTS. A container pins the build environment in this repo,
+    # where a change to it is reviewable. Both Linux artifacts are cut from
+    # this one binary, so this job alone sets the floor for both.
+    container:
+      image: ubuntu:22.04
+    env:
+      # Highest glibc symbol version the released binary may require.
+      # 2.34 covers Ubuntu 22.04 (2.35), Debian 12 (2.36) and RHEL 9 (2.34).
+      GLIBC_FLOOR: "2.34"
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Install dependencies
+      - name: Install build dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libfuse3-dev
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential pkg-config libfuse3-dev \
+            curl ca-certificates git binutils
+
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -81,6 +98,21 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release
+
+      # Fails the release rather than shipping a binary that cannot start on
+      # a supported distro. Without this the floor regresses silently and the
+      # first report arrives from a user who cannot run the program at all.
+      - name: Verify glibc compatibility floor
+        run: |
+          MAX=$(objdump -T target/release/xearthlayer \
+            | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' \
+            | sed 's/GLIBC_//' | sort -V -u | tail -1)
+          echo "Highest required glibc symbol: $MAX (floor: $GLIBC_FLOOR)"
+          if [ "$(printf '%s\n%s\n' "$MAX" "$GLIBC_FLOOR" | sort -V | tail -1)" != "$GLIBC_FLOOR" ]; then
+            echo "::error::Binary requires glibc $MAX, above the supported floor $GLIBC_FLOOR."
+            echo "::error::It will not start on Ubuntu 22.04, Debian 12 or RHEL 9."
+            exit 1
+          fi
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-09-01
+
+Installation fixes. Nothing in the running program changed. This release exists
+because installing it was broken, for prebuilt packages and from source alike.
+
+### Fixed
+
+- **Prebuilt Linux packages would not install on Debian 12 or Ubuntu 22.04 LTS**: The `.deb` and the Linux tarball are both cut from a single build job, so both carried its glibc requirement. That job ran on GitHub's `ubuntu-latest` image, and when GitHub moved that label from Ubuntu 22.04 to 24.04 the requirement rose from glibc 2.34 to 2.39 with no commit on our side. Both artifacts stopped starting on any distribution older than Ubuntu 24.04, reported as a `libc6` version error. Exactly two symbols were responsible, `pidfd_spawnp` and `pidfd_getpid`, which the standard library's process spawn path references when compiled against a glibc that provides them. The release binary is now built inside a pinned `ubuntu:22.04` container rather than on a runner label we do not control, which restores the 2.34 floor and covers Ubuntu 22.04 LTS, Debian 12 and RHEL 9 onwards. A release now fails outright if the binary requires a higher glibc than declared, so the floor cannot rise again unnoticed.
+
+- **Building from source failed with a formatting error instead of a version error**: On a toolchain older than the project supports, `make install` stopped at a `cargo fmt --check` diff about an unrelated function, which reads as though the source in the repository is malformed. The real cause is that several dependencies require a recent compiler, wgpu needing 1.92 and image needing 1.88, so the build could never have succeeded. `rust-toolchain.toml` already pinned the correct version, but only rustup reads that file, so a distribution-installed cargo ignored it silently. The workspace now declares `rust-version`, and cargo refuses up front with the version it requires and the version it found.
+
+- **`make install` ran the full contributor check suite**: Installing from source depended on `make verify`, which runs rustfmt, clippy with warnings denied, and the entire test suite. A user building from a clean clone was therefore blocked from installing by a formatting nit in code they did not write. This also suppressed the fix above, because the formatting check runs first and does not enforce `rust-version`. `release` and `install` now build and install. The check suite is unchanged for the people it is for, and still runs in CI and through `make pre-commit`.
+
+- **Build instructions referenced targets that do not exist**: The README and the getting started guide both documented `make release-gpu` and `make install-gpu`, which have never been targets. The premise was also wrong: GPU encoding requires no special build, since wgpu is an unconditional dependency and the compressor is selected at runtime with `texture.compressor`. Neither document mentioned that Rust is needed at all, and the README linked to no releases page, so every reader was funnelled into building from source whether or not they wanted to. Both now lead with prebuilt packages, state the glibc and Rust requirements, and document GPU encoding as the configuration setting it actually is.
+
 ## [0.4.7] - 2026-08-30
 
 ### Added
@@ -1110,7 +1125,9 @@ Run `xearthlayer config upgrade` to automatically add new settings with defaults
 - Linux support only (Windows and macOS planned for future releases)
 - Requires FUSE3 for filesystem mounting
 
-[Unreleased]: https://github.com/samsoir/xearthlayer/compare/v0.4.6...HEAD
+[Unreleased]: https://github.com/samsoir/xearthlayer/compare/v0.4.8...HEAD
+[0.4.8]: https://github.com/samsoir/xearthlayer/compare/v0.4.7...v0.4.8
+[0.4.7]: https://github.com/samsoir/xearthlayer/compare/v0.4.6...v0.4.7
 [0.4.6]: https://github.com/samsoir/xearthlayer/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/samsoir/xearthlayer/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/samsoir/xearthlayer/compare/v0.4.3...v0.4.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,7 +4812,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xearthlayer"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "axum",
  "bincode",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "xearthlayer-cli"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ version = "0.4.7"
 edition = "2021"
 authors = ["XEarthLayer Contributors"]
 license = "MIT"
+# Minimum supported Rust, matching the pin in rust-toolchain.toml. rustup users
+# get that pin automatically and never notice; this field is what gives everyone
+# else a clear "requires rustc 1.97.1, you have X" instead of an inscrutable
+# rustfmt diff or a wall of compile errors. Bump both together.
+rust-version = "1.97.1"
 repository = "https://github.com/samsoir/xearthlayer"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,11 @@ members = [
 ]
 
 [workspace.package]
-# Unstable dev cycle on develop/0.4.7 — pre-release per semver, sorts below 0.4.7.
-# Bumped to a dated X.Y.Z only at stable promotion. See docs/dev/app-release-runbook.md.
-version = "0.4.7"
+# On `main` and `release/*` this is the released stable version. On a
+# `develop/X.Y.Z` line it instead carries a pre-release identifier, which sorts
+# below the target release per semver, and is bumped to the dated X.Y.Z only at
+# stable promotion. See docs/dev/app-release-runbook.md.
+version = "0.4.8"
 edition = "2021"
 authors = ["XEarthLayer Contributors"]
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -450,6 +450,10 @@ bump-version: ## Bump version across all files (VERSION=x.y.z, STABLE ONLY)
 	@sed -i 's/^version = ".*"/version = "$(VERSION)"/' Cargo.toml
 	@# Update RPM spec file
 	@sed -i 's/^Version:.*/Version:        $(VERSION)/' pkg/rpm/xearthlayer.spec
+	@# Update the Arch PKGBUILD. Omitting this shipped an AUR package at the
+	@# previous version; tests/packaging_metadata.rs guards it, but the guard
+	@# should never be what finds it.
+	@sed -i 's/^pkgver=.*/pkgver=$(VERSION)/' pkg/arch/PKGBUILD
 	@echo "$(GREEN)Version bumped to $(VERSION)$(NC)"
 	@echo ""
 	@echo "$(YELLOW)Next steps:$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -67,14 +67,21 @@ build: ## Build debug version
 	@echo "$(BLUE)Building debug version...$(NC)"
 	$(CARGO) build $(CARGO_FLAGS)
 
+# `release` and `install` are the from-source path for people who just want a
+# working binary, so they deliberately do NOT depend on `verify`. That target
+# is the contributor gate (rustfmt + clippy -D warnings + the full suite), and
+# gating an install on it means a user is blocked from installing by a
+# formatting nit in code they did not write. CI runs `make verify` explicitly
+# in ci.yml, release.yml and release-test.yml, and contributors run
+# `make pre-commit`, so nothing loses coverage here.
 .PHONY: release
-release: verify ## Build optimized release version
+release: ## Build optimized release version
 	@echo "$(BLUE)Building release version...$(NC)"
 	$(CARGO) build --release $(CARGO_FLAGS)
 	@echo "$(GREEN)Release build complete!$(NC)"
 
 .PHONY: release-profiling
-release-profiling: verify ## Build release version with profiling support
+release-profiling: ## Build release version with profiling support
 	@echo "$(BLUE)Building release version with profiling...$(NC)"
 	$(CARGO) build --release --features profiling $(CARGO_FLAGS)
 	@echo "$(GREEN)Release build with profiling complete!$(NC)"

--- a/README.md
+++ b/README.md
@@ -58,17 +58,41 @@ See [How It Works](docs/how-it-works.md) for detailed architecture.
 
 ## Quick Start
 
+### Install a prebuilt package (recommended)
+
+Download the package for your distribution from the
+[latest release](https://github.com/samsoir/xearthlayer/releases/latest):
+a `.deb` for Debian and Ubuntu, an `.rpm` for Fedora and RHEL, or the
+`x86_64-linux.tar.gz` tarball for everything else. Arch users can build from
+the AUR.
+
+Prebuilt binaries require **glibc 2.34 or newer**, which covers Ubuntu 22.04
+LTS, Debian 12 and RHEL 9 onwards. On an older distribution, build from source.
+
+### Or build from source
+
+Building needs **Rust 1.97.1 or newer** and the FUSE 3 development headers.
+Install Rust through [rustup](https://rustup.rs), not your distribution's
+package manager: several dependencies require a recent compiler, and most
+distributions ship one that is too old. rustup also reads this repository's
+`rust-toolchain.toml` and selects the correct version automatically.
+
 ```bash
-# Build and install
+# Rust toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# FUSE 3 headers (Debian/Ubuntu; use fuse3-devel on Fedora)
+sudo apt install libfuse3-dev
+
+# Build and install to ~/.local/bin (no sudo required)
 git clone https://github.com/samsoir/xearthlayer.git
 cd xearthlayer
-make release       # Standard build (ISPC compression)
-make install       # Installs to ~/.local/bin (no sudo required)
+make install
+```
 
-# Or build with GPU-accelerated encoding (optional)
-# make release-gpu
-# make install-gpu
+### Then
 
+```bash
 # Run the setup wizard (first-time configuration)
 xearthlayer setup
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,16 +35,50 @@ If X-Plane is not yet running when XEarthLayer starts, it will fall back to infe
 
 ## Installation
 
-### From Source
+### From a Binary Release
+
+The simplest option. Download the package for your distribution from the
+[latest release](https://github.com/samsoir/xearthlayer/releases/latest):
+
+| Distribution | Asset |
+|---|---|
+| Debian, Ubuntu | `xearthlayer_<version>_amd64.deb` |
+| Fedora, RHEL | `xearthlayer-<version>.x86_64.rpm` |
+| Anything else | `xearthlayer-v<version>-x86_64-linux.tar.gz` |
+| Arch, CachyOS | Build from the AUR |
+
+Prebuilt binaries require **glibc 2.34 or newer**. That covers Ubuntu 22.04 LTS,
+Debian 12 and RHEL 9 onwards. Check yours with `ldd --version`. On anything
+older, build from source.
+
+Verify with:
 
 ```bash
-# Clone the repository
+xearthlayer --version
+```
+
+### From Source
+
+Building needs **Rust 1.97.1 or newer** and the FUSE 3 development headers.
+
+Install Rust through [rustup](https://rustup.rs) rather than your
+distribution's package manager. Several dependencies require a recent
+compiler, and most distributions ship one that is too old to build this
+project at all. rustup also reads the repository's `rust-toolchain.toml` and
+selects the correct version for you.
+
+```bash
+# Rust toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# FUSE 3 headers
+sudo apt install libfuse3-dev      # Debian, Ubuntu
+sudo dnf install fuse3-devel       # Fedora, RHEL
+
+# Clone, build and install
 git clone https://github.com/samsoir/xearthlayer.git
 cd xearthlayer
-
-# Build and install
-make release
-make install  # Installs to ~/.local/bin (no sudo required)
+make install  # Builds, then installs to ~/.local/bin (no sudo required)
 
 # Verify installation
 xearthlayer --version
@@ -55,26 +89,34 @@ xearthlayer --version
 make install PREFIX=/usr/local  # Requires sudo for /usr/local/bin
 ```
 
-### From Binary Release
+If the build stops with `rustc <version> is not supported by the following
+packages`, your Rust is too old. Install rustup as above and start a new
+shell so it takes precedence.
 
-Download the latest release from the releases page and extract to a location of your choice.
+### GPU Encoding
 
-### Building with GPU Support
+GPU-accelerated DDS encoding offloads texture compression from the CPU,
+freeing it for X-Plane. It needs no special build and is included in every
+binary. Select it at runtime:
 
-XEarthLayer supports optional GPU-accelerated DDS encoding, which offloads texture compression to the GPU and frees CPU resources for X-Plane. This requires a separate build:
+```ini
+[texture]
+compressor = gpu
+```
+
+Then confirm your hardware is detected:
 
 ```bash
-# Build with GPU encoding support
-make release-gpu
-make install-gpu  # Installs to ~/.local/bin
-
-# Verify GPU detection
 xearthlayer diagnostics
 ```
 
-The diagnostics output will show detected GPU adapters. Any wgpu-compatible GPU works (most modern GPUs from AMD, NVIDIA, and Intel).
+The output lists the detected GPU adapters. Any wgpu-compatible GPU works,
+which is most modern hardware from AMD, NVIDIA and Intel.
 
-GPU encoding is most beneficial when you have an idle integrated GPU (e.g., AMD Radeon on Ryzen or Intel UHD) while your discrete GPU handles X-Plane. See the [texture configuration](configuration.md#texture) for compressor selection.
+GPU encoding helps most when you have an idle integrated GPU, such as AMD
+Radeon graphics on a Ryzen or Intel UHD, while your discrete card handles
+X-Plane. See the [texture configuration](configuration.md#texture) for the
+full list of compressor backends.
 
 ## Initial Setup
 

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Sam de Freyssinet <sam@def.reyssi.net>
 pkgname=xearthlayer
-pkgver=0.4.7
+pkgver=0.4.8
 pkgrel=1
 pkgdesc="High-quality satellite imagery for X-Plane, streamed on demand"
 arch=('x86_64')

--- a/pkg/rpm/xearthlayer.spec
+++ b/pkg/rpm/xearthlayer.spec
@@ -1,5 +1,5 @@
 Name:           xearthlayer
-Version:        0.4.7
+Version:        0.4.8
 Release:        1%{?dist}
 Summary:        High-quality satellite imagery for X-Plane, streamed on demand
 

--- a/version.json
+++ b/version.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.4.7",
-  "tag": "v0.4.7",
-  "release_date": "2026-08-30",
+  "version": "0.4.8",
+  "tag": "v0.4.8",
+  "release_date": "2026-09-01",
   "homepage": "https://xearthlayer.app",
   "assets": {
     "deb": {
-      "filename": "xearthlayer_0.4.7-1_amd64.deb",
+      "filename": "xearthlayer_0.4.8-1_amd64.deb",
       "description": "Debian/Ubuntu package"
     },
     "rpm": {
-      "filename": "xearthlayer-0.4.7-1.fc44.x86_64.rpm",
+      "filename": "xearthlayer-0.4.8-1.fc44.x86_64.rpm",
       "description": "Fedora/RHEL package"
     },
     "tarball": {
-      "filename": "xearthlayer-v0.4.7-x86_64-linux.tar.gz",
+      "filename": "xearthlayer-v0.4.8-x86_64-linux.tar.gz",
       "description": "Linux binary tarball"
     },
     "aur": {
@@ -21,5 +21,5 @@
       "description": "Arch Linux AUR package"
     }
   },
-  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.7"
+  "download_base_url": "https://github.com/samsoir/xearthlayer/releases/download/v0.4.8"
 }

--- a/xearthlayer-cli/Cargo.toml
+++ b/xearthlayer-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xearthlayer-cli"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/xearthlayer/Cargo.toml
+++ b/xearthlayer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xearthlayer"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/xearthlayer/src/metrics/daemon.rs
+++ b/xearthlayer/src/metrics/daemon.rs
@@ -1043,7 +1043,7 @@ mod tests {
     /// Runs `f` under a tracing subscriber that captures every event's
     /// fields, returning them in emission order. Uses only
     /// `tracing`/`tracing-subscriber`, both already direct dependencies of
-    /// this crate (see Cargo.toml) — no new dependency is introduced.
+    /// this crate (see Cargo.toml), so no new dependency is introduced.
     fn capture_events<F: FnOnce()>(f: F) -> Vec<std::collections::HashMap<String, String>> {
         use tracing_subscriber::layer::SubscriberExt;
 
@@ -1055,6 +1055,40 @@ mod tests {
         tracing::subscriber::with_default(subscriber, f);
         let captured = events.lock().unwrap().clone();
         captured
+    }
+
+    /// Like [`find_memory_sample`], but panics with what *was* captured.
+    ///
+    /// A bare `.expect` on the lookup cannot distinguish "no events at all"
+    /// from "events, but none of them the one we wanted". That distinction is
+    /// the first thing anyone debugging a missing sample needs, and its
+    /// absence is why one observed failure here taught us nothing.
+    ///
+    /// Read the message before theorising. `0 event(s) captured: []` means the
+    /// capture harness; anything else means `log_memory_sample` itself. Two
+    /// theories about the harness were investigated and **refuted** by
+    /// experiment, so do not spend time on them again: `with_default` installs
+    /// a thread-local subscriber and nothing in this test binary installs a
+    /// global one, and a probe of 16 threads by 2,000 iterations against a
+    /// single shared callsite dropped none of its 32,000 captures.
+    fn expect_memory_sample(
+        events: &[std::collections::HashMap<String, String>],
+    ) -> &std::collections::HashMap<String, String> {
+        find_memory_sample(events).unwrap_or_else(|| {
+            let messages: Vec<&str> = events
+                .iter()
+                .map(|e| {
+                    e.get("message")
+                        .map(String::as_str)
+                        .unwrap_or("<no message>")
+                })
+                .collect();
+            panic!(
+                "log_memory_sample must emit a \"Memory sample\" event, but {} event(s) \
+                 were captured: {messages:?}",
+                events.len()
+            )
+        })
     }
 
     /// Finds the first captured event whose message is "Memory sample".
@@ -1085,7 +1119,7 @@ mod tests {
         let _tiles: Vec<Vec<u8>> = (0..6).map(|_| vec![0u8; 11 * 1024 * 1024]).collect();
 
         let events = capture_events(|| daemon.log_memory_sample());
-        let sample = find_memory_sample(&events).expect("must emit a memory sample");
+        let sample = expect_memory_sample(&events);
 
         let num = |k: &str| -> u64 {
             sample
@@ -1159,8 +1193,7 @@ mod tests {
         daemon.state.mem_cache_writes_active = 20;
 
         let events = capture_events(|| daemon.log_memory_sample());
-        let sample = find_memory_sample(&events)
-            .expect("log_memory_sample must emit a \"Memory sample\" event");
+        let sample = expect_memory_sample(&events);
 
         // Field-by-field: name -> expected value. `rss_mb` and `mem_cache_mb`
         // are seeded from byte counts that are NOT whole multiples of MB, so


### PR DESCRIPTION
Installation-only patch release. Nothing in the running program changed.

Fixes #261

## Why

A Debian 12 user could not install XEarthLayer by any route and emailed support. The `.deb` refused on libc6, and building from source died on a `cargo fmt --check` diff about `serde_json::json!`, which reads as though the source in this repository is malformed.

Both were real, and neither was visible to us. Every maintainer uses rustup and CI only ever ran on the current runner image, so the internal experience stayed green throughout.

## What was wrong

**Prebuilt packages required glibc 2.39.** The `.deb` and the tarball are cut from the same `build-binary` artifact, so one job sets the floor for both. GitHub moved `ubuntu-latest` from Ubuntu 22.04 to 24.04 and the floor rose from 2.34 to 2.39 with no commit on our side. That broke Ubuntu 22.04 LTS, Debian 12 and RHEL 9. Exactly two weak symbols were responsible, `pidfd_spawnp` and `pidfd_getpid`, referenced by std's process spawn path when built against a glibc that has them.

**Building from source reported the wrong problem.** wgpu 28 needs rustc 1.92, image 0.25 needs 1.88, clap 4.6 needs 1.85, so a distribution toolchain could never have built this. `rust-toolchain.toml` pins the right version but only rustup reads it, and a distro cargo ignores it silently. Nothing declared `rust-version`, so cargo never said so.

**`make install` ran the contributor check suite.** `install` depended on `release`, which depended on `verify`, so installing from source ran rustfmt, clippy with warnings denied and 2500 tests first. This also suppressed the `rust-version` fix, because `format-check` runs first and `cargo fmt --check` does not enforce `rust-version`.

**Documentation pointed at targets that never existed.** `make release-gpu` and `make install-gpu` appeared in the README and the getting started guide. GPU encoding needs no special build at all; wgpu is an unconditional dependency and the backend is a runtime setting.

## Verification

- glibc floor measured on the shipped v0.4.7 tarball with `objdump -T`, not inferred.
- The new `GLIBC_FLOOR` release check was mutation-tested against that binary: rejected at 2.34, accepted at 2.39, so it discriminates rather than passing vacuously.
- `rust-version` verified by raising the floor above the installed toolchain and confirming cargo refuses, then end to end: `make install` now stops at `rustc 1.97.1 is not supported by the following packages`.
- `bump-version` gap found by `tests/packaging_metadata.rs` during release prep and fixed at source; verified by seeding a wrong `pkgver` and confirming correction.
- `make pre-commit` green.

## Notes for review

The build environment is pinned as an `ubuntu:22.04` container rather than `runs-on: ubuntu-22.04`. A runner label is GitHub's to retire, and pinning to it would reproduce this same failure on their schedule instead of ours.

`bump-version` now also rewrites `pkg/arch/PKGBUILD`, which it previously skipped. Without it this release would have shipped an AUR package pinned to 0.4.7.

The CHANGELOG gains a dated `[0.4.8]` section, plus the `[0.4.7]` link reference that was omitted at the last release cut.