### PR TITLE
refactor(preflight): registered preflight check framework

### DIFF
--- a/xearthlayer-cli/src/commands/run.rs
+++ b/xearthlayer-cli/src/commands/run.rs
@@ -1,13 +1,10 @@
 //! Run command - mount all installed ortho packages.
 
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use xearthlayer::airport::validate_airport_icao;
 use xearthlayer::config::{
-    analyze_config, config_file_path, format_size, ControlPlaneSettings, DownloadConfig,
-    PipelineSettings, TextureConfig,
+    format_size, ControlPlaneSettings, DownloadConfig, PipelineSettings, TextureConfig,
 };
 use xearthlayer::manager::LocalPackageStore;
 use xearthlayer::package::PackageType;
@@ -19,10 +16,9 @@ use xearthlayer::xplane::XPlaneEnvironment;
 
 use super::common::{resolve_dds_format, resolve_provider, DdsCompression, ProviderType};
 use crate::error::CliError;
-use crate::preflight::paths::resolve_custom_scenery_path;
-use crate::runner::CliRunner;
 use crate::tui_app::{run_headless, run_tui, TuiAppConfig};
 use crate::ui;
+use xearthlayer::preflight::BootstrapContext;
 
 /// Arguments for the run command.
 ///
@@ -43,82 +39,25 @@ pub struct RunArgs {
 }
 
 /// Run the run command.
-pub fn run(args: RunArgs) -> Result<(), CliError> {
+pub fn run(args: RunArgs, ctx: &BootstrapContext) -> Result<(), CliError> {
     // Initialize panic handler early for crash cleanup
     panic_handler::init();
 
-    // Check for first-run scenario: no config file and no packages directory
-    // This provides a friendly welcome message instead of confusing errors
-    let config_path = xearthlayer::config::config_file_path();
-    if !config_path.exists() {
-        let default_packages_dir = dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".xearthlayer")
-            .join("packages");
+    // Every prerequisite below was verified before dispatch. Absence here is a
+    // misconfigured registry, not a user error, so it names the check that owed
+    // the value rather than degrading into a vague failure.
+    let config = ctx
+        .config()
+        .expect("preflight check 'load-config' contributes the configuration");
+    let install_location = ctx
+        .install_location()
+        .expect("preflight check 'packages-installed' contributes the install location")
+        .clone();
+    let custom_scenery_path = ctx
+        .custom_scenery_path()
+        .expect("preflight check 'resolve-custom-scenery' contributes the Custom Scenery path")
+        .clone();
 
-        if !default_packages_dir.exists() {
-            // First-run scenario: show welcome message and exit cleanly
-            return Err(CliError::NeedsSetup);
-        }
-    }
-
-    let runner = CliRunner::new()?;
-    runner.log_startup("run");
-
-    // Raise file descriptor limit to the hard maximum. XEL's FUSE mount +
-    // HTTP connections + disk cache can exceed the default soft limit (often
-    // 1024) inherited from the desktop environment. Safe to call at any time;
-    // takes effect immediately for all subsequent open() calls.
-    raise_fd_limit();
-
-    let config = runner.config();
-
-    // Check for config upgrade needs
-    check_config_upgrade_warning();
-
-    // Get install location (where packages are stored)
-    let install_location = config.packages.install_location.clone().unwrap_or_else(|| {
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".xearthlayer")
-            .join("packages")
-    });
-
-    if !install_location.exists() {
-        return Err(CliError::NoPackages {
-            install_location: install_location.clone(),
-        });
-    }
-
-    // Get Custom Scenery path (where mounts go)
-    let custom_scenery_path = resolve_custom_scenery_path(
-        config.packages.custom_scenery_path.clone(),
-        config.xplane.scenery_dir.clone(),
-        || xearthlayer::config::detect_custom_scenery().ok(),
-    )
-    .ok_or_else(|| {
-        CliError::Config(
-            "No Custom Scenery path configured. \
-             Run 'xearthlayer init' or set packages.custom_scenery_path in config.ini"
-                .to_string(),
-        )
-    })?;
-
-    if !custom_scenery_path.exists() {
-        return Err(CliError::Config(format!(
-            "Custom Scenery directory does not exist: {}\n\
-             Check your configuration or run 'xearthlayer init'",
-            custom_scenery_path.display()
-        )));
-    }
-
-    // Validate airport code early (before heavy initialization)
-    if let Some(ref icao) = args.airport {
-        validate_airport_icao(&custom_scenery_path, icao)
-            .map_err(|e| CliError::Config(e.to_string()))?;
-    }
-
-    // Discover installed packages from install_location
     let store = LocalPackageStore::new(&install_location);
     let packages = store
         .list()
@@ -376,74 +315,4 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
     println!("All packages unmounted. Goodbye!");
 
     Ok(())
-}
-
-/// Raise the file descriptor soft limit to the hard maximum.
-///
-/// Linux processes inherit a soft FD limit (often 1024) that can be lower
-/// than the hard limit. XEL needs many FDs simultaneously: HTTP connections
-/// to the imagery CDN, disk cache file handles, and FUSE file descriptors
-/// for X-Plane's open textures. This raises the soft limit to the hard
-/// limit (no root required), matching what the system administrator allows.
-fn raise_fd_limit() {
-    match rlimit::Resource::NOFILE.get() {
-        Ok((soft, hard)) if soft < hard => {
-            if let Err(e) = rlimit::Resource::NOFILE.set(hard, hard) {
-                tracing::warn!(soft, hard, error = %e, "Failed to raise FD limit");
-            } else {
-                tracing::info!(
-                    old_soft = soft,
-                    new_soft = hard,
-                    "Raised file descriptor limit"
-                );
-            }
-        }
-        Ok((soft, _)) => {
-            tracing::debug!(soft, "FD limit already at maximum");
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to query FD limit");
-        }
-    }
-}
-
-/// Display warning if configuration file needs upgrade.
-///
-/// Checks if the user's config.ini is missing settings from the current version
-/// and displays a helpful message with instructions on how to upgrade.
-fn check_config_upgrade_warning() {
-    let path = config_file_path();
-
-    // Only check if config file exists
-    if !path.exists() {
-        return;
-    }
-
-    match analyze_config(&path) {
-        Ok(analysis) if analysis.needs_upgrade => {
-            let missing_count = analysis.missing_keys.len();
-            let deprecated_count = analysis.deprecated_keys.len();
-
-            eprintln!();
-            eprintln!(
-                "Warning: Your configuration file is missing {} new setting(s)",
-                missing_count
-            );
-            if deprecated_count > 0 {
-                eprintln!(
-                    "         and contains {} deprecated setting(s).",
-                    deprecated_count
-                );
-            }
-            eprintln!();
-            eprintln!("Run 'xearthlayer config upgrade' to update your configuration.");
-            eprintln!("Use 'xearthlayer config upgrade --dry-run' to preview changes first.");
-            eprintln!();
-        }
-        Ok(_) => {} // Up to date, no message needed
-        Err(e) => {
-            // Log error but don't fail - config upgrade is informational
-            tracing::warn!("Failed to analyze config for upgrade: {}", e);
-        }
-    }
 }

--- a/xearthlayer-cli/src/commands/run.rs
+++ b/xearthlayer-cli/src/commands/run.rs
@@ -19,6 +19,7 @@ use xearthlayer::xplane::XPlaneEnvironment;
 
 use super::common::{resolve_dds_format, resolve_provider, DdsCompression, ProviderType};
 use crate::error::CliError;
+use crate::preflight::paths::resolve_custom_scenery_path;
 use crate::runner::CliRunner;
 use crate::tui_app::{run_headless, run_tui, TuiAppConfig};
 use crate::ui;
@@ -406,20 +407,6 @@ fn raise_fd_limit() {
     }
 }
 
-/// Resolve the Custom Scenery path from configuration, falling back to
-/// auto-detection of the X-Plane installation.
-///
-/// Precedence: `packages.custom_scenery_path` > `xplane.scenery_dir` >
-/// auto-detect. Auto-detection is only attempted when both config values
-/// are unset.
-fn resolve_custom_scenery_path(
-    custom_scenery_path: Option<PathBuf>,
-    scenery_dir: Option<PathBuf>,
-    detect: impl FnOnce() -> Option<PathBuf>,
-) -> Option<PathBuf> {
-    custom_scenery_path.or(scenery_dir).or_else(detect)
-}
-
 /// Display warning if configuration file needs upgrade.
 ///
 /// Checks if the user's config.ini is missing settings from the current version
@@ -458,41 +445,5 @@ fn check_config_upgrade_warning() {
             // Log error but don't fail - config upgrade is informational
             tracing::warn!("Failed to analyze config for upgrade: {}", e);
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn explicit_custom_scenery_path_wins() {
-        let resolved = resolve_custom_scenery_path(
-            Some(PathBuf::from("/configured")),
-            Some(PathBuf::from("/scenery-dir")),
-            || panic!("auto-detect must not run when config is set"),
-        );
-        assert_eq!(resolved, Some(PathBuf::from("/configured")));
-    }
-
-    #[test]
-    fn scenery_dir_used_when_custom_scenery_path_unset() {
-        let resolved =
-            resolve_custom_scenery_path(None, Some(PathBuf::from("/scenery-dir")), || {
-                panic!("auto-detect must not run when scenery_dir is set")
-            });
-        assert_eq!(resolved, Some(PathBuf::from("/scenery-dir")));
-    }
-
-    #[test]
-    fn auto_detect_used_when_both_config_values_unset() {
-        let resolved = resolve_custom_scenery_path(None, None, || Some(PathBuf::from("/detected")));
-        assert_eq!(resolved, Some(PathBuf::from("/detected")));
-    }
-
-    #[test]
-    fn none_when_nothing_configured_and_detection_fails() {
-        let resolved = resolve_custom_scenery_path(None, None, || None);
-        assert_eq!(resolved, None);
     }
 }

--- a/xearthlayer-cli/src/main.rs
+++ b/xearthlayer-cli/src/main.rs
@@ -18,6 +18,7 @@
 mod commands;
 mod error;
 mod logging_init;
+mod preflight;
 mod runner;
 mod tui_app;
 mod ui;

--- a/xearthlayer-cli/src/main.rs
+++ b/xearthlayer-cli/src/main.rs
@@ -166,6 +166,35 @@ enum Commands {
 // Main Entry Point
 // ============================================================================
 
+/// The command being run, as the preflight checks name it.
+///
+/// Exhaustive on purpose: a new subcommand must decide what it is called here
+/// before it compiles, rather than silently inheriting another command's
+/// prerequisites.
+fn command_name(command: &Option<Commands>) -> &'static str {
+    match command {
+        // No subcommand defaults to `run`, so it gets `run`'s prerequisites.
+        None | Some(Commands::Run { .. }) => "run",
+        Some(Commands::Init) => "init",
+        Some(Commands::Setup) => "setup",
+        Some(Commands::Config { .. }) => "config",
+        Some(Commands::Cache { .. }) => "cache",
+        Some(Commands::SceneryIndex { .. }) => "scenery-index",
+        Some(Commands::Diagnostics) => "diagnostics",
+        Some(Commands::Publish { .. }) => "publish",
+        Some(Commands::Packages { .. }) => "packages",
+        Some(Commands::Patches { .. }) => "patches",
+    }
+}
+
+/// The airport requested on the command line, if any.
+fn requested_airport(command: &Option<Commands>) -> Option<String> {
+    match command {
+        Some(Commands::Run { airport, .. }) => airport.clone(),
+        _ => None,
+    }
+}
+
 fn main() -> ExitCode {
     // First, before anything allocates in earnest, and before any thread is
     // created — the arena ceiling only bounds arenas not yet made.
@@ -205,9 +234,18 @@ fn main() -> ExitCode {
         }
     };
 
-    let result = match cli.command {
+    // Prerequisites run before dispatch, not inside `run`. Both `run` and the
+    // setup wizard independently answer "does this installation exist" from the
+    // same state, so a check that lived in `run` alone would leave `setup`
+    // treating an existing user as new and discarding their settings.
+    let mut ctx = xearthlayer::preflight::BootstrapContext::new(
+        command_name(&cli.command),
+        requested_airport(&cli.command),
+    );
+
+    let result = preflight::enforce(&mut ctx).and_then(|()| match cli.command {
         // Default to 'run' when no subcommand is provided
-        None => commands::run::run(commands::run::RunArgs::default()),
+        None => commands::run::run(commands::run::RunArgs::default(), &ctx),
 
         Some(Commands::Init) => commands::init::run(),
         Some(Commands::Setup) => commands::setup::run(),
@@ -228,18 +266,21 @@ fn main() -> ExitCode {
             no_cache,
             no_prefetch,
             airport,
-        }) => commands::run::run(commands::run::RunArgs {
-            provider,
-            google_api_key,
-            mapbox_token,
-            dds_format,
-            timeout,
-            parallel,
-            no_cache,
-            no_prefetch,
-            airport,
-        }),
-    };
+        }) => commands::run::run(
+            commands::run::RunArgs {
+                provider,
+                google_api_key,
+                mapbox_token,
+                dds_format,
+                timeout,
+                parallel,
+                no_cache,
+                no_prefetch,
+                airport,
+            },
+            &ctx,
+        ),
+    });
 
     // Returning ExitCode (rather than calling process::exit) lets the
     // _logging_guard drop normally, which forces tracing-appender's

--- a/xearthlayer-cli/src/preflight/config.rs
+++ b/xearthlayer-cli/src/preflight/config.rs
@@ -1,0 +1,329 @@
+//! Configuration-family preflight checks.
+
+use super::names;
+use std::borrow::Cow;
+use std::path::PathBuf;
+use xearthlayer::config::{analyze_config, config_file_path, ConfigFile};
+use xearthlayer::preflight::{BootstrapContext, Preflight, PreflightError, Remedy, Status};
+
+/// The legacy default package directory, used only to decide whether this is a
+/// genuinely fresh installation.
+fn legacy_default_packages_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".xearthlayer")
+        .join("packages")
+}
+
+/// Is this a first run: no configuration file and no packages?
+///
+/// Both must be absent. A user with packages but no config is not new, they are
+/// misconfigured, and telling them to run the setup wizard would be wrong.
+pub struct FirstRun {
+    config_path: PathBuf,
+    legacy_packages_dir: PathBuf,
+}
+
+impl FirstRun {
+    pub fn production() -> Self {
+        Self {
+            config_path: config_file_path(),
+            legacy_packages_dir: legacy_default_packages_dir(),
+        }
+    }
+
+    /// Construct with explicit paths so tests never consult a real home
+    /// directory.
+    pub fn with_paths(config_path: PathBuf, legacy_packages_dir: PathBuf) -> Self {
+        Self {
+            config_path,
+            legacy_packages_dir,
+        }
+    }
+}
+
+impl Preflight<BootstrapContext> for FirstRun {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(names::FIRST_RUN)
+    }
+
+    /// Only `run`. `setup` and `init` exist to create the state this check
+    /// rejects, so applying it there would lock a new user out of the only
+    /// commands that help them.
+    fn applies(&self, ctx: &BootstrapContext) -> bool {
+        ctx.command() == "run"
+    }
+
+    fn inspect(&self, _ctx: &BootstrapContext) -> Status {
+        if !self.config_path.exists() && !self.legacy_packages_dir.exists() {
+            Status::unsatisfied("no configuration file and no installed packages")
+        } else {
+            Status::Satisfied
+        }
+    }
+}
+
+/// Load the configuration file and contribute it to the context.
+pub struct LoadConfig {
+    path: PathBuf,
+}
+
+impl LoadConfig {
+    pub fn production() -> Self {
+        Self {
+            path: config_file_path(),
+        }
+    }
+
+    pub fn with_path(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Preflight<BootstrapContext> for LoadConfig {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(names::LOAD_CONFIG)
+    }
+
+    fn applies(&self, ctx: &BootstrapContext) -> bool {
+        ctx.command() == "run"
+    }
+
+    fn inspect(&self, ctx: &BootstrapContext) -> Status {
+        if ctx.config().is_some() {
+            Status::Satisfied
+        } else {
+            Status::unsatisfied("configuration has not been loaded").remediable()
+        }
+    }
+
+    fn remediate(
+        &self,
+        ctx: &mut BootstrapContext,
+    ) -> Result<Remedy<BootstrapContext>, PreflightError> {
+        match ConfigFile::load_from(&self.path) {
+            Ok(config) => {
+                ctx.set_config(config);
+                Ok(Remedy::default())
+            }
+            // Attach the ConfigFileError so the CLI can rebuild the error it has
+            // always shown for a corrupt config, including its help text.
+            Err(e) => Err(PreflightError::new(names::LOAD_CONFIG, e.to_string()).with_source(e)),
+        }
+    }
+}
+
+/// Warn when the configuration file is missing settings this version knows
+/// about, or carries settings it no longer does.
+///
+/// Informational: it must never block startup, which is why an analysis failure
+/// is logged and reported as satisfied rather than escalated.
+pub struct ConfigUpgradeWarning {
+    path: PathBuf,
+}
+
+impl ConfigUpgradeWarning {
+    pub fn production() -> Self {
+        Self {
+            path: config_file_path(),
+        }
+    }
+
+    pub fn with_path(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Render the warning.
+    ///
+    /// Reproduces `commands/run.rs` as it stood before the framework, byte for
+    /// byte including the surrounding blank lines. The trailing newline is
+    /// supplied by the reporter's `eprintln!`.
+    pub fn message(missing: usize, deprecated: usize) -> String {
+        let mut out = format!(
+            "\nWarning: Your configuration file is missing {} new setting(s)\n",
+            missing
+        );
+        if deprecated > 0 {
+            out.push_str(&format!(
+                "         and contains {} deprecated setting(s).\n",
+                deprecated
+            ));
+        }
+        out.push_str("\nRun 'xearthlayer config upgrade' to update your configuration.\n");
+        out.push_str("Use 'xearthlayer config upgrade --dry-run' to preview changes first.\n");
+        out
+    }
+}
+
+impl Preflight<BootstrapContext> for ConfigUpgradeWarning {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(names::CONFIG_UPGRADE)
+    }
+
+    fn applies(&self, ctx: &BootstrapContext) -> bool {
+        ctx.command() == "run"
+    }
+
+    fn inspect(&self, _ctx: &BootstrapContext) -> Status {
+        if !self.path.exists() {
+            return Status::Satisfied;
+        }
+        match analyze_config(&self.path) {
+            Ok(analysis) if analysis.needs_upgrade => Status::Warning(Self::message(
+                analysis.missing_keys.len(),
+                analysis.deprecated_keys.len(),
+            )),
+            Ok(_) => Status::Satisfied,
+            Err(e) => {
+                // Logging only, no state change: inspection stays pure. Config
+                // upgrade is advisory and must not become a startup blocker.
+                tracing::warn!("Failed to analyze config for upgrade: {}", e);
+                Status::Satisfied
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xearthlayer::config::ConfigFileError;
+    use xearthlayer::preflight::Preflight;
+
+    fn ctx_for(command: &'static str) -> BootstrapContext {
+        BootstrapContext::new(command, None)
+    }
+
+    // ---- FirstRun ----
+
+    #[test]
+    fn first_run_is_unsatisfied_when_neither_config_nor_packages_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        let check =
+            FirstRun::with_paths(dir.path().join("config.ini"), dir.path().join("packages"));
+        assert!(matches!(
+            check.inspect(&ctx_for("run")),
+            Status::Unsatisfied {
+                remediable: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn first_run_is_satisfied_when_packages_exist_without_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("packages")).unwrap();
+        let check =
+            FirstRun::with_paths(dir.path().join("config.ini"), dir.path().join("packages"));
+        assert_eq!(check.inspect(&ctx_for("run")), Status::Satisfied);
+    }
+
+    #[test]
+    fn first_run_is_satisfied_when_config_exists_without_packages() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.ini"), "[general]\n").unwrap();
+        let check =
+            FirstRun::with_paths(dir.path().join("config.ini"), dir.path().join("packages"));
+        assert_eq!(check.inspect(&ctx_for("run")), Status::Satisfied);
+    }
+
+    #[test]
+    fn first_run_applies_only_to_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let check =
+            FirstRun::with_paths(dir.path().join("config.ini"), dir.path().join("packages"));
+        assert!(check.applies(&ctx_for("run")));
+        assert!(
+            !check.applies(&ctx_for("setup")),
+            "setup exists to create the state this check rejects"
+        );
+        assert!(!check.applies(&ctx_for("init")));
+        assert!(!check.applies(&ctx_for("diagnostics")));
+    }
+
+    // ---- LoadConfig ----
+
+    #[test]
+    fn load_config_contributes_and_is_then_satisfied() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.ini");
+        std::fs::write(&path, "[general]\nupdate_check = false\n").unwrap();
+        let check = LoadConfig::with_path(path);
+        let mut ctx = ctx_for("run");
+
+        assert!(matches!(
+            check.inspect(&ctx),
+            Status::Unsatisfied {
+                remediable: true,
+                ..
+            }
+        ));
+        check.remediate(&mut ctx).expect("valid config loads");
+        assert!(ctx.config().is_some());
+        assert_eq!(check.inspect(&ctx), Status::Satisfied);
+    }
+
+    #[test]
+    fn load_config_carries_the_underlying_error_so_the_cli_can_render_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.ini");
+        std::fs::write(&path, "this is not an ini file at all\n[[[\n").unwrap();
+        let check = LoadConfig::with_path(path);
+        let mut ctx = ctx_for("run");
+
+        let err = check
+            .remediate(&mut ctx)
+            .expect_err("a corrupt config fails");
+        assert_eq!(err.check, names::LOAD_CONFIG);
+        assert!(
+            err.source_ref()
+                .and_then(|s| s.downcast_ref::<ConfigFileError>())
+                .is_some(),
+            "the ConfigFileError must survive so CliError::ConfigFile can be rebuilt"
+        );
+    }
+
+    // ---- ConfigUpgradeWarning ----
+
+    #[test]
+    fn upgrade_warning_is_satisfied_when_no_config_file_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let check = ConfigUpgradeWarning::with_path(dir.path().join("absent.ini"));
+        assert_eq!(check.inspect(&ctx_for("run")), Status::Satisfied);
+    }
+
+    #[test]
+    fn upgrade_warning_reproduces_the_current_message_exactly() {
+        // Byte-for-byte against commands/run.rs:437-457 as it stood before the
+        // framework. The reporter appends the final newline via eprintln!.
+        let rendered = ConfigUpgradeWarning::message(3, 0);
+        assert_eq!(
+            rendered,
+            "\nWarning: Your configuration file is missing 3 new setting(s)\n\
+             \nRun 'xearthlayer config upgrade' to update your configuration.\n\
+             Use 'xearthlayer config upgrade --dry-run' to preview changes first.\n"
+        );
+    }
+
+    #[test]
+    fn upgrade_warning_includes_the_deprecated_line_only_when_there_are_any() {
+        let with = ConfigUpgradeWarning::message(3, 1);
+        assert_eq!(
+            with,
+            "\nWarning: Your configuration file is missing 3 new setting(s)\n\
+             \u{20}        and contains 1 deprecated setting(s).\n\
+             \nRun 'xearthlayer config upgrade' to update your configuration.\n\
+             Use 'xearthlayer config upgrade --dry-run' to preview changes first.\n"
+        );
+        assert!(!ConfigUpgradeWarning::message(3, 0).contains("deprecated"));
+    }
+
+    #[test]
+    fn upgrade_warning_applies_only_to_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let check = ConfigUpgradeWarning::with_path(dir.path().join("config.ini"));
+        assert!(check.applies(&ctx_for("run")));
+        assert!(!check.applies(&ctx_for("config")));
+    }
+}

--- a/xearthlayer-cli/src/preflight/config.rs
+++ b/xearthlayer-cli/src/preflight/config.rs
@@ -3,17 +3,8 @@
 use super::names;
 use std::borrow::Cow;
 use std::path::PathBuf;
-use xearthlayer::config::{analyze_config, config_file_path, ConfigFile};
+use xearthlayer::config::{analyze_config, ConfigFile};
 use xearthlayer::preflight::{BootstrapContext, Preflight, PreflightError, Remedy, Status};
-
-/// The legacy default package directory, used only to decide whether this is a
-/// genuinely fresh installation.
-fn legacy_default_packages_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".xearthlayer")
-        .join("packages")
-}
 
 /// Is this a first run: no configuration file and no packages?
 ///
@@ -25,13 +16,6 @@ pub struct FirstRun {
 }
 
 impl FirstRun {
-    pub fn production() -> Self {
-        Self {
-            config_path: config_file_path(),
-            legacy_packages_dir: legacy_default_packages_dir(),
-        }
-    }
-
     /// Construct with explicit paths so tests never consult a real home
     /// directory.
     pub fn with_paths(config_path: PathBuf, legacy_packages_dir: PathBuf) -> Self {
@@ -69,12 +53,6 @@ pub struct LoadConfig {
 }
 
 impl LoadConfig {
-    pub fn production() -> Self {
-        Self {
-            path: config_file_path(),
-        }
-    }
-
     pub fn with_path(path: PathBuf) -> Self {
         Self { path }
     }
@@ -123,12 +101,6 @@ pub struct ConfigUpgradeWarning {
 }
 
 impl ConfigUpgradeWarning {
-    pub fn production() -> Self {
-        Self {
-            path: config_file_path(),
-        }
-    }
-
     pub fn with_path(path: PathBuf) -> Self {
         Self { path }
     }

--- a/xearthlayer-cli/src/preflight/mod.rs
+++ b/xearthlayer-cli/src/preflight/mod.rs
@@ -20,6 +20,7 @@ use xearthlayer::preflight::BootstrapContext;
 /// and change what the user sees.
 pub mod config;
 pub mod paths;
+pub mod system;
 
 pub mod names {
     pub const FIRST_RUN: &str = "first-run";

--- a/xearthlayer-cli/src/preflight/mod.rs
+++ b/xearthlayer-cli/src/preflight/mod.rs
@@ -19,6 +19,7 @@ use xearthlayer::preflight::BootstrapContext;
 /// dispatches on them: a typo would silently fall through to the generic arm
 /// and change what the user sees.
 pub mod config;
+pub mod paths;
 
 pub mod names {
     pub const FIRST_RUN: &str = "first-run";

--- a/xearthlayer-cli/src/preflight/mod.rs
+++ b/xearthlayer-cli/src/preflight/mod.rs
@@ -1,0 +1,129 @@
+//! XEarthLayer's own preflight checks and their registry.
+//!
+//! The framework lives in the library crate; the concrete checks live here,
+//! because what counts as a prerequisite is a property of the CLI rather than
+//! of the engine.
+//!
+// Scaffolding lands before the checks that use it, and the project gate is
+// `-D warnings`. Nothing in the binary consumes these until main() runs the
+// registry. REMOVE THIS ATTRIBUTE in the wiring commit; the tests below
+// already exercise every item it covers.
+#![allow(dead_code)]
+
+use crate::error::CliError;
+use xearthlayer::preflight::BootstrapContext;
+
+/// Check names.
+///
+/// Constants rather than literals at the call site because [`to_cli_error`]
+/// dispatches on them: a typo would silently fall through to the generic arm
+/// and change what the user sees.
+pub mod names {
+    pub const FIRST_RUN: &str = "first-run";
+    pub const LOAD_CONFIG: &str = "load-config";
+    pub const FD_LIMIT: &str = "fd-limit";
+    pub const CONFIG_UPGRADE: &str = "config-upgrade";
+    pub const PACKAGES_INSTALLED: &str = "packages-installed";
+    pub const RESOLVE_CUSTOM_SCENERY: &str = "resolve-custom-scenery";
+    pub const CUSTOM_SCENERY_EXISTS: &str = "custom-scenery-exists";
+    pub const AIRPORT_ICAO: &str = "airport-icao";
+}
+
+/// Map a failed check onto the [`CliError`] the CLI already produces for it.
+///
+/// # Why this dispatches on the check name
+///
+/// Two of these errors are not plain messages. [`CliError::NeedsSetup`] prints
+/// a welcome and **exits 0**, because a fresh install is not a failure.
+/// [`CliError::NoPackages`] renders installation guidance built from the
+/// resolved install location. Neither survives a generic
+/// "reason plus optional hint" rendering, and both must be preserved byte for
+/// byte while the framework is introduced.
+///
+/// This is a deliberate temporary seam. It disappears once we are free to
+/// change those two messages, at which point every check maps uniformly.
+pub fn to_cli_error(
+    check: &str,
+    reason: String,
+    hint: Option<String>,
+    ctx: &BootstrapContext,
+) -> CliError {
+    match check {
+        names::FIRST_RUN => CliError::NeedsSetup,
+        names::PACKAGES_INSTALLED => CliError::NoPackages {
+            install_location: ctx.install_location().cloned().unwrap_or_default(),
+        },
+        _ => CliError::Config(match hint {
+            Some(hint) => format!("{}\n{}", reason, hint),
+            None => reason,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn first_run_maps_to_needs_setup_preserving_the_welcome_and_exit_zero() {
+        let ctx = BootstrapContext::new("run", None);
+        let e = to_cli_error(names::FIRST_RUN, "no config".to_string(), None, &ctx);
+        assert!(matches!(e, CliError::NeedsSetup));
+    }
+
+    #[test]
+    fn packages_maps_to_no_packages_carrying_the_install_location() {
+        let mut ctx = BootstrapContext::new("run", None);
+        ctx.set_install_location(PathBuf::from("/opt/packages"));
+        let e = to_cli_error(names::PACKAGES_INSTALLED, "missing".to_string(), None, &ctx);
+        match e {
+            CliError::NoPackages { install_location } => {
+                assert_eq!(install_location, PathBuf::from("/opt/packages"))
+            }
+            other => panic!("expected NoPackages, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn everything_else_becomes_a_config_error_with_the_hint_appended() {
+        let ctx = BootstrapContext::new("run", None);
+        let e = to_cli_error(
+            "some.check",
+            "it is broken".to_string(),
+            Some("fix it".to_string()),
+            &ctx,
+        );
+        assert_eq!(e.to_string(), "Configuration error: it is broken\nfix it");
+    }
+
+    #[test]
+    fn a_reason_without_a_hint_is_not_padded() {
+        let ctx = BootstrapContext::new("run", None);
+        let e = to_cli_error("some.check", "it is broken".to_string(), None, &ctx);
+        assert_eq!(e.to_string(), "Configuration error: it is broken");
+    }
+
+    #[test]
+    fn check_names_are_unique() {
+        let all = [
+            names::FIRST_RUN,
+            names::LOAD_CONFIG,
+            names::FD_LIMIT,
+            names::CONFIG_UPGRADE,
+            names::PACKAGES_INSTALLED,
+            names::RESOLVE_CUSTOM_SCENERY,
+            names::CUSTOM_SCENERY_EXISTS,
+            names::AIRPORT_ICAO,
+        ];
+        let mut seen: Vec<&str> = all.to_vec();
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(
+            seen.len(),
+            all.len(),
+            "to_cli_error dispatches on these, so a duplicate would silently \
+             reroute one check's error to another's"
+        );
+    }
+}

--- a/xearthlayer-cli/src/preflight/mod.rs
+++ b/xearthlayer-cli/src/preflight/mod.rs
@@ -3,15 +3,11 @@
 //! The framework lives in the library crate; the concrete checks live here,
 //! because what counts as a prerequisite is a property of the CLI rather than
 //! of the engine.
-//!
-// Scaffolding lands before the checks that use it, and the project gate is
-// `-D warnings`. Nothing in the binary consumes these until main() runs the
-// registry. REMOVE THIS ATTRIBUTE in the wiring commit; the tests below
-// already exercise every item it covers.
-#![allow(dead_code)]
 
 use crate::error::CliError;
-use xearthlayer::preflight::BootstrapContext;
+use std::path::PathBuf;
+use xearthlayer::config::{config_file_path, ConfigFileError};
+use xearthlayer::preflight::{BootstrapContext, PreflightError, RunOutcome, Runner};
 
 /// Check names.
 ///
@@ -25,12 +21,101 @@ pub mod system;
 pub mod names {
     pub const FIRST_RUN: &str = "first-run";
     pub const LOAD_CONFIG: &str = "load-config";
+    pub const LOG_STARTUP: &str = "log-startup";
     pub const FD_LIMIT: &str = "fd-limit";
     pub const CONFIG_UPGRADE: &str = "config-upgrade";
     pub const PACKAGES_INSTALLED: &str = "packages-installed";
     pub const RESOLVE_CUSTOM_SCENERY: &str = "resolve-custom-scenery";
     pub const CUSTOM_SCENERY_EXISTS: &str = "custom-scenery-exists";
     pub const AIRPORT_ICAO: &str = "airport-icao";
+}
+
+/// The legacy default package directory.
+///
+/// One definition: two checks need it, and a path rule that exists twice is a
+/// path rule that drifts.
+pub fn legacy_default_packages_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".xearthlayer")
+        .join("packages")
+}
+
+/// Build the bootstrap registry.
+///
+/// **Registration order is execution order**, and this order reproduces what
+/// `commands/run.rs` did inline. It is asserted by test, because it is
+/// load-bearing and was previously implicit in the shape of one function.
+pub fn build_registry() -> Runner<BootstrapContext> {
+    build_registry_with(config_file_path(), legacy_default_packages_dir(), || {
+        xearthlayer::config::detect_custom_scenery().ok()
+    })
+}
+
+/// Build the registry against explicit paths and detector, for tests.
+pub fn build_registry_with(
+    config_path: PathBuf,
+    legacy_packages_dir: PathBuf,
+    detect: impl Fn() -> Option<PathBuf> + Send + Sync + 'static,
+) -> Runner<BootstrapContext> {
+    let mut runner = Runner::new();
+    runner.register(Box::new(config::FirstRun::with_paths(
+        config_path.clone(),
+        legacy_packages_dir,
+    )));
+    runner.register(Box::new(config::LoadConfig::with_path(config_path.clone())));
+    runner.register(Box::<system::LogStartup>::default());
+    runner.register(Box::<system::FdLimit>::default());
+    runner.register(Box::new(config::ConfigUpgradeWarning::with_path(
+        config_path,
+    )));
+    runner.register(Box::new(paths::PackagesInstalled));
+    runner.register(Box::new(paths::ResolveCustomScenery::with_detector(detect)));
+    runner.register(Box::new(paths::CustomSceneryExists));
+    runner.register(Box::new(system::AirportIcao));
+    runner
+}
+
+/// Run every applicable prerequisite for this command.
+///
+/// Executes before dispatch, so `run` and `setup` get the same answer to
+/// "does this installation exist". Placing it inside `run` alone would leave
+/// the setup wizard treating an existing user as new.
+pub fn enforce(ctx: &mut BootstrapContext) -> Result<(), CliError> {
+    let mut registry = build_registry();
+    registry.set_reporter(Box::new(|_check, message| eprintln!("{}", message)));
+    finish(registry.enforce(ctx), ctx)
+}
+
+fn finish(
+    outcome: Result<RunOutcome, PreflightError>,
+    ctx: &BootstrapContext,
+) -> Result<(), CliError> {
+    match outcome {
+        Ok(RunOutcome::AllSatisfied) => Ok(()),
+        Ok(RunOutcome::Failed {
+            check,
+            reason,
+            hint,
+        }) => Err(to_cli_error(&check, reason, hint, ctx)),
+        Err(e) => Err(remediation_to_cli_error(e)),
+    }
+}
+
+/// Map a remediation failure onto the error the CLI already produces.
+///
+/// A corrupt configuration file has always rendered as
+/// [`CliError::ConfigFile`], with its own help text pointing at the file. The
+/// check attaches the underlying error precisely so that survives.
+pub fn remediation_to_cli_error(e: PreflightError) -> CliError {
+    let message = e.message.clone();
+    match e.into_source() {
+        Some(source) => match source.downcast::<ConfigFileError>() {
+            Ok(cause) => CliError::ConfigFile(*cause),
+            Err(_) => CliError::Config(message),
+        },
+        None => CliError::Config(message),
+    }
 }
 
 /// Map a failed check onto the [`CliError`] the CLI already produces for it.
@@ -108,11 +193,141 @@ mod tests {
         assert_eq!(e.to_string(), "Configuration error: it is broken");
     }
 
+    fn fabricate_complete_environment() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let packages = dir.path().join("packages");
+        let scenery = dir.path().join("Custom Scenery");
+        std::fs::create_dir(&packages).unwrap();
+        std::fs::create_dir(&scenery).unwrap();
+        let config_path = dir.path().join("config.ini");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[packages]\ninstall_location = {}\ncustom_scenery_path = {}\n",
+                packages.display(),
+                scenery.display()
+            ),
+        )
+        .unwrap();
+        (dir, config_path)
+    }
+
+    #[test]
+    fn the_bootstrap_pipeline_fills_every_context_field() {
+        // The property the whole design rests on: preflight leaves behind the
+        // inputs XEarthLayer launches from. Adding a context field with no
+        // check to fill it fails here.
+        let (dir, config_path) = fabricate_complete_environment();
+        let mut registry =
+            build_registry_with(config_path, dir.path().join("no-legacy-packages"), || None);
+        let mut ctx = BootstrapContext::new("run", None);
+
+        let outcome = registry.enforce(&mut ctx).expect("no remediation failure");
+        assert!(
+            matches!(outcome, RunOutcome::AllSatisfied),
+            "expected every prerequisite satisfied, got {outcome:?}"
+        );
+
+        assert!(ctx.config().is_some(), "no check contributed the config");
+        assert!(
+            ctx.install_location().is_some(),
+            "no check contributed the install location"
+        );
+        assert!(
+            ctx.custom_scenery_path().is_some(),
+            "no check contributed the Custom Scenery path"
+        );
+    }
+
+    #[test]
+    fn registration_order_reproduces_what_run_did_inline() {
+        // Load-bearing and, until now, implicit in the shape of one function.
+        let registry = build_registry_with(
+            PathBuf::from("/nonexistent/config.ini"),
+            PathBuf::from("/nonexistent/packages"),
+            || None,
+        );
+        let order: Vec<String> = registry
+            .check_names()
+            .iter()
+            .map(|n| n.to_string())
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                names::FIRST_RUN,
+                names::LOAD_CONFIG,
+                names::LOG_STARTUP,
+                names::FD_LIMIT,
+                names::CONFIG_UPGRADE,
+                names::PACKAGES_INSTALLED,
+                names::RESOLVE_CUSTOM_SCENERY,
+                names::CUSTOM_SCENERY_EXISTS,
+                names::AIRPORT_ICAO,
+            ]
+        );
+    }
+
+    #[test]
+    fn setup_does_not_inherit_runs_prerequisites() {
+        // setup exists to create the state these checks require. If any applied,
+        // a new user could never reach the wizard.
+        let registry = build_registry_with(
+            PathBuf::from("/nonexistent/config.ini"),
+            PathBuf::from("/nonexistent/packages"),
+            || None,
+        );
+        let ctx = BootstrapContext::new("setup", None);
+        assert!(
+            registry.report(&ctx).is_empty(),
+            "no run prerequisite may apply to setup, found {:?}",
+            registry.report(&ctx)
+        );
+    }
+
+    #[test]
+    fn a_first_run_environment_still_reports_needs_setup() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry = build_registry_with(
+            dir.path().join("absent.ini"),
+            dir.path().join("absent-packages"),
+            || None,
+        );
+        let mut ctx = BootstrapContext::new("run", None);
+        let err = finish(registry.enforce(&mut ctx), &ctx).expect_err("first run blocks");
+        assert!(
+            matches!(err, CliError::NeedsSetup),
+            "a fresh install must still print the welcome and exit 0, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_corrupt_config_still_renders_as_a_config_file_error() {
+        // CliError::ConfigFile carries its own help text pointing at the file.
+        // Degrading it to a generic message would be a behaviour change.
+        let cause = ConfigFileError::WriteError("bad ini".to_string());
+        let e = PreflightError::new(names::LOAD_CONFIG, cause.to_string()).with_source(cause);
+        assert!(matches!(
+            remediation_to_cli_error(e),
+            CliError::ConfigFile(_)
+        ));
+    }
+
+    #[test]
+    fn a_remediation_failure_without_a_source_is_a_plain_config_error() {
+        let e = PreflightError::new(names::RESOLVE_CUSTOM_SCENERY, "nothing configured");
+        match remediation_to_cli_error(e) {
+            CliError::Config(msg) => assert_eq!(msg, "nothing configured"),
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
     #[test]
     fn check_names_are_unique() {
         let all = [
             names::FIRST_RUN,
             names::LOAD_CONFIG,
+            names::LOG_STARTUP,
             names::FD_LIMIT,
             names::CONFIG_UPGRADE,
             names::PACKAGES_INSTALLED,

--- a/xearthlayer-cli/src/preflight/mod.rs
+++ b/xearthlayer-cli/src/preflight/mod.rs
@@ -18,6 +18,8 @@ use xearthlayer::preflight::BootstrapContext;
 /// Constants rather than literals at the call site because [`to_cli_error`]
 /// dispatches on them: a typo would silently fall through to the generic arm
 /// and change what the user sees.
+pub mod config;
+
 pub mod names {
     pub const FIRST_RUN: &str = "first-run";
     pub const LOAD_CONFIG: &str = "load-config";

--- a/xearthlayer-cli/src/preflight/paths.rs
+++ b/xearthlayer-cli/src/preflight/paths.rs
@@ -1,6 +1,6 @@
 //! Path-resolution preflight checks.
 
-use super::names;
+use super::{legacy_default_packages_dir, names};
 use std::borrow::Cow;
 use std::path::PathBuf;
 use xearthlayer::preflight::{BootstrapContext, Preflight, PreflightError, Remedy, Status};
@@ -20,15 +20,6 @@ pub fn resolve_custom_scenery_path(
     detect: impl FnOnce() -> Option<PathBuf>,
 ) -> Option<PathBuf> {
     custom_scenery_path.or(scenery_dir).or_else(detect)
-}
-
-/// The legacy default package directory, used when configuration does not
-/// specify one.
-fn legacy_default_packages_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".xearthlayer")
-        .join("packages")
 }
 
 /// Resolve where packages are installed, and require that the directory exists.
@@ -81,12 +72,6 @@ pub struct ResolveCustomScenery {
 }
 
 impl ResolveCustomScenery {
-    pub fn production() -> Self {
-        Self {
-            detect: Box::new(|| xearthlayer::config::detect_custom_scenery().ok()),
-        }
-    }
-
     /// Inject the detector so tests never probe for a real X-Plane install.
     pub fn with_detector(detect: impl Fn() -> Option<PathBuf> + Send + Sync + 'static) -> Self {
         Self {

--- a/xearthlayer-cli/src/preflight/paths.rs
+++ b/xearthlayer-cli/src/preflight/paths.rs
@@ -1,0 +1,332 @@
+//! Path-resolution preflight checks.
+
+use super::names;
+use std::borrow::Cow;
+use std::path::PathBuf;
+use xearthlayer::preflight::{BootstrapContext, Preflight, PreflightError, Remedy, Status};
+
+/// Resolve the Custom Scenery directory from configuration, falling back to
+/// auto-detection of the X-Plane installation.
+///
+/// Precedence: `packages.custom_scenery_path` > `xplane.scenery_dir` >
+/// auto-detect. Auto-detection is only attempted when both config values are
+/// unset.
+///
+/// Moved here from `commands/run.rs` with its tests. One definition, because
+/// duplicating a precedence rule is how the two copies drift.
+pub fn resolve_custom_scenery_path(
+    custom_scenery_path: Option<PathBuf>,
+    scenery_dir: Option<PathBuf>,
+    detect: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    custom_scenery_path.or(scenery_dir).or_else(detect)
+}
+
+/// The legacy default package directory, used when configuration does not
+/// specify one.
+fn legacy_default_packages_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".xearthlayer")
+        .join("packages")
+}
+
+/// Resolve where packages are installed, and require that the directory exists.
+///
+/// Resolves during remediation and judges during the inspection that follows.
+pub struct PackagesInstalled;
+
+impl Preflight<BootstrapContext> for PackagesInstalled {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(names::PACKAGES_INSTALLED)
+    }
+
+    fn applies(&self, ctx: &BootstrapContext) -> bool {
+        ctx.command() == "run"
+    }
+
+    fn inspect(&self, ctx: &BootstrapContext) -> Status {
+        if ctx.config().is_none() {
+            // Names the missing value rather than unwrapping. A misordered
+            // registry becomes a legible error instead of a panic.
+            return Status::unsatisfied("configuration has not been loaded");
+        }
+        match ctx.install_location() {
+            None => {
+                Status::unsatisfied("package install location has not been resolved").remediable()
+            }
+            Some(path) if !path.exists() => {
+                Status::unsatisfied(format!("no ortho packages at {}", path.display()))
+            }
+            Some(_) => Status::Satisfied,
+        }
+    }
+
+    fn remediate(
+        &self,
+        ctx: &mut BootstrapContext,
+    ) -> Result<Remedy<BootstrapContext>, PreflightError> {
+        let location = ctx
+            .config()
+            .and_then(|c| c.packages.install_location.clone())
+            .unwrap_or_else(legacy_default_packages_dir);
+        ctx.set_install_location(location);
+        Ok(Remedy::default())
+    }
+}
+
+/// Resolve X-Plane's Custom Scenery directory and contribute it.
+pub struct ResolveCustomScenery {
+    detect: Box<dyn Fn() -> Option<PathBuf> + Send + Sync>,
+}
+
+impl ResolveCustomScenery {
+    pub fn production() -> Self {
+        Self {
+            detect: Box::new(|| xearthlayer::config::detect_custom_scenery().ok()),
+        }
+    }
+
+    /// Inject the detector so tests never probe for a real X-Plane install.
+    pub fn with_detector(detect: impl Fn() -> Option<PathBuf> + Send + Sync + 'static) -> Self {
+        Self {
+            detect: Box::new(detect),
+        }
+    }
+}
+
+impl Preflight<BootstrapContext> for ResolveCustomScenery {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(names::RESOLVE_CUSTOM_SCENERY)
+    }
+
+    fn applies(&self, ctx: &BootstrapContext) -> bool {
+        ctx.command() == "run"
+    }
+
+    fn inspect(&self, ctx: &BootstrapContext) -> Status {
+        if ctx.config().is_none() {
+            return Status::unsatisfied("configuration has not been loaded");
+        }
+        if ctx.custom_scenery_path().is_some() {
+            Status::Satisfied
+        } else {
+            Status::unsatisfied("Custom Scenery path has not been resolved").remediable()
+        }
+    }
+
+    fn remediate(
+        &self,
+        ctx: &mut BootstrapContext,
+    ) -> Result<Remedy<BootstrapContext>, PreflightError> {
+        let config = ctx.config();
+        let resolved = resolve_custom_scenery_path(
+            config.and_then(|c| c.packages.custom_scenery_path.clone()),
+            config.and_then(|c| c.xplane.scenery_dir.clone()),
+            || (self.detect)(),
+        );
+
+        match resolved {
+            Some(path) => {
+                ctx.set_custom_scenery_path(path);
+                Ok(Remedy::default())
+            }
+            None => Err(PreflightError::new(
+                names::RESOLVE_CUSTOM_SCENERY,
+                "No Custom Scenery path configured. \
+                 Run 'xearthlayer init' or set packages.custom_scenery_path in config.ini",
+            )),
+        }
+    }
+}
+
+/// Require that the resolved Custom Scenery directory exists.
+pub struct CustomSceneryExists;
+
+impl Preflight<BootstrapContext> for CustomSceneryExists {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(names::CUSTOM_SCENERY_EXISTS)
+    }
+
+    fn applies(&self, ctx: &BootstrapContext) -> bool {
+        ctx.command() == "run"
+    }
+
+    fn inspect(&self, ctx: &BootstrapContext) -> Status {
+        match ctx.custom_scenery_path() {
+            None => Status::unsatisfied("Custom Scenery path has not been resolved"),
+            Some(path) if !path.exists() => Status::unsatisfied(format!(
+                "Custom Scenery directory does not exist: {}\n\
+                 Check your configuration or run 'xearthlayer init'",
+                path.display()
+            )),
+            Some(_) => Status::Satisfied,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xearthlayer::config::ConfigFile;
+
+    fn ctx_with_config() -> BootstrapContext {
+        let mut ctx = BootstrapContext::new("run", None);
+        ctx.set_config(ConfigFile::default());
+        ctx
+    }
+
+    // ---- resolve_custom_scenery_path (moved from commands/run.rs) ----
+
+    #[test]
+    fn explicit_custom_scenery_path_wins() {
+        let resolved = resolve_custom_scenery_path(
+            Some(PathBuf::from("/configured")),
+            Some(PathBuf::from("/scenery-dir")),
+            || panic!("auto-detect must not run when config is set"),
+        );
+        assert_eq!(resolved, Some(PathBuf::from("/configured")));
+    }
+
+    #[test]
+    fn scenery_dir_used_when_custom_scenery_path_unset() {
+        let resolved =
+            resolve_custom_scenery_path(None, Some(PathBuf::from("/scenery-dir")), || {
+                panic!("auto-detect must not run when scenery_dir is set")
+            });
+        assert_eq!(resolved, Some(PathBuf::from("/scenery-dir")));
+    }
+
+    #[test]
+    fn auto_detect_used_when_both_config_values_unset() {
+        let resolved = resolve_custom_scenery_path(None, None, || Some(PathBuf::from("/detected")));
+        assert_eq!(resolved, Some(PathBuf::from("/detected")));
+    }
+
+    #[test]
+    fn none_when_nothing_configured_and_detection_fails() {
+        let resolved = resolve_custom_scenery_path(None, None, || None);
+        assert_eq!(resolved, None);
+    }
+
+    // ---- PackagesInstalled ----
+
+    #[test]
+    fn packages_names_the_missing_config_rather_than_panicking() {
+        // Reads what LoadConfig contributes. Run it against a context where
+        // that check has not run: the reason must say so.
+        let ctx = BootstrapContext::new("run", None);
+        match PackagesInstalled.inspect(&ctx) {
+            Status::Unsatisfied { reason, .. } => assert!(
+                reason.contains("configuration"),
+                "reason must name the missing value, got: {reason}"
+            ),
+            other => panic!("expected Unsatisfied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn packages_asks_to_be_remediated_before_the_location_is_resolved() {
+        let ctx = ctx_with_config();
+        assert!(matches!(
+            PackagesInstalled.inspect(&ctx),
+            Status::Unsatisfied {
+                remediable: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn packages_is_unsatisfied_when_the_resolved_directory_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ctx = ctx_with_config();
+        ctx.set_install_location(dir.path().join("nope"));
+        assert!(matches!(
+            PackagesInstalled.inspect(&ctx),
+            Status::Unsatisfied {
+                remediable: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn packages_is_satisfied_once_the_resolved_directory_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ctx = ctx_with_config();
+        ctx.set_install_location(dir.path().to_path_buf());
+        assert_eq!(PackagesInstalled.inspect(&ctx), Status::Satisfied);
+    }
+
+    #[test]
+    fn packages_remediation_contributes_the_configured_location() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = ConfigFile::default();
+        config.packages.install_location = Some(dir.path().to_path_buf());
+        let mut ctx = BootstrapContext::new("run", None);
+        ctx.set_config(config);
+
+        PackagesInstalled.remediate(&mut ctx).unwrap();
+        assert_eq!(ctx.install_location(), Some(&dir.path().to_path_buf()));
+        assert_eq!(PackagesInstalled.inspect(&ctx), Status::Satisfied);
+    }
+
+    // ---- ResolveCustomScenery ----
+
+    #[test]
+    fn resolve_custom_scenery_message_is_unchanged_when_nothing_is_configured() {
+        let mut ctx = ctx_with_config();
+        let check = ResolveCustomScenery::with_detector(|| None);
+        let err = check.remediate(&mut ctx).expect_err("nothing to resolve");
+        assert_eq!(
+            err.message,
+            "No Custom Scenery path configured. \
+             Run 'xearthlayer init' or set packages.custom_scenery_path in config.ini"
+        );
+    }
+
+    #[test]
+    fn resolve_custom_scenery_contributes_the_detected_path() {
+        let mut ctx = ctx_with_config();
+        let check = ResolveCustomScenery::with_detector(|| Some(PathBuf::from("/detected")));
+        check.remediate(&mut ctx).unwrap();
+        assert_eq!(ctx.custom_scenery_path(), Some(&PathBuf::from("/detected")));
+    }
+
+    // ---- CustomSceneryExists ----
+
+    #[test]
+    fn custom_scenery_exists_names_the_missing_value_rather_than_panicking() {
+        let ctx = BootstrapContext::new("run", None);
+        match CustomSceneryExists.inspect(&ctx) {
+            Status::Unsatisfied { reason, .. } => assert!(
+                reason.contains("Custom Scenery path"),
+                "reason must name the missing value, got: {reason}"
+            ),
+            other => panic!("expected Unsatisfied naming the missing value, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_scenery_exists_message_is_unchanged_when_the_directory_is_absent() {
+        let mut ctx = BootstrapContext::new("run", None);
+        ctx.set_custom_scenery_path(PathBuf::from("/definitely/not/here"));
+        match CustomSceneryExists.inspect(&ctx) {
+            Status::Unsatisfied { reason, .. } => assert_eq!(
+                reason,
+                "Custom Scenery directory does not exist: /definitely/not/here\n\
+                 Check your configuration or run 'xearthlayer init'"
+            ),
+            other => panic!("expected Unsatisfied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_scenery_exists_is_satisfied_for_a_real_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ctx = BootstrapContext::new("run", None);
+        ctx.set_custom_scenery_path(dir.path().to_path_buf());
+        assert_eq!(CustomSceneryExists.inspect(&ctx), Status::Satisfied);
+    }
+}

--- a/xearthlayer-cli/src/preflight/system.rs
+++ b/xearthlayer-cli/src/preflight/system.rs
@@ -6,6 +6,48 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use xearthlayer::airport::validate_airport_icao;
 use xearthlayer::preflight::{BootstrapContext, Preflight, PreflightError, Remedy, Status};
 
+/// Write the startup banner to the log.
+///
+/// An action rather than a test, and it lives in the registry because its
+/// **position** is what matters: after the configuration is loaded, and before
+/// anything that can fail. A failed startup is exactly when a support log most
+/// needs to say which version produced it, so this must not move behind the
+/// checks that can reject the run.
+///
+/// Modelled as remediation so a diagnostic report, which only inspects, does
+/// not write to the log as a side effect of being asked a question.
+#[derive(Default)]
+pub struct LogStartup {
+    logged: AtomicBool,
+}
+
+impl Preflight<BootstrapContext> for LogStartup {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(names::LOG_STARTUP)
+    }
+
+    fn applies(&self, ctx: &BootstrapContext) -> bool {
+        ctx.command() == "run"
+    }
+
+    fn inspect(&self, _ctx: &BootstrapContext) -> Status {
+        if self.logged.load(Ordering::SeqCst) {
+            Status::Satisfied
+        } else {
+            Status::unsatisfied("startup has not been logged").remediable()
+        }
+    }
+
+    fn remediate(
+        &self,
+        ctx: &mut BootstrapContext,
+    ) -> Result<Remedy<BootstrapContext>, PreflightError> {
+        crate::runner::log_startup(ctx.command());
+        self.logged.store(true, Ordering::SeqCst);
+        Ok(Remedy::default())
+    }
+}
+
 /// Raise the file descriptor soft limit to the hard maximum.
 ///
 /// Processes inherit a soft FD limit (often 1024) that can be lower than the
@@ -37,7 +79,10 @@ impl Default for FdLimit {
 }
 
 impl FdLimit {
-    /// Construct with a fixed view of the limits, for tests.
+    /// Construct with a fixed view of the limits.
+    ///
+    /// A test seam: production reads the real limit through `Default`.
+    #[cfg(test)]
     pub fn with_limits(soft: u64, hard: u64) -> Self {
         Self {
             attempted: AtomicBool::new(false),
@@ -137,6 +182,23 @@ impl Preflight<BootstrapContext> for AirportIcao {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    // ---- LogStartup ----
+
+    #[test]
+    fn log_startup_records_once_and_is_then_satisfied() {
+        let check = LogStartup::default();
+        let mut ctx = BootstrapContext::new("run", None);
+        assert!(matches!(
+            check.inspect(&ctx),
+            Status::Unsatisfied {
+                remediable: true,
+                ..
+            }
+        ));
+        check.remediate(&mut ctx).unwrap();
+        assert_eq!(check.inspect(&ctx), Status::Satisfied);
+    }
 
     // ---- FdLimit ----
 

--- a/xearthlayer-cli/src/preflight/system.rs
+++ b/xearthlayer-cli/src/preflight/system.rs
@@ -1,0 +1,224 @@
+//! System-level preflight checks.
+
+use super::names;
+use std::borrow::Cow;
+use std::sync::atomic::{AtomicBool, Ordering};
+use xearthlayer::airport::validate_airport_icao;
+use xearthlayer::preflight::{BootstrapContext, Preflight, PreflightError, Remedy, Status};
+
+/// Raise the file descriptor soft limit to the hard maximum.
+///
+/// Processes inherit a soft FD limit (often 1024) that can be lower than the
+/// hard limit. XEarthLayer needs many descriptors at once: HTTP connections to
+/// the imagery CDN, disk cache handles, and FUSE descriptors for X-Plane's open
+/// textures. Raising soft to hard needs no privileges and stays within what the
+/// administrator allows.
+///
+/// **Best effort, never fatal.** Raising the limit has never blocked startup,
+/// so the check is satisfied once an attempt has been made, whether or not the
+/// attempt succeeded. That is why it tracks having tried rather than
+/// re-reading the limit: re-reading would turn a failed raise into a startup
+/// failure, which is a behaviour change.
+pub struct FdLimit {
+    attempted: AtomicBool,
+    /// Injected so inspection is deterministic. Reading the real process limit
+    /// from a test races every other test that raises it, and the limit is a
+    /// property of the machine rather than of this code.
+    limits: Box<dyn Fn() -> std::io::Result<(u64, u64)> + Send + Sync>,
+}
+
+impl Default for FdLimit {
+    fn default() -> Self {
+        Self {
+            attempted: AtomicBool::new(false),
+            limits: Box::new(|| rlimit::Resource::NOFILE.get()),
+        }
+    }
+}
+
+impl FdLimit {
+    /// Construct with a fixed view of the limits, for tests.
+    pub fn with_limits(soft: u64, hard: u64) -> Self {
+        Self {
+            attempted: AtomicBool::new(false),
+            limits: Box::new(move || Ok((soft, hard))),
+        }
+    }
+}
+
+impl Preflight<BootstrapContext> for FdLimit {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(names::FD_LIMIT)
+    }
+
+    fn applies(&self, ctx: &BootstrapContext) -> bool {
+        ctx.command() == "run"
+    }
+
+    fn inspect(&self, _ctx: &BootstrapContext) -> Status {
+        if self.attempted.load(Ordering::SeqCst) {
+            return Status::Satisfied;
+        }
+        match (self.limits)() {
+            Ok((soft, hard)) if soft < hard => {
+                Status::unsatisfied("file descriptor limit is below the hard maximum").remediable()
+            }
+            Ok((soft, _)) => {
+                tracing::debug!(soft, "FD limit already at maximum");
+                Status::Satisfied
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to query FD limit");
+                Status::Satisfied
+            }
+        }
+    }
+
+    fn remediate(
+        &self,
+        _ctx: &mut BootstrapContext,
+    ) -> Result<Remedy<BootstrapContext>, PreflightError> {
+        self.attempted.store(true, Ordering::SeqCst);
+        match rlimit::Resource::NOFILE.get() {
+            Ok((soft, hard)) if soft < hard => {
+                if let Err(e) = rlimit::Resource::NOFILE.set(hard, hard) {
+                    tracing::warn!(soft, hard, error = %e, "Failed to raise FD limit");
+                } else {
+                    tracing::info!(
+                        old_soft = soft,
+                        new_soft = hard,
+                        "Raised file descriptor limit"
+                    );
+                }
+            }
+            Ok((soft, _)) => {
+                tracing::debug!(soft, "FD limit already at maximum");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to query FD limit");
+            }
+        }
+        Ok(Remedy::default())
+    }
+}
+
+/// Validate a requested airport ICAO code against X-Plane's database.
+///
+/// Early, before heavy initialisation, so a typo costs a second rather than a
+/// scene load.
+pub struct AirportIcao;
+
+impl Preflight<BootstrapContext> for AirportIcao {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(names::AIRPORT_ICAO)
+    }
+
+    /// The conditional becomes declarative: the check applies when an airport
+    /// was actually requested, rather than the caller wrapping it in an `if`.
+    fn applies(&self, ctx: &BootstrapContext) -> bool {
+        ctx.command() == "run" && ctx.airport().is_some()
+    }
+
+    fn inspect(&self, ctx: &BootstrapContext) -> Status {
+        let Some(scenery) = ctx.custom_scenery_path() else {
+            return Status::unsatisfied("Custom Scenery path has not been resolved");
+        };
+        let Some(icao) = ctx.airport() else {
+            return Status::Satisfied;
+        };
+        match validate_airport_icao(scenery, icao) {
+            Ok(()) => Status::Satisfied,
+            Err(e) => Status::unsatisfied(e.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ---- FdLimit ----
+
+    #[test]
+    fn fd_limit_asks_to_be_raised_when_soft_is_below_hard() {
+        let check = FdLimit::with_limits(1024, 524_288);
+        assert!(matches!(
+            check.inspect(&BootstrapContext::new("run", None)),
+            Status::Unsatisfied {
+                remediable: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn fd_limit_is_satisfied_when_soft_already_equals_hard() {
+        let check = FdLimit::with_limits(524_288, 524_288);
+        assert_eq!(
+            check.inspect(&BootstrapContext::new("run", None)),
+            Status::Satisfied
+        );
+    }
+
+    #[test]
+    fn fd_limit_is_satisfied_after_an_attempt_even_if_raising_failed() {
+        // Best effort. Raising the limit has never been fatal, and turning it
+        // into a startup blocker would be a behaviour change. The injected
+        // limits stay below hard, so only the attempt can satisfy this.
+        let check = FdLimit::with_limits(1024, 524_288);
+        let mut ctx = BootstrapContext::new("run", None);
+        check.remediate(&mut ctx).expect("raising is never fatal");
+        assert_eq!(check.inspect(&ctx), Status::Satisfied);
+    }
+
+    #[test]
+    fn fd_limit_applies_only_to_run() {
+        let check = FdLimit::default();
+        assert!(check.applies(&BootstrapContext::new("run", None)));
+        assert!(!check.applies(&BootstrapContext::new("config", None)));
+    }
+
+    // ---- AirportIcao ----
+
+    #[test]
+    fn airport_check_does_not_apply_without_the_flag() {
+        assert!(!AirportIcao.applies(&BootstrapContext::new("run", None)));
+    }
+
+    #[test]
+    fn airport_check_applies_when_the_flag_is_present() {
+        assert!(AirportIcao.applies(&BootstrapContext::new("run", Some("KSFO".into()))));
+    }
+
+    #[test]
+    fn airport_check_does_not_apply_outside_run() {
+        assert!(!AirportIcao.applies(&BootstrapContext::new("packages", Some("KSFO".into()))));
+    }
+
+    #[test]
+    fn airport_check_names_the_missing_scenery_path_rather_than_panicking() {
+        let ctx = BootstrapContext::new("run", Some("KSFO".into()));
+        match AirportIcao.inspect(&ctx) {
+            Status::Unsatisfied { reason, .. } => assert!(
+                reason.contains("Custom Scenery path"),
+                "reason must name the missing value, got: {reason}"
+            ),
+            other => panic!("expected Unsatisfied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn airport_check_is_unsatisfied_when_the_scenery_path_is_not_an_xplane_install() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ctx = BootstrapContext::new("run", Some("KSFO".into()));
+        ctx.set_custom_scenery_path(PathBuf::from(dir.path()));
+        assert!(matches!(
+            AirportIcao.inspect(&ctx),
+            Status::Unsatisfied {
+                remediable: false,
+                ..
+            }
+        ));
+    }
+}

--- a/xearthlayer-cli/src/runner.rs
+++ b/xearthlayer-cli/src/runner.rs
@@ -28,11 +28,15 @@ impl CliRunner {
     pub fn config(&self) -> &ConfigFile {
         &self.config
     }
+}
 
-    /// Log startup information for a command.
-    pub fn log_startup(&self, command: &str) {
-        info!("XEarthLayer v{}", xearthlayer::VERSION);
-        info!("XEarthLayer CLI: {} command", command);
-        xearthlayer::metrics::log_allocator_environment();
-    }
+/// Log startup information for a command.
+///
+/// Free function because it never needed the runner's state, and `run` now
+/// takes its configuration from the preflight context rather than from a
+/// `CliRunner`.
+pub fn log_startup(command: &str) {
+    info!("XEarthLayer v{}", xearthlayer::VERSION);
+    info!("XEarthLayer CLI: {} command", command);
+    xearthlayer::metrics::log_allocator_environment();
 }

--- a/xearthlayer/src/lib.rs
+++ b/xearthlayer/src/lib.rs
@@ -39,6 +39,7 @@ pub mod package;
 pub mod panic;
 pub mod patches;
 pub mod prefetch;
+pub mod preflight;
 pub mod provider;
 pub mod publisher;
 pub mod runtime;

--- a/xearthlayer/src/preflight/check.rs
+++ b/xearthlayer/src/preflight/check.rs
@@ -1,0 +1,43 @@
+//! The [`Preflight`] trait.
+
+use super::{PreflightError, Remedy, Status};
+use std::borrow::Cow;
+
+/// A single prerequisite, generic over the context it operates on.
+///
+/// A check declares nothing about other checks and never calls one. It accepts
+/// a context, reads what it needs, and contributes what it owns. Check families
+/// that operate on different contexts get their own registries, so the context
+/// type is a parameter rather than one shared object every check must fit.
+pub trait Preflight<C>: Send + Sync {
+    /// Stable identifier, used in reports and error mapping.
+    ///
+    /// `Cow` rather than `&'static str` so a check constructed at runtime,
+    /// including one supplied by a future plugin, can name itself.
+    fn name(&self) -> Cow<'static, str>;
+
+    /// Whether this check applies at all. Defaults to always.
+    ///
+    /// This is how a conditional check stays declarative: an airport
+    /// validation applies only when an airport was requested, rather than the
+    /// caller wrapping the check in an `if`.
+    fn applies(&self, _ctx: &C) -> bool {
+        true
+    }
+
+    /// Inspect the prerequisite.
+    ///
+    /// **Must have no side effects.** Report mode calls this and never
+    /// [`Preflight::remediate`], so a violation mutates a user's installation
+    /// when they only asked for a diagnostic.
+    fn inspect(&self, ctx: &C) -> Status;
+
+    /// Fix the prerequisite and contribute to the context.
+    ///
+    /// Called only in enforce mode, and only when [`Preflight::inspect`]
+    /// returned a remediable [`Status::Unsatisfied`]. Defaults to doing
+    /// nothing, which suits checks that only validate.
+    fn remediate(&self, _ctx: &mut C) -> Result<Remedy<C>, PreflightError> {
+        Ok(Remedy::default())
+    }
+}

--- a/xearthlayer/src/preflight/context.rs
+++ b/xearthlayer/src/preflight/context.rs
@@ -1,0 +1,138 @@
+//! The context threaded through the bootstrap preflight pipeline.
+
+use crate::config::ConfigFile;
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+/// Values accumulated by the bootstrap preflight pipeline.
+///
+/// Checks read what they need and contribute what they own. They never call one
+/// another, so every field a check contributes is `Option` until that check has
+/// run. A check that reads an absent field returns
+/// [`Status::Unsatisfied`](super::Status) naming it, which turns a misordered
+/// registry into a legible error rather than a silent `None`.
+///
+/// A concrete struct rather than a type-keyed store: this states the pipeline's
+/// whole contract in one definition, the compiler enumerates every reader, and
+/// absence is greppable. A dynamic bag hides all three.
+///
+/// # Inputs, not services
+///
+/// This carries **validated inputs**: resolved paths, the loaded configuration,
+/// detected hardware. It does not carry constructed services.
+/// [`service::builder`](crate::service), `service::runtime_builder` and the
+/// service orchestrator already own construction and consume these values.
+/// Preflight establishes preconditions; it does not start XEarthLayer.
+///
+/// # Library types only
+///
+/// Deliberately free of CLI argument types. A `clap` dependency here would make
+/// the context unusable from anywhere but the binary, which is exactly the
+/// coupling the generic [`Preflight`](super::Preflight) trait exists to avoid.
+pub struct BootstrapContext {
+    command: Cow<'static, str>,
+    airport: Option<String>,
+    config: Option<ConfigFile>,
+    install_location: Option<PathBuf>,
+    custom_scenery_path: Option<PathBuf>,
+}
+
+impl BootstrapContext {
+    /// Create a context for `command`, carrying the requested airport if any.
+    pub fn new(command: impl Into<Cow<'static, str>>, airport: Option<String>) -> Self {
+        Self {
+            command: command.into(),
+            airport,
+            config: None,
+            install_location: None,
+            custom_scenery_path: None,
+        }
+    }
+
+    /// The command being run. Checks use this to decide whether they apply.
+    pub fn command(&self) -> &str {
+        &self.command
+    }
+
+    /// The airport requested on the command line, if any.
+    pub fn airport(&self) -> Option<&str> {
+        self.airport.as_deref()
+    }
+
+    /// The loaded configuration, once a check has contributed it.
+    pub fn config(&self) -> Option<&ConfigFile> {
+        self.config.as_ref()
+    }
+
+    /// Where installed packages live, once a check has resolved it.
+    pub fn install_location(&self) -> Option<&PathBuf> {
+        self.install_location.as_ref()
+    }
+
+    /// X-Plane's Custom Scenery directory, once a check has resolved it.
+    pub fn custom_scenery_path(&self) -> Option<&PathBuf> {
+        self.custom_scenery_path.as_ref()
+    }
+
+    /// Contribute the loaded configuration.
+    pub fn set_config(&mut self, config: ConfigFile) {
+        self.config = Some(config);
+    }
+
+    /// Contribute the resolved package install location.
+    pub fn set_install_location(&mut self, path: PathBuf) {
+        self.install_location = Some(path);
+    }
+
+    /// Contribute the resolved Custom Scenery path.
+    pub fn set_custom_scenery_path(&mut self, path: PathBuf) {
+        self.custom_scenery_path = Some(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn readers_are_empty_before_any_check_contributes() {
+        let ctx = BootstrapContext::new("run", None);
+        assert_eq!(ctx.command(), "run");
+        assert!(ctx.airport().is_none());
+        assert!(ctx.config().is_none());
+        assert!(ctx.install_location().is_none());
+        assert!(ctx.custom_scenery_path().is_none());
+    }
+
+    #[test]
+    fn contributions_are_visible_to_later_readers() {
+        let mut ctx = BootstrapContext::new("run", Some("KSFO".to_string()));
+        ctx.set_install_location(PathBuf::from("/tmp/packages"));
+        ctx.set_custom_scenery_path(PathBuf::from("/tmp/Custom Scenery"));
+        assert_eq!(
+            ctx.install_location(),
+            Some(&PathBuf::from("/tmp/packages"))
+        );
+        assert_eq!(
+            ctx.custom_scenery_path(),
+            Some(&PathBuf::from("/tmp/Custom Scenery"))
+        );
+        assert_eq!(ctx.airport(), Some("KSFO"));
+    }
+
+    #[test]
+    fn config_is_contributed_not_loaded_by_the_context() {
+        let mut ctx = BootstrapContext::new("run", None);
+        ctx.set_config(ConfigFile::default());
+        assert!(
+            ctx.config().is_some(),
+            "the context stores what a check gives it and loads nothing itself"
+        );
+    }
+
+    #[test]
+    fn command_accepts_a_borrowed_static_without_allocating() {
+        let ctx = BootstrapContext::new("diagnostics", None);
+        assert_eq!(ctx.command(), "diagnostics");
+    }
+}

--- a/xearthlayer/src/preflight/mod.rs
+++ b/xearthlayer/src/preflight/mod.rs
@@ -10,7 +10,9 @@
 //! get their own registries.
 
 mod check;
+mod runner;
 mod types;
 
 pub use check::Preflight;
+pub use runner::{Reporter, Runner};
 pub use types::{PreflightError, Remedy, RunOutcome, Status};

--- a/xearthlayer/src/preflight/mod.rs
+++ b/xearthlayer/src/preflight/mod.rs
@@ -10,9 +10,11 @@
 //! get their own registries.
 
 mod check;
+mod context;
 mod runner;
 mod types;
 
 pub use check::Preflight;
+pub use context::BootstrapContext;
 pub use runner::{Reporter, Runner};
 pub use types::{PreflightError, Remedy, RunOutcome, Status};

--- a/xearthlayer/src/preflight/mod.rs
+++ b/xearthlayer/src/preflight/mod.rs
@@ -1,0 +1,16 @@
+//! Prerequisite checks run before XEarthLayer does any work.
+//!
+//! A [`Preflight`] check is one prerequisite: a thing that must be true, or a
+//! value that must be resolved, before a command can proceed. Checks are held
+//! in a [`Runner`] and executed in registration order.
+//!
+//! The trait is generic over its context. A check declares nothing about other
+//! checks and never calls one; it accepts a context, reads what it needs, and
+//! contributes what it owns. Check families that operate on different contexts
+//! get their own registries.
+
+mod check;
+mod types;
+
+pub use check::Preflight;
+pub use types::{PreflightError, Remedy, RunOutcome, Status};

--- a/xearthlayer/src/preflight/runner.rs
+++ b/xearthlayer/src/preflight/runner.rs
@@ -1,0 +1,333 @@
+//! The [`Runner`]: an ordered registry of prerequisite checks.
+
+use super::{Preflight, PreflightError, RunOutcome, Status};
+use std::borrow::Cow;
+
+/// Callback used to surface warnings and remediation messages.
+///
+/// Injected rather than hardcoded to `eprintln!` so the framework stays
+/// testable and the CLI keeps ownership of how things are printed.
+pub type Reporter = Box<dyn Fn(&str, &str) + Send + Sync>;
+
+/// An ordered registry of prerequisites over a single context type.
+///
+/// **Registration order is execution order.** There is no dependency graph and
+/// no reordering. Most checks only contribute, so their order is genuinely
+/// free; the few that read a value an earlier check contributed carry a real
+/// ordering constraint, and the framework does not remove it. What it does is
+/// make the failure legible: such a check returns a [`Status::Unsatisfied`]
+/// naming the value it lacked, so a misordering surfaces as a named error
+/// rather than a silent `None` several steps downstream.
+pub struct Runner<C> {
+    checks: Vec<Box<dyn Preflight<C>>>,
+    reporter: Option<Reporter>,
+}
+
+impl<C> Default for Runner<C> {
+    fn default() -> Self {
+        Self {
+            checks: Vec::new(),
+            reporter: None,
+        }
+    }
+}
+
+impl<C> Runner<C> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a check. Order of registration is order of execution.
+    pub fn register(&mut self, check: Box<dyn Preflight<C>>) {
+        self.checks.push(check);
+    }
+
+    /// Set the callback used for warnings and remediation messages.
+    pub fn set_reporter(&mut self, reporter: Reporter) {
+        self.reporter = Some(reporter);
+    }
+
+    /// Remove a check by name.
+    ///
+    /// Exists for tests and for commands that must opt out of a prerequisite,
+    /// not as a general mechanism.
+    pub fn deregister(&mut self, name: &str) {
+        self.checks.retain(|c| c.name() != name);
+    }
+
+    /// Inspect every applicable check, with no side effects.
+    ///
+    /// This is what a diagnostic report runs. It never calls
+    /// [`Preflight::remediate`], which is why inspection must stay pure.
+    pub fn report(&self, ctx: &C) -> Vec<(Cow<'static, str>, Status)> {
+        self.checks
+            .iter()
+            .filter(|c| c.applies(ctx))
+            .map(|c| (c.name(), c.inspect(ctx)))
+            .collect()
+    }
+
+    /// Inspect and remediate, stopping at the first prerequisite that is unmet
+    /// and cannot be fixed.
+    ///
+    /// Walked by index rather than by iterator so that checks appended by a
+    /// [`Remedy`](super::Remedy) are picked up at the tail without
+    /// invalidating the walk. That is the mechanism a discovery check uses to
+    /// contribute further checks, and appending at the tail is what keeps
+    /// execution a straight line.
+    pub fn enforce(&mut self, ctx: &mut C) -> Result<RunOutcome, PreflightError> {
+        let mut i = 0;
+        while i < self.checks.len() {
+            if !self.checks[i].applies(ctx) {
+                i += 1;
+                continue;
+            }
+
+            let name = self.checks[i].name();
+            match self.checks[i].inspect(ctx) {
+                Status::Satisfied => {}
+                Status::Warning(message) => self.emit(&name, &message),
+                Status::Unsatisfied {
+                    reason,
+                    remediable: false,
+                    hint,
+                } => {
+                    return Ok(RunOutcome::Failed {
+                        check: name,
+                        reason,
+                        hint,
+                    });
+                }
+                Status::Unsatisfied {
+                    remediable: true, ..
+                } => {
+                    let remedy = self.checks[i].remediate(ctx)?;
+                    if let Some(message) = &remedy.message {
+                        self.emit(&name, message);
+                    }
+                    self.checks.extend(remedy.register);
+                }
+            }
+
+            i += 1;
+        }
+
+        Ok(RunOutcome::AllSatisfied)
+    }
+
+    fn emit(&self, check: &str, message: &str) {
+        if let Some(reporter) = &self.reporter {
+            reporter(check, message);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preflight::{Preflight, PreflightError, Remedy, RunOutcome, Status};
+    use std::borrow::Cow;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[derive(Default)]
+    struct Ctx {
+        trace: Vec<&'static str>,
+    }
+
+    struct Recording {
+        id: &'static str,
+        status: Status,
+    }
+
+    impl Preflight<Ctx> for Recording {
+        fn name(&self) -> Cow<'static, str> {
+            Cow::Borrowed(self.id)
+        }
+        fn inspect(&self, _: &Ctx) -> Status {
+            self.status.clone()
+        }
+        fn remediate(&self, ctx: &mut Ctx) -> Result<Remedy<Ctx>, PreflightError> {
+            ctx.trace.push(self.id);
+            Ok(Remedy::default())
+        }
+    }
+
+    fn remediable(id: &'static str) -> Box<Recording> {
+        Box::new(Recording {
+            id,
+            status: Status::unsatisfied("x").remediable(),
+        })
+    }
+
+    #[test]
+    fn executes_in_registration_order() {
+        let mut r = Runner::new();
+        r.register(remediable("first"));
+        r.register(remediable("second"));
+        r.register(remediable("third"));
+        let mut ctx = Ctx::default();
+        r.enforce(&mut ctx).expect("all remediable");
+        assert_eq!(ctx.trace, vec!["first", "second", "third"]);
+    }
+
+    #[test]
+    fn unsatisfied_and_not_remediable_stops_the_queue() {
+        let mut r = Runner::new();
+        r.register(Box::new(Recording {
+            id: "blocker",
+            status: Status::unsatisfied("nope"),
+        }));
+        r.register(remediable("never_runs"));
+        let mut ctx = Ctx::default();
+        match r.enforce(&mut ctx).expect("no remediation error") {
+            RunOutcome::Failed { check, reason, .. } => {
+                assert_eq!(check, "blocker");
+                assert_eq!(reason, "nope");
+            }
+            other => panic!("expected Failed, got {:?}", other),
+        }
+        assert!(ctx.trace.is_empty(), "queue must stop at the blocker");
+    }
+
+    #[test]
+    fn registrations_from_a_remedy_run_at_the_tail() {
+        struct Discovery;
+        impl Preflight<Ctx> for Discovery {
+            fn name(&self) -> Cow<'static, str> {
+                Cow::Borrowed("discovery")
+            }
+            fn inspect(&self, _: &Ctx) -> Status {
+                Status::unsatisfied("x").remediable()
+            }
+            fn remediate(&self, ctx: &mut Ctx) -> Result<Remedy<Ctx>, PreflightError> {
+                ctx.trace.push("discovery");
+                Ok(Remedy {
+                    message: None,
+                    register: vec![remediable("discovered")],
+                })
+            }
+        }
+        let mut r = Runner::new();
+        r.register(Box::new(Discovery));
+        r.register(remediable("registered_earlier"));
+        let mut ctx = Ctx::default();
+        r.enforce(&mut ctx).unwrap();
+        // Discovered checks run after everything already queued, never spliced in
+        // ahead of a check that has not run yet.
+        assert_eq!(
+            ctx.trace,
+            vec!["discovery", "registered_earlier", "discovered"]
+        );
+    }
+
+    #[test]
+    fn applies_false_skips_the_check_entirely() {
+        struct Never;
+        impl Preflight<Ctx> for Never {
+            fn name(&self) -> Cow<'static, str> {
+                Cow::Borrowed("never")
+            }
+            fn applies(&self, _: &Ctx) -> bool {
+                false
+            }
+            fn inspect(&self, _: &Ctx) -> Status {
+                panic!("must not be inspected when applies() is false")
+            }
+        }
+        let mut r = Runner::new();
+        r.register(Box::new(Never));
+        let mut ctx = Ctx::default();
+        assert!(matches!(
+            r.enforce(&mut ctx).unwrap(),
+            RunOutcome::AllSatisfied
+        ));
+        assert!(
+            r.report(&ctx).is_empty(),
+            "report mode also honours applies"
+        );
+    }
+
+    #[test]
+    fn report_mode_never_remediates() {
+        struct Exploding;
+        impl Preflight<Ctx> for Exploding {
+            fn name(&self) -> Cow<'static, str> {
+                Cow::Borrowed("exploding")
+            }
+            fn inspect(&self, _: &Ctx) -> Status {
+                Status::unsatisfied("x").remediable()
+            }
+            fn remediate(&self, _: &mut Ctx) -> Result<Remedy<Ctx>, PreflightError> {
+                panic!("report mode must not call remediate")
+            }
+        }
+        let mut r = Runner::new();
+        r.register(Box::new(Exploding));
+        let statuses = r.report(&Ctx::default());
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].0, "exploding");
+    }
+
+    #[test]
+    fn warning_is_reported_and_does_not_stop_the_queue() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut r = Runner::new();
+        r.register(Box::new(Recording {
+            id: "warn",
+            status: Status::Warning("heads up".into()),
+        }));
+        r.register(remediable("after_warning"));
+        let seen = Arc::clone(&calls);
+        r.set_reporter(Box::new(move |_, _| {
+            seen.fetch_add(1, Ordering::SeqCst);
+        }));
+        let mut ctx = Ctx::default();
+        r.enforce(&mut ctx).unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "warning reported once");
+        assert_eq!(
+            ctx.trace,
+            vec!["after_warning"],
+            "a warning does not stop the queue"
+        );
+    }
+
+    #[test]
+    fn deregister_removes_a_check_by_name() {
+        let mut r = Runner::new();
+        r.register(remediable("keep"));
+        r.register(remediable("drop"));
+        r.deregister("drop");
+        let mut ctx = Ctx::default();
+        r.enforce(&mut ctx).unwrap();
+        assert_eq!(ctx.trace, vec!["keep"]);
+    }
+
+    #[test]
+    fn a_failed_remediation_propagates_rather_than_being_swallowed() {
+        struct Broken;
+        impl Preflight<Ctx> for Broken {
+            fn name(&self) -> Cow<'static, str> {
+                Cow::Borrowed("broken")
+            }
+            fn inspect(&self, _: &Ctx) -> Status {
+                Status::unsatisfied("x").remediable()
+            }
+            fn remediate(&self, _: &mut Ctx) -> Result<Remedy<Ctx>, PreflightError> {
+                Err(PreflightError {
+                    check: Cow::Borrowed("broken"),
+                    message: "disk is full".to_string(),
+                })
+            }
+        }
+        let mut r = Runner::new();
+        r.register(Box::new(Broken));
+        r.register(remediable("never_runs"));
+        let mut ctx = Ctx::default();
+        let err = r
+            .enforce(&mut ctx)
+            .expect_err("remediation failure propagates");
+        assert_eq!(err.to_string(), "broken: disk is full");
+        assert!(ctx.trace.is_empty());
+    }
+}

--- a/xearthlayer/src/preflight/runner.rs
+++ b/xearthlayer/src/preflight/runner.rs
@@ -314,10 +314,7 @@ mod tests {
                 Status::unsatisfied("x").remediable()
             }
             fn remediate(&self, _: &mut Ctx) -> Result<Remedy<Ctx>, PreflightError> {
-                Err(PreflightError {
-                    check: Cow::Borrowed("broken"),
-                    message: "disk is full".to_string(),
-                })
+                Err(PreflightError::new("broken", "disk is full"))
             }
         }
         let mut r = Runner::new();

--- a/xearthlayer/src/preflight/runner.rs
+++ b/xearthlayer/src/preflight/runner.rs
@@ -55,6 +55,14 @@ impl<C> Runner<C> {
         self.checks.retain(|c| c.name() != name);
     }
 
+    /// Names of the registered checks, in execution order.
+    ///
+    /// Exists so the order can be asserted. It is load-bearing and was
+    /// previously implicit in the shape of one function.
+    pub fn check_names(&self) -> Vec<Cow<'static, str>> {
+        self.checks.iter().map(|c| c.name()).collect()
+    }
+
     /// Inspect every applicable check, with no side effects.
     ///
     /// This is what a diagnostic report runs. It never calls

--- a/xearthlayer/src/preflight/runner.rs
+++ b/xearthlayer/src/preflight/runner.rs
@@ -106,6 +106,27 @@ impl<C> Runner<C> {
                         self.emit(&name, message);
                     }
                     self.checks.extend(remedy.register);
+
+                    // Re-inspect. A remediation must leave the prerequisite
+                    // satisfied, and inspection is pure so this costs nothing
+                    // but a second read. It also lets one check contribute a
+                    // value and then judge it: without the re-inspection, a
+                    // check that resolves a path in remediate could never go
+                    // on to reject that path.
+                    match self.checks[i].inspect(ctx) {
+                        Status::Satisfied => {}
+                        Status::Warning(message) => self.emit(&name, &message),
+                        Status::Unsatisfied { reason, hint, .. } => {
+                            // Deliberately not remediated again: one attempt,
+                            // then the verdict, so a check that cannot fix
+                            // itself cannot spin.
+                            return Ok(RunOutcome::Failed {
+                                check: name,
+                                reason,
+                                hint,
+                            });
+                        }
+                    }
                 }
             }
 
@@ -127,7 +148,7 @@ mod tests {
     use super::*;
     use crate::preflight::{Preflight, PreflightError, Remedy, RunOutcome, Status};
     use std::borrow::Cow;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
 
     #[derive(Default)]
@@ -135,9 +156,23 @@ mod tests {
         trace: Vec<&'static str>,
     }
 
+    /// A check whose remediation genuinely fixes the problem: once remediated
+    /// it inspects as satisfied. Modelling that matters, because the runner
+    /// verifies remediation with a second inspection.
     struct Recording {
         id: &'static str,
         status: Status,
+        remediated: AtomicBool,
+    }
+
+    impl Recording {
+        fn new(id: &'static str, status: Status) -> Self {
+            Self {
+                id,
+                status,
+                remediated: AtomicBool::new(false),
+            }
+        }
     }
 
     impl Preflight<Ctx> for Recording {
@@ -145,19 +180,21 @@ mod tests {
             Cow::Borrowed(self.id)
         }
         fn inspect(&self, _: &Ctx) -> Status {
-            self.status.clone()
+            if self.remediated.load(Ordering::SeqCst) {
+                Status::Satisfied
+            } else {
+                self.status.clone()
+            }
         }
         fn remediate(&self, ctx: &mut Ctx) -> Result<Remedy<Ctx>, PreflightError> {
             ctx.trace.push(self.id);
+            self.remediated.store(true, Ordering::SeqCst);
             Ok(Remedy::default())
         }
     }
 
     fn remediable(id: &'static str) -> Box<Recording> {
-        Box::new(Recording {
-            id,
-            status: Status::unsatisfied("x").remediable(),
-        })
+        Box::new(Recording::new(id, Status::unsatisfied("x").remediable()))
     }
 
     #[test]
@@ -174,10 +211,10 @@ mod tests {
     #[test]
     fn unsatisfied_and_not_remediable_stops_the_queue() {
         let mut r = Runner::new();
-        r.register(Box::new(Recording {
-            id: "blocker",
-            status: Status::unsatisfied("nope"),
-        }));
+        r.register(Box::new(Recording::new(
+            "blocker",
+            Status::unsatisfied("nope"),
+        )));
         r.register(remediable("never_runs"));
         let mut ctx = Ctx::default();
         match r.enforce(&mut ctx).expect("no remediation error") {
@@ -192,16 +229,24 @@ mod tests {
 
     #[test]
     fn registrations_from_a_remedy_run_at_the_tail() {
-        struct Discovery;
+        #[derive(Default)]
+        struct Discovery {
+            done: AtomicBool,
+        }
         impl Preflight<Ctx> for Discovery {
             fn name(&self) -> Cow<'static, str> {
                 Cow::Borrowed("discovery")
             }
             fn inspect(&self, _: &Ctx) -> Status {
-                Status::unsatisfied("x").remediable()
+                if self.done.load(Ordering::SeqCst) {
+                    Status::Satisfied
+                } else {
+                    Status::unsatisfied("plugins have not been discovered").remediable()
+                }
             }
             fn remediate(&self, ctx: &mut Ctx) -> Result<Remedy<Ctx>, PreflightError> {
                 ctx.trace.push("discovery");
+                self.done.store(true, Ordering::SeqCst);
                 Ok(Remedy {
                     message: None,
                     register: vec![remediable("discovered")],
@@ -209,7 +254,7 @@ mod tests {
             }
         }
         let mut r = Runner::new();
-        r.register(Box::new(Discovery));
+        r.register(Box::<Discovery>::default());
         r.register(remediable("registered_earlier"));
         let mut ctx = Ctx::default();
         r.enforce(&mut ctx).unwrap();
@@ -273,10 +318,10 @@ mod tests {
     fn warning_is_reported_and_does_not_stop_the_queue() {
         let calls = Arc::new(AtomicUsize::new(0));
         let mut r = Runner::new();
-        r.register(Box::new(Recording {
-            id: "warn",
-            status: Status::Warning("heads up".into()),
-        }));
+        r.register(Box::new(Recording::new(
+            "warn",
+            Status::Warning("heads up".into()),
+        )));
         r.register(remediable("after_warning"));
         let seen = Arc::clone(&calls);
         r.set_reporter(Box::new(move |_, _| {
@@ -290,6 +335,88 @@ mod tests {
             vec!["after_warning"],
             "a warning does not stop the queue"
         );
+    }
+
+    #[test]
+    fn remediation_is_verified_by_a_second_inspection() {
+        // A check that contributes a value in remediate and then judges it.
+        // Without the re-inspection this could never report the value as bad.
+        struct ResolveThenReject {
+            calls: Arc<AtomicUsize>,
+        }
+        impl Preflight<Ctx> for ResolveThenReject {
+            fn name(&self) -> Cow<'static, str> {
+                Cow::Borrowed("resolve-then-reject")
+            }
+            fn inspect(&self, _: &Ctx) -> Status {
+                if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Status::unsatisfied("not resolved yet").remediable()
+                } else {
+                    Status::unsatisfied("resolved, but the directory is missing")
+                }
+            }
+            fn remediate(&self, ctx: &mut Ctx) -> Result<Remedy<Ctx>, PreflightError> {
+                ctx.trace.push("resolved");
+                Ok(Remedy::default())
+            }
+        }
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut r = Runner::new();
+        r.register(Box::new(ResolveThenReject {
+            calls: Arc::clone(&calls),
+        }));
+        r.register(remediable("never_runs"));
+        let mut ctx = Ctx::default();
+
+        match r.enforce(&mut ctx).unwrap() {
+            RunOutcome::Failed { check, reason, .. } => {
+                assert_eq!(check, "resolve-then-reject");
+                assert_eq!(reason, "resolved, but the directory is missing");
+            }
+            other => panic!("expected Failed after re-inspection, got {:?}", other),
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "inspected before and after"
+        );
+        assert_eq!(
+            ctx.trace,
+            vec!["resolved"],
+            "the queue stopped at the verdict"
+        );
+    }
+
+    #[test]
+    fn a_remediation_that_fixes_the_problem_lets_the_queue_continue() {
+        struct FixesItself {
+            calls: Arc<AtomicUsize>,
+        }
+        impl Preflight<Ctx> for FixesItself {
+            fn name(&self) -> Cow<'static, str> {
+                Cow::Borrowed("fixes-itself")
+            }
+            fn inspect(&self, _: &Ctx) -> Status {
+                if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Status::unsatisfied("not yet").remediable()
+                } else {
+                    Status::Satisfied
+                }
+            }
+            fn remediate(&self, ctx: &mut Ctx) -> Result<Remedy<Ctx>, PreflightError> {
+                ctx.trace.push("fixed");
+                Ok(Remedy::default())
+            }
+        }
+        let mut r = Runner::new();
+        r.register(Box::new(FixesItself {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }));
+        r.register(remediable("runs_after"));
+        let mut ctx = Ctx::default();
+        r.enforce(&mut ctx).unwrap();
+        assert_eq!(ctx.trace, vec!["fixed", "runs_after"]);
     }
 
     #[test]

--- a/xearthlayer/src/preflight/types.rs
+++ b/xearthlayer/src/preflight/types.rs
@@ -1,0 +1,191 @@
+//! Outcome types for prerequisite checks.
+
+use super::Preflight;
+use std::borrow::Cow;
+use std::fmt;
+
+/// Outcome of inspecting a single prerequisite.
+///
+/// Produced by [`Preflight::inspect`], which is pure: report mode calls it and
+/// nothing else, so a check that mutates during inspection would silently
+/// change a user's installation when they ask for a diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Status {
+    /// The prerequisite is met.
+    Satisfied,
+    /// The prerequisite is met, but something is worth telling the user.
+    /// Execution continues.
+    Warning(String),
+    /// The prerequisite is not met.
+    Unsatisfied {
+        /// What is wrong, in the user's terms.
+        ///
+        /// When a check reads a value an earlier check contributes, this must
+        /// name the missing value. That is what turns a misordered registry
+        /// into a legible error instead of a silent `None` several steps later.
+        reason: String,
+        /// Whether [`Preflight::remediate`] can fix it.
+        remediable: bool,
+        /// Optional second line: what the user should do about it.
+        hint: Option<String>,
+    },
+}
+
+impl Status {
+    /// An unmet prerequisite that the framework cannot fix.
+    pub fn unsatisfied(reason: impl Into<String>) -> Self {
+        Status::Unsatisfied {
+            reason: reason.into(),
+            remediable: false,
+            hint: None,
+        }
+    }
+
+    /// Mark an unmet prerequisite as fixable. No effect on other variants.
+    pub fn remediable(self) -> Self {
+        match self {
+            Status::Unsatisfied { reason, hint, .. } => Status::Unsatisfied {
+                reason,
+                remediable: true,
+                hint,
+            },
+            other => other,
+        }
+    }
+
+    /// Attach guidance shown below the reason. No effect on other variants.
+    pub fn with_hint(self, hint: impl Into<String>) -> Self {
+        match self {
+            Status::Unsatisfied {
+                reason, remediable, ..
+            } => Status::Unsatisfied {
+                reason,
+                remediable,
+                hint: Some(hint.into()),
+            },
+            other => other,
+        }
+    }
+}
+
+/// What a successful remediation produced.
+pub struct Remedy<C> {
+    /// Reported to the user when present.
+    pub message: Option<String>,
+    /// Checks discovered by this one, appended at the tail of the queue.
+    ///
+    /// This is how a future plugin-discovery check contributes further checks
+    /// without the registry needing to know plugins exist. Appending at the
+    /// tail keeps execution a straight line: nothing is ever spliced in ahead
+    /// of a check that has already run.
+    pub register: Vec<Box<dyn Preflight<C>>>,
+}
+
+impl<C> Default for Remedy<C> {
+    fn default() -> Self {
+        Self {
+            message: None,
+            register: Vec::new(),
+        }
+    }
+}
+
+/// A remediation failed.
+///
+/// Deliberately not `CliError`: that type lives in the binary crate, and naming
+/// it here would make [`Preflight`] unimplementable from anywhere else.
+#[derive(Debug)]
+pub struct PreflightError {
+    /// Name of the check that failed to remediate.
+    pub check: Cow<'static, str>,
+    /// What went wrong.
+    pub message: String,
+}
+
+impl fmt::Display for PreflightError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.check, self.message)
+    }
+}
+
+impl std::error::Error for PreflightError {}
+
+/// Result of running a whole registry.
+#[derive(Debug)]
+pub enum RunOutcome {
+    /// Every applicable check passed.
+    AllSatisfied,
+    /// A check was unmet and could not be remediated. Execution stopped there.
+    Failed {
+        check: Cow<'static, str>,
+        reason: String,
+        hint: Option<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsatisfied_carries_reason_and_remediability() {
+        let s = Status::unsatisfied("configuration has not been loaded");
+        match s {
+            Status::Unsatisfied {
+                reason,
+                remediable,
+                hint,
+            } => {
+                assert_eq!(reason, "configuration has not been loaded");
+                assert!(!remediable, "unsatisfied defaults to not remediable");
+                assert!(hint.is_none());
+            }
+            other => panic!("expected Unsatisfied, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn remediable_unsatisfied_opts_in_explicitly() {
+        let s = Status::unsatisfied("file descriptor limit is below the hard maximum").remediable();
+        assert!(matches!(
+            s,
+            Status::Unsatisfied {
+                remediable: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn with_hint_attaches_a_second_line() {
+        let s = Status::unsatisfied("macFUSE is not installed").with_hint("See docs/macos.md");
+        match s {
+            Status::Unsatisfied { hint, .. } => {
+                assert_eq!(hint.as_deref(), Some("See docs/macos.md"))
+            }
+            other => panic!("expected Unsatisfied, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn hint_and_remediable_do_not_apply_to_satisfied() {
+        assert_eq!(Status::Satisfied.remediable(), Status::Satisfied);
+        assert_eq!(Status::Satisfied.with_hint("ignored"), Status::Satisfied);
+    }
+
+    #[test]
+    fn remedy_defaults_to_no_message_and_no_registrations() {
+        let r: Remedy<()> = Remedy::default();
+        assert!(r.message.is_none());
+        assert!(r.register.is_empty());
+    }
+
+    #[test]
+    fn preflight_error_displays_check_and_message() {
+        let e = PreflightError {
+            check: "load-config".into(),
+            message: "permission denied".to_string(),
+        };
+        assert_eq!(e.to_string(), "load-config: permission denied");
+    }
+}

--- a/xearthlayer/src/preflight/types.rs
+++ b/xearthlayer/src/preflight/types.rs
@@ -81,6 +81,20 @@ pub struct Remedy<C> {
     pub register: Vec<Box<dyn Preflight<C>>>,
 }
 
+impl<C> fmt::Debug for Remedy<C> {
+    // Manual: the registered checks are trait objects and cannot derive Debug.
+    // Their count is the part worth seeing in a test failure.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Remedy")
+            .field("message", &self.message)
+            .field(
+                "register",
+                &format_args!("{} check(s)", self.register.len()),
+            )
+            .finish()
+    }
+}
+
 impl<C> Default for Remedy<C> {
     fn default() -> Self {
         Self {
@@ -94,12 +108,40 @@ impl<C> Default for Remedy<C> {
 ///
 /// Deliberately not `CliError`: that type lives in the binary crate, and naming
 /// it here would make [`Preflight`] unimplementable from anywhere else.
+///
+/// The optional source is how a caller recovers a richer error than the message
+/// string. A check that wraps a domain error attaches it here, and the CLI
+/// downcasts to render the error it has always rendered for that failure.
 #[derive(Debug)]
 pub struct PreflightError {
     /// Name of the check that failed to remediate.
     pub check: Cow<'static, str>,
     /// What went wrong.
     pub message: String,
+    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
+
+impl PreflightError {
+    pub fn new(check: impl Into<Cow<'static, str>>, message: impl Into<String>) -> Self {
+        Self {
+            check: check.into(),
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// Attach the underlying error so a caller can downcast to it.
+    pub fn with_source(mut self, source: impl std::error::Error + Send + Sync + 'static) -> Self {
+        self.source = Some(Box::new(source));
+        self
+    }
+
+    /// The attached source, if any.
+    pub fn source_ref(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_deref()
+            .map(|e| e as &(dyn std::error::Error + 'static))
+    }
 }
 
 impl fmt::Display for PreflightError {
@@ -108,7 +150,11 @@ impl fmt::Display for PreflightError {
     }
 }
 
-impl std::error::Error for PreflightError {}
+impl std::error::Error for PreflightError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source_ref()
+    }
+}
 
 /// Result of running a whole registry.
 #[derive(Debug)]
@@ -181,11 +227,18 @@ mod tests {
     }
 
     #[test]
+    fn remedy_debug_reports_how_many_checks_it_registered() {
+        let r: Remedy<()> = Remedy::default();
+        assert_eq!(
+            format!("{:?}", r),
+            "Remedy { message: None, register: 0 check(s) }"
+        );
+    }
+
+    #[test]
     fn preflight_error_displays_check_and_message() {
-        let e = PreflightError {
-            check: "load-config".into(),
-            message: "permission denied".to_string(),
-        };
+        let e = PreflightError::new("load-config", "permission denied");
         assert_eq!(e.to_string(), "load-config: permission denied");
+        assert!(e.source_ref().is_none());
     }
 }

--- a/xearthlayer/src/preflight/types.rs
+++ b/xearthlayer/src/preflight/types.rs
@@ -136,6 +136,15 @@ impl PreflightError {
         self
     }
 
+    /// Take ownership of the attached source.
+    ///
+    /// Ownership rather than a borrow because the caller's purpose is to
+    /// downcast it back to a concrete error and rebuild a richer error from it,
+    /// and not every error type is `Clone`.
+    pub fn into_source(self) -> Option<Box<dyn std::error::Error + Send + Sync + 'static>> {
+        self.source
+    }
+
     /// The attached source, if any.
     pub fn source_ref(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.source


### PR DESCRIPTION
Implements the framework from #265. Replaces the prerequisite checks written inline in `commands/run.rs` with a registered, FIFO ordered preflight registry executed before command dispatch.

`run.rs` loses 197 lines. No behaviour change.

## Why before dispatch, not inside `run`

`run.rs` and `setup/wizard.rs` each answered "does this installation exist" independently, from the same state. A check living inside `run` alone would leave the setup wizard treating an existing user as new and silently discarding their settings.

## Design

* `Preflight<C>` is generic over its context, so check families operating on different contexts get their own registries rather than one shared object every check must fit. It lives in the library crate because a trait in a binary crate cannot be implemented from anywhere else, and for the same reason the error type is framework owned rather than `CliError`.
* Inspection is pure, remediation acts. That split is what gives a future diagnostics report and any dry run mode an implementation for free, and it is covered by a test that registers a check which panics if remediated.
* `BootstrapContext` accumulates. Checks read what they need and contribute what they own, never calling one another. It carries validated inputs, not constructed services: `service::builder`, `runtime_builder` and the orchestrator still own construction and consume these values.
* A check that reads a value an earlier check contributes names the absent value rather than unwrapping it, so a misordered registry produces a legible error instead of a panic.
* `Remedy` can carry further registrations, appended at the tail. Nothing depends on that yet, but it is how a plugin discovery check would contribute work later without the registry knowing plugins exist.

## Verification

The suite cannot see terminal output, so the no behaviour change claim rests on a direct comparison. I built a binary from the base commit `57b6ae3` and ran five scenarios against both, diffing stdout, stderr and exit code:

| Scenario | Expected |
|---|---|
| Fresh install | Welcome message, **exit 0** |
| Config present, packages missing | `NoPackages` with install guidance |
| Custom Scenery path missing | Config error naming the path |
| Invalid airport | Config error from validation |
| Custom Scenery unresolvable | Config error with the init hint |

All five are byte identical once timestamps and the log's own source line annotation are normalised.

That comparison caught a regression the 66 new tests did not. Moving `log_startup` into `run()` meant the version banner stopped being written whenever a check failed, which is exactly when a support log needs to say which build produced the failure. `LogStartup` restores its position in the sequence.

## Notes for review

* `to_cli_error` dispatches on the check name. This is a deliberate temporary seam: `NeedsSetup` prints a welcome and exits 0, and `NoPackages` renders guidance built from the resolved install location. Neither survives a generic rendering, and both had to be preserved exactly. It goes away once those two messages are free to change.
* `resolve_custom_scenery_path` moved out of `run.rs` with its four tests rather than being reimplemented. A precedence rule that exists twice is a rule that drifts.
* `LogStartup` is an action rather than a test, which stretches the word "check". It is in the registry because its position is what matters, and it is modelled as remediation so a report mode does not write to the log merely by asking.
* No CHANGELOG entry. That file is compiled at release cut, so an empty `[Unreleased]` is correct here.

The two checks that should exist and do not, macFUSE presence on macOS and a running instance guard, follow in a second PR so this one stays a pure refactor.
